### PR TITLE
Fix Availability JSON parsing failure

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -329,7 +329,8 @@ export class ExportInfo extends React.Component<Props, State> {
             data,
             headers: { 'X-CSRFToken': csrfmiddlewaretoken },
         }).then((response) => {
-            newProvider.availability = response.data;
+            // The backend currently returns the response as a string, it needs to be parsed before being used.
+            newProvider.availability = JSON.parse(response.data);
             newProvider.availability.slug = provider.slug;
             return newProvider;
         }).catch(() => {

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -219,6 +219,8 @@ class ProviderCheck(object):
         else:
             self.result = CheckResults.TOO_LARGE
 
+        # TODO: This should not be dumped to a string here
+        # The front end should NOT receive a string, it should get a valid JSON response.
         result_json = json.dumps(self.result.value[0]) % self.token_dict
         logger.debug("Provider check returning result: %s", result_json)
         return result_json


### PR DESCRIPTION
This reverts a change to the availability checker on the front end. The front end will receive a JSON response as a string and needs to decode it before use.