### PR TITLE
pinned dep versions

### DIFF
--- a/conda/Dockerfile
+++ b/conda/Dockerfile
@@ -1,19 +1,19 @@
-FROM cloudfoundry/cflinuxfs2:1.46.0
+FROM cloudfoundry/cflinuxfs3:0.82.0
 
 WORKDIR /root
 
 ENV PATH="/root/miniconda3/bin:$PATH"
 
 RUN apt-get update && apt-get install -y groff groff-base libcairo2-dev libpango1.0-dev libgif-dev && \
-    curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh && \
+    curl -L https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -o miniconda.sh && \
     /bin/bash miniconda.sh -b -p $HOME/miniconda3 && \
     rm miniconda.sh && \
     echo 'root=$(pwd -P)' >> /root/.bashrc && \
     export root=$root && \
     echo "y" | conda install python=3.5 && \
-    conda config --add channels local && \
-    conda config --add channels conda-forge && \
     conda config --add channels bioconda && \
+    conda config --add channels conda-forge && \
+    conda config --add channels local && \
     echo "y" | conda update -n root --all && \
     # because there is a bug in the latest version when indexing
     echo "y" | conda install --force "conda-build=3.0.9"

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -17,8 +17,8 @@ conda index /root/miniconda3/conda-bld/noarch
 echo "Adding channels"
 conda config --remove channels defaults
 conda config --add channels defaults
-conda config --add channels conda-forge
 conda config --add channels bioconda
+conda config --add channels conda-forge
 conda config --add channels local
 
 cd /root/repo

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloudfoundry/cflinuxfs2:1.46.0
+FROM cloudfoundry/cflinuxfs3:0.82.0
 
 
 RUN groupadd -g 880 eventkit && useradd -u 8800 -g 880 -m eventkit && \
@@ -14,7 +14,7 @@ COPY --chown=eventkit ./conda /var/lib/eventkit/conda
 
 ENV PATH="/home/eventkit/miniconda3/bin:$PATH"
 
-RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh && \
+RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -o miniconda.sh && \
     /bin/bash miniconda.sh -b -p "/home/eventkit/miniconda3" && \
     rm miniconda.sh && \
     echo "y" | conda update -n root --all && \

--- a/config/Dockerfile_webpack
+++ b/config/Dockerfile_webpack
@@ -1,4 +1,4 @@
-FROM node:8.12.0-slim
+FROM node:8.16.0-slim
 
 RUN apt-get update && apt-get install -y \
     ruby \
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y \
     libpango1.0-dev \
     libgif-dev \
     build-essential \
-    g++
+    g++ \
+    python && \
+    apt-get clean
 
 WORKDIR /var/lib/eventkit
 


### PR DESCRIPTION
This pins the miniconda build as newer versions drop support for python 3.5.   In the future it may make sense to switch for python 3.6, since other dependencies may start requiring it. 