### PR TITLE
Celery Group Scaling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - DATABASE_URL=postgres://eventkit:eventkit_exports@postgis:5432/eventkit_exports
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
       - BROKER_API_URL=http://guest:guest@rabbitmq:15672/api/
+      - CELERY_GROUP_NAME=GROUP_A
       - SITE_NAME
       - SITE_IP
       - TERM
@@ -108,6 +109,7 @@ services:
       - DATABASE_URL=postgres://eventkit:eventkit_exports@postgis:5432/eventkit_exports
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
       - BROKER_API_URL=http://guest:guest@rabbitmq:15672/api/
+      - CELERY_GROUP_NAME=GROUP_A
       - CONCURRENCY=1
       - SITE_NAME
       - SITE_IP

--- a/eventkit_cloud/settings/celery.py
+++ b/eventkit_cloud/settings/celery.py
@@ -60,17 +60,6 @@ if PCF_SCALING:
         },
     })
 
-app.conf.task_queues = [
-    Queue('celery', routing_key='celery'),
-    Queue("scale".format(socket.gethostname()), Exchange("scale".format(socket.gethostname())),
-          routing_key="scale".format(socket.gethostname())),
-    # Work needs to be able to be assigned to a specific worker.  That worker has access to the staged files.
-    Queue(socket.gethostname(), Exchange(socket.gethostname()), routing_key=socket.gethostname()),
-    # Canceling needs to be assigned to a specific worker, because that worker will have the actual PID to kill.
-    Queue("{0}.cancel".format(socket.gethostname()), Exchange("{0}.cancel".format(socket.gethostname())),
-          routing_key="{0}.cancel".format(socket.gethostname())),
-]
-
 app.conf.beat_schedule = BEAT_SCHEDULE
 
 CELERYD_USER = CELERYD_GROUP = 'eventkit'

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -856,7 +856,7 @@ def pick_up_run_task(self, result=None, run_uid=None, user_details=None, *args, 
     from eventkit_cloud.tasks.task_factory import TaskFactory
     run = ExportRun.objects.get(uid=run_uid)
     try:
-        worker = socket.gethostname()
+        worker = os.getenv("CELERY_GROUP_NAME", socket.gethostname())
         run.worker = worker
         run.save()
         TaskFactory().parse_tasks(worker=worker, run_uid=run_uid, user_details=user_details)

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -856,7 +856,7 @@ def pick_up_run_task(self, result=None, run_uid=None, user_details=None, *args, 
     from eventkit_cloud.tasks.task_factory import TaskFactory
     run = ExportRun.objects.get(uid=run_uid)
     try:
-        worker = os.getenv("CELERY_GROUP_NAME", socket.gethostname())
+        worker = socket.gethostname()
         run.worker = worker
         run.save()
         TaskFactory().parse_tasks(worker=worker, run_uid=run_uid, user_details=user_details)

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1269,9 +1269,9 @@ def cancel_synchronous_task_chain(data_provider_task_uid=None):
             queue_group = os.getenv("CELERY_GROUP_NAME", export_task.worker)
             kill_task.apply_async(
                 kwargs={"task_pid": export_task.pid, "celery_uid": export_task.celery_uid},
-                queue="{0}.cancel".format(queue_group),
+                queue="{0}.cancel".format(export_task.worker),
                 priority=TaskPriority.CANCEL.value,
-                routing_key="{0}.cancel".format(queue_group))
+                routing_key="{0}.cancel".format(export_task.worker))
 
 
 @app.task(name='Cancel Export Provider Task', base=UserDetailsBase)
@@ -1330,9 +1330,9 @@ def cancel_export_provider_task(result=None, data_provider_task_uid=None, cancel
             queue_group = os.getenv("CELERY_GROUP_NAME", export_task.worker)
             kill_task.apply_async(
                 kwargs={"task_pid": export_task.pid, "celery_uid": export_task.celery_uid},
-                queue="{0}.cancel".format(queue_group),
+                queue="{0}.cancel".format(export_task.worker),
                 priority=TaskPriority.CANCEL.value,
-                routing_key="{0}.cancel".format(queue_group))
+                routing_key="{0}.cancel".format(export_task.worker))
 
     if TaskStates[data_provider_task_record.status] not in TaskStates.get_finished_states():
         if error:

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -514,7 +514,7 @@ def get_message_count(queue_name):
     broker_api_url = getattr(settings, 'BROKER_API_URL')
     queue_class = "queues"
 
-    for queue in get_all_rabbitmq_objects(queue_class):
+    for queue in get_all_rabbitmq_objects(broker_api_url, queue_class):
         if queue.get("name") == queue_name:
             try:
                 return queue.get("messages")

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -488,14 +488,6 @@ def get_all_rabbitmq_objects(api_url, rabbit_class):
     :param rabbit_class: The type of rabbitmq class (i.e. queues or exchanges) as a string.
     :return: An array of dicts with the desired objects.
     """
-    if not api_url:
-        logger.error("Cannot fetch queues without BROKER_API_URL")
-        return
-    with app.connection() as conn:
-        channel = conn.channel()
-        if not channel:
-            logger.error("Could not establish a rabbitmq channel")
-            return
 
     queues_url = "{}/{}".format(api_url.rstrip('/'), rabbit_class)
     response = requests.get(queues_url)

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import os
+import socket
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -104,6 +105,21 @@ def pcf_scale_celery(max_instances):
     if message_count > 0:
         logger.info(F"Sending task to {app_name} with command {command}")
         client.run_task(command, app_name=app_name)
+        return
+
+    celery_group_name = os.getenv("CELERY_GROUP_NAME", socket.gethostname())
+    broker_api_url = getattr(settings, 'BROKER_API_URL')
+    queue_class = "queues"
+
+    for queue in get_all_rabbitmq_objects(broker_api_url, queue_class):
+        queue_name = queue.get('name')
+        pending_messages = queue.get('messages')
+        if celery_group_name in queue_name:
+            logger.info(f"Queue {queue_name} has {pending_messages} pending messages.")
+            if pending_messages > 0 and running_tasks_count < 1:
+                logger.info(F"Sending task to {app_name} with command {command}")
+                client.run_task(command, app_name=app_name)
+                return
 
 
 @app.task(name="Check Provider Availability")

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -97,7 +97,7 @@ def pcf_scale_celery(max_instances):
     "celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n runs@%h -Q runs "
     "& exec celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME "
     "& exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery "
-    "& exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@%h -Q $CELERY_GROUP_NAME.cancel "
+    "& exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel "
     "& exec celery worker -A eventkit_cloud --concurrency=2 -n finalize@%h -Q $CELERY_GROUP_NAME.finalize "
     "& exec celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n osm@%h -Q $CELERY_GROUP_NAME.osm ")
 

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -126,11 +126,9 @@ def pcf_scale_celery(max_instances):
     if total_pending_messages == 0 and running_tasks_count > 0:
         hostnames = []
         workers = ["runs", "worker", "celery", "cancel", "finalize", "osm"]
-        for worker in workers:
-            hostnames.append(F"{worker}@{socket.gethostname()}")
 
         logger.info("Queue is at zero, shutting down.")
-        app.control.broadcast("shutdown", destination=hostnames)
+        app.control.broadcast("shutdown", destination=workers)
 
 @app.task(name="Check Provider Availability")
 def check_provider_availability():

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import os
+import uuid
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -92,9 +93,19 @@ def pcf_scale_celery(max_instances):
         logger.info("Already at max instances, skipping.")
         return
 
+    celery_group_name = uuid.uuid4()
+    command = (f"python manage.py runinitial && echo 'Starting celery workers' && celery worker -A eventkit_cloud"
+    f"--concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n runs@{celery_group_name} -Q runs & exec celery worker -A"
+    f"eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@{celery_group_name} -Q"
+    f"{celery_group_name} & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@{celery_group_name} -Q"
+    f"celery & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@{celery_group_name} -Q"
+    f"{celery_group_name}.cancel & exec celery worker -A eventkit_cloud --concurrency=2 -n"
+    f"finalize@{celery_group_name} -Q {celery_group_name}.finalize & exec celery worker -A eventkit_cloud"
+    f"--concurrency=1 --loglevel=$LOG_LEVEL -n osm@{celery_group_name} -Q {celery_group_name}.osm &"
+    f"exec export CELERY_GROUP_NAME={celery_group_name}")
+
     message_count = get_message_count("runs")
     if message_count > 0:
-        command = os.getenv('CELERY_TASK_COMMAND')
         logger.info(F"Sending task to {app_name} with command {command}")
         client.run_task(command, app_name=app_name)
 

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -93,16 +93,16 @@ def pcf_scale_celery(max_instances):
         logger.info("Already at max instances, skipping.")
         return
 
-    celery_group_name = uuid.uuid4()
+    CELERY_GROUP_NAME = uuid.uuid4()
     command = (f"python manage.py runinitial && echo 'Starting celery workers' && celery worker -A eventkit_cloud "
-    f"--concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n runs@{celery_group_name} -Q runs & exec celery worker -A "
-    f"eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@{celery_group_name} -Q "
-    f"{celery_group_name} & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@{celery_group_name} -Q "
-    f"celery & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@{celery_group_name} -Q "
-    f"{celery_group_name}.cancel & exec celery worker -A eventkit_cloud --concurrency=2 -n "
-    f"finalize@{celery_group_name} -Q {celery_group_name}.finalize & exec celery worker -A eventkit_cloud "
-    f"--concurrency=1 --loglevel=$LOG_LEVEL -n osm@{celery_group_name} -Q {celery_group_name}.osm & "
-    f"exec export CELERY_GROUP_NAME={celery_group_name}")
+    f"--concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n runs@{CELERY_GROUP_NAME} -Q runs & exec celery worker -A "
+    f"eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@{CELERY_GROUP_NAME} -Q "
+    f"{CELERY_GROUP_NAME} & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@{CELERY_GROUP_NAME} -Q "
+    f"celery & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@{CELERY_GROUP_NAME} -Q "
+    f"{CELERY_GROUP_NAME}.cancel & exec celery worker -A eventkit_cloud --concurrency=2 -n "
+    f"finalize@{CELERY_GROUP_NAME} -Q {CELERY_GROUP_NAME}.finalize & exec celery worker -A eventkit_cloud "
+    f"--concurrency=1 --loglevel=$LOG_LEVEL -n osm@{CELERY_GROUP_NAME} -Q {CELERY_GROUP_NAME}.osm & "
+    f"exec export CELERY_GROUP_NAME={CELERY_GROUP_NAME}")
 
     message_count = get_message_count("runs")
     if message_count > 0:

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -94,14 +94,14 @@ def pcf_scale_celery(max_instances):
         return
 
     celery_group_name = uuid.uuid4()
-    command = (f"python manage.py runinitial && echo 'Starting celery workers' && celery worker -A eventkit_cloud"
-    f"--concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n runs@{celery_group_name} -Q runs & exec celery worker -A"
-    f"eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@{celery_group_name} -Q"
-    f"{celery_group_name} & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@{celery_group_name} -Q"
-    f"celery & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@{celery_group_name} -Q"
-    f"{celery_group_name}.cancel & exec celery worker -A eventkit_cloud --concurrency=2 -n"
-    f"finalize@{celery_group_name} -Q {celery_group_name}.finalize & exec celery worker -A eventkit_cloud"
-    f"--concurrency=1 --loglevel=$LOG_LEVEL -n osm@{celery_group_name} -Q {celery_group_name}.osm &"
+    command = (f"python manage.py runinitial && echo 'Starting celery workers' && celery worker -A eventkit_cloud "
+    f"--concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n runs@{celery_group_name} -Q runs & exec celery worker -A "
+    f"eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@{celery_group_name} -Q "
+    f"{celery_group_name} & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@{celery_group_name} -Q "
+    f"celery & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@{celery_group_name} -Q "
+    f"{celery_group_name}.cancel & exec celery worker -A eventkit_cloud --concurrency=2 -n "
+    f"finalize@{celery_group_name} -Q {celery_group_name}.finalize & exec celery worker -A eventkit_cloud "
+    f"--concurrency=1 --loglevel=$LOG_LEVEL -n osm@{celery_group_name} -Q {celery_group_name}.osm & "
     f"exec export CELERY_GROUP_NAME={celery_group_name}")
 
     message_count = get_message_count("runs")

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -156,25 +156,17 @@ def clean_up_queues():
     queue_class = "queues"
     exchange_class = "exchanges"
 
-    if not broker_api_url:
-        logger.error("Cannot clean up queues without a BROKER_API_URL.")
-        return
-    with app.connection() as conn:
-        channel = conn.channel()
-        if not channel:
-            logger.error("Could not establish a rabbitmq channel")
-            return
-        for queue in get_all_rabbitmq_objects(broker_api_url, queue_class):
-            queue_name = queue.get('name')
-            try:
-                channel.queue_delete(queue_name, if_unused=True, if_empty=True)
-                logger.info("Removed queue: {}".format(queue_name))
-            except Exception as e:
-                logger.info(e)
-        for exchange in get_all_rabbitmq_objects(broker_api_url, exchange_class):
-            exchange_name = exchange.get('name')
-            try:
-                channel.exchange_delete(exchange_name, if_unused=True)
-                logger.info("Removed exchange: {}".format(exchange_name))
-            except Exception as e:
-                logger.info(e)
+    for queue in get_all_rabbitmq_objects(broker_api_url, queue_class):
+        queue_name = queue.get('name')
+        try:
+            channel.queue_delete(queue_name, if_unused=True, if_empty=True)
+            logger.info("Removed queue: {}".format(queue_name))
+        except Exception as e:
+            logger.info(e)
+    for exchange in get_all_rabbitmq_objects(broker_api_url, exchange_class):
+        exchange_name = exchange.get('name')
+        try:
+            channel.exchange_delete(exchange_name, if_unused=True)
+            logger.info("Removed exchange: {}".format(exchange_name))
+        except Exception as e:
+            logger.info(e)

--- a/eventkit_cloud/tasks/scripts/debug.py
+++ b/eventkit_cloud/tasks/scripts/debug.py
@@ -45,7 +45,7 @@ def final_task(result=None, job_num=None, task_num=None):
 
 @task(base=TestTask)
 def pick_up_job_task(job_num=None):
-    worker = os.getenv("CELERY_GROUP_NAME", socket.gethostname())
+    worker = socket.gethostname()
     print(("AssignTask picked up by {0} running job {1}".format(worker, job_num)))
     create_task_factory(worker, job_num)
 

--- a/eventkit_cloud/tasks/scripts/debug.py
+++ b/eventkit_cloud/tasks/scripts/debug.py
@@ -45,7 +45,7 @@ def final_task(result=None, job_num=None, task_num=None):
 
 @task(base=TestTask)
 def pick_up_job_task(job_num=None):
-    worker = socket.gethostname()
+    worker = os.getenv("CELERY_GROUP_NAME", socket.gethostname())
     print(("AssignTask picked up by {0} running job {1}".format(worker, job_num)))
     create_task_factory(worker, job_num)
 

--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -3,6 +3,6 @@
 celery worker -A eventkit_cloud --concurrency=$RUNS_CONCURRENCY --loglevel=$LOG_LEVEL -n runs@%h -Q runs & \
 celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME & \
 celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
-celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n cancel@%h -Q $CELERY_GROUP_NAME.cancel & \
+celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel & \
 celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n finalize@%h -Q $CELERY_GROUP_NAME.finalize & \
 celery worker -A eventkit_cloud --concurrency=$OSM_CONCURRENCY --loglevel=$LOG_LEVEL -n osm@%h -Q $CELERY_GROUP_NAME.osm

--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 celery worker -A eventkit_cloud --concurrency=$RUNS_CONCURRENCY --loglevel=$LOG_LEVEL -n runs@%h -Q runs & \
-celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $HOSTNAME & \
+celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME & \
 celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
-celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel & \
-celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n finalize@%h -Q $HOSTNAME.finalize & \
-celery worker -A eventkit_cloud --concurrency=$OSM_CONCURRENCY --loglevel=$LOG_LEVEL -n osm@%h -Q $HOSTNAME.osm
+celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n cancel@%h -Q $CELERY_GROUP_NAME.cancel & \
+celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n finalize@%h -Q $CELERY_GROUP_NAME.finalize & \
+celery worker -A eventkit_cloud --concurrency=$OSM_CONCURRENCY --loglevel=$LOG_LEVEL -n osm@%h -Q $CELERY_GROUP_NAME.osm


### PR DESCRIPTION
This PR changes our celery setup to use groups, so that we can spin up and shut down workers based on their group.  It also makes sure that if a worker crashes, we'll spin a new one up if there are still messages in queue to handle.  It also shuts down all workers if there are no messages remaining on any queue.