### PR TITLE
reduce number of processes started by celery by default

### DIFF
--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -2,7 +2,7 @@
 
 celery worker -A eventkit_cloud --concurrency=$RUNS_CONCURRENCY --loglevel=$LOG_LEVEL -n runs@%h -Q runs & \
 celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $HOSTNAME & \
-celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
-celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel & \
-celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n finalize@%h -Q $HOSTNAME.finalize & \
+celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
+celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel & \
+celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n finalize@%h -Q $HOSTNAME.finalize & \
 celery worker -A eventkit_cloud --concurrency=$OSM_CONCURRENCY --loglevel=$LOG_LEVEL -n osm@%h -Q $HOSTNAME.osm


### PR DESCRIPTION
This specifies concurrency=1, for queue that are setup to respond from user events.  The default for celery is the number of processors available and this commonly results in 4.  Each process is about 100 MB in size.  Setting concurrency to 1 actually results in two celery processes but overall ends up reducing the memory footprint by about 800MB. 