### PR TITLE
allow specifying certificate variable in config

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -115,6 +115,12 @@ service credentials can be added to the environment using the service slug as th
 
 For example a slug of 'osm' would use environment variables `OSM_CRED` or `OSM_CERT` if requiring authentication.
 
+If there are many services that use the same certificate, a certificate can be added to the environment and then referenced, 
+in the configuration block for each data provider.  For example, the certificate can be loaded as a single string in an 
+environment setting, `SOURCE_CERT`.  Then in each data provider, in the configuration block, there would be a key
+and value added `cert_var: SOURCE_CERT`.  _Note: The cert_var IS case sensitive._
+
+
 ##### Basic Auth
 To use basic auth, add the username and password to the environment as such
 <pre>SLUG_CRED='username:password'</pre>

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -723,7 +723,6 @@ class DataProviderViewSet(viewsets.ReadOnlyModelViewSet):
 
         except Exception as e:
             logger.error(e)
-            logger.error(str(e))
             return Response([{'detail': _('Internal Server Error')}], status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def list(self, request, slug=None, *args, **kwargs):

--- a/eventkit_cloud/auth/models.py
+++ b/eventkit_cloud/auth/models.py
@@ -10,7 +10,7 @@ class OAuth(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, blank=False)
     identification = models.CharField(max_length=200, unique=True, blank=False)
     commonname = models.CharField(max_length=100, blank=False)
-    user_info = JSONField(default={})
+    user_info = JSONField(default=dict)
 
     class Meta:  # pragma: no cover
         managed = True

--- a/eventkit_cloud/jobs/admin.py
+++ b/eventkit_cloud/jobs/admin.py
@@ -12,6 +12,7 @@ from django_celery_beat.models import IntervalSchedule, CrontabSchedule
 
 from eventkit_cloud.jobs.models import ExportFormat, Job, Region, DataProvider, DataProviderType, \
     DatamodelPreset, License, DataProviderStatus
+from eventkit_cloud.tasks.helpers import clean_config
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +132,8 @@ class DataProviderForm(forms.ModelForm):
             if not config:
                 raise forms.ValidationError("Configuration is required for OSM data providers")
             from eventkit_cloud.feature_selection.feature_selection import FeatureSelection
-            feature_selection = FeatureSelection(config)
+            cleaned_config = clean_config(config)
+            feature_selection = FeatureSelection(cleaned_config)
             feature_selection.valid
             if feature_selection.errors:
                 raise forms.ValidationError("Invalid configuration: {0}".format(feature_selection.errors))

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -374,7 +374,7 @@ def osm_data_collection_pipeline(
     op = overpass.Overpass(
         bbox=bbox, stage_dir=stage_dir, slug=slug, url=url,
         job_name=job_name, task_uid=export_task_record_uid,
-        raw_data_filename='{}_query.osm'.format(job_name)
+        raw_data_filename='{}_query.osm'.format(job_name), config=config
     )
 
     osm_data_filename = op.run_query(user_details=user_details, subtask_percentage=65, eta=eta)  # run the query
@@ -689,7 +689,7 @@ def wfs_export_task(self, result=None, layer=None, config=None, run_uid=None, ta
         service_url += "?" + query_str
 
     url = service_url
-    cred = get_cred(slug=name, url=url)
+    cred = get_cred(cred_var=name, url=url)
     if cred:
         user, pw = cred
         if not re.search(r"(?<=://)[a-zA-Z0-9\-._~]+:[a-zA-Z0-9\-._~]+(?=@)", url):

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -33,7 +33,7 @@ from eventkit_cloud.tasks.helpers import normalize_name, get_archive_data_path, 
     get_download_filename, get_run_staging_dir, get_provider_staging_dir, get_run_download_dir, Directory, \
     default_format_time, progressive_kill, get_style_files, generate_qgs_style, create_license_file, \
     get_human_readable_metadata_document, pickle_exception, get_data_type_from_provider, get_arcgis_metadata, \
-    get_message_count
+    get_message_count, clean_config
 from eventkit_cloud.utils.auth_requests import get_cred
 from eventkit_cloud.utils import (
     overpass, pbf, s3, mapproxy, wcs, geopackage, gdalutils
@@ -391,6 +391,7 @@ def osm_data_collection_pipeline(
         logger.error("No configuration was provided for OSM export")
         raise RuntimeError("The configuration field is required for OSM data providers")
 
+    config = clean_config(config)
     feature_selection = FeatureSelection.example(config)
 
     update_progress(export_task_record_uid, progress=67, eta=eta, msg='Converting data to Geopackage')

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -13,13 +13,13 @@ from django.db.models import Q
 from enum import Enum
 from numpy import linspace
 
-from eventkit_cloud.celery import app
 from eventkit_cloud.utils import auth_requests
 from eventkit_cloud.utils.gdalutils import get_band_statistics
 import pickle
 import logging
 from time import sleep
 import signal
+import yaml
 
 logger = logging.getLogger()
 
@@ -513,3 +513,18 @@ def get_message_count(queue_name):
                 return queue.get("messages")
             except Exception as e:
                 logger.info(e)
+
+def clean_config(config):
+    """
+    Used to remove adhoc service related values from the configuration.
+    :param config: A yaml structured string.
+    :return:
+    """
+    service_keys = ["cert_var", "cert_cred", "concurrency", "max_repeat"]
+
+    conf = yaml.load(config)
+
+    for service_key in service_keys:
+        conf.pop(service_key, None)
+
+    return yaml.dump(conf)

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -226,16 +226,16 @@ def get_file_paths(directory, paths=None):
     return paths
 
 
-def get_last_update(url, type, slug=None):
+def get_last_update(url, type, cert_var=None):
     """
     A wrapper to get different timestamps.
     :param url: The url to get the timestamp
     :param type: The type of services (e.g. osm)
-    :param slug: Optionally a slug if the service requires credentials.
+    :param cert_var: Optionally a slug if the service requires credentials.
     :return: The timestamp as a string.
     """
     if type == 'osm':
-        return get_osm_last_update(url, slug=slug)
+        return get_osm_last_update(url, cert_var=cert_var)
 
 
 def get_metadata_url(url, type):
@@ -251,16 +251,16 @@ def get_metadata_url(url, type):
         return url
 
 
-def get_osm_last_update(url, slug=None):
+def get_osm_last_update(url, cert_var=None):
     """
 
     :param url: A path to the overpass api.
-    :param slug: Optionally a slug if credentials are needed
+    :param cert_var: Optionally a slug if credentials are needed
     :return: The default timestamp as a string (2018-06-18T13:09:59Z)
     """
     try:
         timestamp_url = "{0}timestamp".format(url.rstrip('/').rstrip('interpreter'))
-        response = auth_requests.get(timestamp_url, slug=slug)
+        response = auth_requests.get(timestamp_url, cert_var=cert_var)
         if response:
             return response.content.decode()
         raise Exception("Get OSM last update failed with {0}: {1}".format(response.status_code, response.content))
@@ -398,6 +398,7 @@ def get_metadata(data_provider_task_uid):
                         provider_task.slug,
                         download_filename
                     )
+                    cert_var = yaml.load(data_provider.config).get('cert_var', data_provider.slug)
                     metadata['data_sources'][provider_task.slug] = {'uid': str(provider_task.uid),
                                                                     'slug': provider_task.slug,
                                                                     'name': provider_task.name,
@@ -411,7 +412,7 @@ def get_metadata(data_provider_task_uid):
                                                                     # 'description': data_provider.service_description,
                                                                     'last_update': get_last_update(data_provider.url,
                                                                                                    provider_type,
-                                                                                                   slug=data_provider.slug),
+                                                                                                   cert_var=cert_var),
                                                                     'metadata': get_metadata_url(data_provider.url,
                                                                                                  provider_type),
                                                                     'copyright': data_provider.service_copyright}

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -141,6 +141,7 @@ def shutdown_celery_workers():
     logger.info("Queue is at zero, shutting down.")
     app.control.broadcast("shutdown", destination=hostnames)
 
+
 @app.task(name="Check Provider Availability")
 def check_provider_availability():
     from eventkit_cloud.jobs.models import DataProvider, DataProviderStatus

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -66,7 +66,7 @@ class TestHelpers(TestCase):
         test_url = "https://test"
         test_type = "osm"
         test_slug = "slug"
-        get_last_update(test_url, test_type, slug=test_slug)
+        get_last_update(test_url, test_type, cert_var=test_slug)
         mock_get_osm_last_update.assert_called_once_with(test_url, slug=test_slug)
 
     @patch('eventkit_cloud.tasks.helpers.auth_requests')
@@ -77,12 +77,12 @@ class TestHelpers(TestCase):
         expected_time = "2017-12-29T13:09:59Z"
 
         mock_auth_requests.get.return_value.content.decode.return_value = expected_time
-        returned_time = get_osm_last_update(test_url, slug=test_slug)
+        returned_time = get_osm_last_update(test_url, cert_var=test_slug)
         mock_auth_requests.get.assert_called_once_with(expected_url, slug=test_slug)
         self.assertEqual(expected_time, returned_time)
 
         mock_auth_requests.get.side_effect = Exception("FAIL")
-        returned_time = get_osm_last_update(test_url, slug=test_slug)
+        returned_time = get_osm_last_update(test_url, cert_var=test_slug)
         self.assertIsNone(returned_time)
 
     def test_get_metadata_url(self):

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -189,8 +189,11 @@ class MapproxyGeopackage(object):
         mapproxy.cache.geopackage.GeopackageCache.load_tile_metadata = load_tile_metadata
         logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:
-            auth_requests.patch_https(self.name)
-            auth_requests.patch_mapproxy_opener_cache(slug=self.name)
+            cert_var = yaml.load(self.config).get("cert_var")
+            auth_requests.patch_https(slug=self.name, cert_var=cert_var)
+
+            cred_var = yaml.load(self.config).get("cred_var")
+            auth_requests.patch_mapproxy_opener_cache(slug=self.name, cred_var=cred_var)
 
             progress_store = get_progress_store(self.gpkgfile)
             progress_logger = CustomLogger(verbose=True, task_uid=self.task_uid, progress_store=progress_store)

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -12,8 +12,10 @@ from django.conf import settings
 from django.contrib.gis.geos import GEOSGeometry, Polygon, GeometryCollection
 from django.utils.translation import ugettext as _
 from enum import Enum
+import yaml
 
 from eventkit_cloud.utils import auth_requests
+from eventkit_cloud.jobs.models import DataProvider
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +100,7 @@ class ProviderCheck(object):
     Once returned, the information is displayed via an icon and tooltip in the EventKit UI.
     """
 
-    def __init__(self, service_url, layer, aoi_geojson=None, slug=None, max_area=0):
+    def __init__(self, service_url, layer, aoi_geojson=None, slug=None, max_area=None, config: dict = None):
         """
         Initialize this ProviderCheck object with a service URL and layer.
         :param service_url: URL of provider, if applicable. Query string parameters are ignored.
@@ -114,6 +116,7 @@ class ProviderCheck(object):
         self.result = CheckResults.SUCCESS
         self.timeout = 10
         self.verify = getattr(settings, "SSL_VERIFICATION", True)
+        self.config = config
 
         if aoi_geojson is not None and aoi_geojson is not "":
             if isinstance(aoi_geojson, str):
@@ -159,7 +162,8 @@ class ProviderCheck(object):
                 self.result = CheckResults.NO_URL
                 return None
 
-            response = auth_requests.get(self.service_url, slug=self.slug, params=self.query, timeout=self.timeout,
+            cert_var = self.config.get("cert_var", self.slug)
+            response = auth_requests.get(self.service_url, cert_var=cert_var, params=self.query, timeout=self.timeout,
                                          verify=self.verify)
 
             self.token_dict['status'] = response.status_code
@@ -582,15 +586,16 @@ def get_provider_checker(type_slug):
         return ProviderCheck
 
 
-def perform_provider_check(provider, geojson):
+def perform_provider_check(provider: DataProvider, geojson):
     provider_type = str(provider.export_provider_type)
 
     url = str(provider.url)
     if url == '' and 'osm' in provider_type:
         url = settings.OVERPASS_API_URL
 
-    checker_type = get_provider_checker(provider_type)
-    checker = checker_type(service_url=url, layer=provider.layer, aoi_geojson=geojson, slug=provider.slug, max_area=provider.max_selection)
+    provider_checker = get_provider_checker(provider_type)
+    checker = provider_checker(service_url=url, layer=provider.layer, aoi_geojson=geojson, slug=provider.slug,
+                               max_area=provider.max_selection, config=yaml.load(provider.config))
     response = checker.check()
 
     logger.info("Status of provider '{}': {}".format(str(provider.name), response))

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -240,8 +240,10 @@ class OverpassProviderCheck(ProviderCheck):
                 self.result = CheckResults.NO_URL
                 return
 
-            response = auth_requests.post(url=self.service_url, slug=self.slug, data="out meta;", timeout=self.timeout,
-                                          verify=self.verify)
+            cert_var = self.config.get('cert_var') or self.slug
+
+            response = auth_requests.post(url=self.service_url, cert_var=cert_var, data="out meta;",
+                                          timeout=self.timeout, verify=self.verify)
 
             self.token_dict['status'] = response.status_code
 

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -77,7 +77,7 @@ class WCSConverter(object):
 
     def get_coverage_with_gdal(self):
         # Get username and password from url params, if possible
-        cred = auth_requests.get_cred(slug=self.name, url=self.service_url)
+        cred = auth_requests.get_cred(cred_var=self.name, url=self.service_url)
 
         try:
             # Isolate url params
@@ -156,7 +156,8 @@ class WCSConverter(object):
             except OSError:
                 pass
             try:
-                req = auth_requests.get(self.service_url, params=params, slug=self.slug, stream=True,
+                cert_var = self.config.get('cert_var', self.slug)
+                req = auth_requests.get(self.service_url, params=params, cert_var=cert_var, stream=True,
                                         verify=getattr(settings, 'SSL_VERIFICATION', True))
                 logger.info("Getting the coverage: {0}".format(req.url))
                 try:


### PR DESCRIPTION
This adds the ability to specify certificate variables in provider configs. 

To test add a certificate to the environment of eventkit and celery that doesn't match the data provider slug.  Then add to the data provider config section `cert_var: <certificate variable name>`, and ensure that data provider checks and exports work for that data provider. 