### PR TITLE
Fix an issue where licenses caused things to appear incorrectly on the Status Download Page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/LicenseRow.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/LicenseRow.tsx
@@ -26,6 +26,19 @@ const jss = (theme: Eventkit.Theme & Theme) => createStyles({
             width: '120px',
         },
     },
+    estimatedFinishColumn: {
+        whiteSpace: 'pre',
+        width: '80px',
+        paddingRight: '0px',
+        paddingLeft: '0px',
+        textAlign: 'center',
+        color: theme.eventkit.colors.black,
+        fontSize: '12px',
+        [theme.breakpoints.up('md')]: {
+            fontSize: '14px',
+            width: '120px',
+        },
+    },
     providerStatusColumn: {
         width: '80px',
         padding: '0px',
@@ -110,6 +123,7 @@ export class LicenseRow extends React.Component<Props, State> {
                     </BaseDialog>
                 </TableCell>
                 <TableCell classes={{ root: classes.fileSizeColumn }} />
+                <TableCell classes={{ root: classes.estimatedFinishColumn }} />
                 <TableCell classes={{ root: classes.providerStatusColumn }} />
                 <TableCell classes={{ root: classes.menuColumn }} />
                 <TableCell classes={{ root: classes.arrowColumn }} />

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/LicenseRow.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/LicenseRow.spec.tsx
@@ -26,7 +26,7 @@ describe('LicenseRow component', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         expect(wrapper.find(TableRow)).toHaveLength(1);
-        expect(wrapper.find(TableCell)).toHaveLength(6);
+        expect(wrapper.find(TableCell)).toHaveLength(7);
         expect(wrapper.find(BaseDialog)).toHaveLength(1);
         expect(wrapper.find('i')).toHaveLength(1);
         expect(wrapper.find('i').text()).toEqual('Use of this data is governed by\u00a0test name');


### PR DESCRIPTION
The license row mimics the structure of the regular provider rows in order to sit above them. A table cell was missed causing any provider row below a license to appear shortened.