### PR TITLE
Add Zoom Levels to Status Page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGridItem.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGridItem.tsx
@@ -441,6 +441,7 @@ export class DataPackGridItem extends React.Component<Props, State> {
                                 </IconMenu>
                                 <ProviderDialog
                                     uids={this.props.run.provider_tasks}
+                                    jobuid={this.props.run.job.uid}
                                     open={this.state.providerDialogOpen}
                                     onClose={this.handleProviderClose}
                                     providers={this.props.providers}

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackListItem.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackListItem.tsx
@@ -259,6 +259,7 @@ export class DataPackListItem extends React.Component<Props, State> {
                                 <ProviderDialog
                                     open={this.state.providerDialogOpen}
                                     uids={this.props.run.provider_tasks}
+                                    jobuid={this.props.run.job.uid}
                                     providers={this.props.providers}
                                     onClose={this.handleProviderClose}
                                 />

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackTableItem.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackTableItem.tsx
@@ -272,6 +272,7 @@ export class DataPackTableItem extends React.Component<Props, State> {
                     <ProviderDialog
                         open={this.state.providerDialogOpen}
                         uids={this.props.run.provider_tasks}
+                        jobuid={this.props.run.job.uid}
                         providers={this.props.providers}
                         onClose={this.handleProviderClose}
                     />

--- a/eventkit_cloud/ui/static/ui/app/components/Dialog/ProviderDialog.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/Dialog/ProviderDialog.tsx
@@ -7,6 +7,7 @@ import Progress from '@material-ui/core/CircularProgress';
 import BaseDialog from '../Dialog/BaseDialog';
 import DropDownListItem from '../common/DropDownListItem';
 import { getProviderTask } from '../../actions/providerActions';
+import { getJobDetails } from "../../utils/generic"
 
 interface OwnProps {
     uids: string[];
@@ -17,10 +18,12 @@ interface OwnProps {
 
 interface State {
     loading: boolean;
+    job: Eventkit.Job;
 }
 
 interface StateProps {
     providerTasks: Eventkit.ProviderTask[];
+    jobuid: string;
 }
 
 interface DispatchProps {
@@ -34,6 +37,7 @@ export class ProviderDialog extends React.Component<Props, State> {
         super(props);
         this.state = {
             loading: false,
+            job: null,
         };
     }
 
@@ -41,6 +45,11 @@ export class ProviderDialog extends React.Component<Props, State> {
         if (this.props.open) {
             this.getProviders(this.props.uids);
         }
+        getJobDetails(this.props.jobuid).then(data => {
+            this.setState({
+                job: data
+            })
+        })
     }
 
     componentDidUpdate(prevProps) {
@@ -99,13 +108,22 @@ export class ProviderDialog extends React.Component<Props, State> {
                             if (!provider) {
                                 return;
                             }
+
+                            const { job } = this.state
+                            const dataProviderTask = job && job.provider_tasks.find(obj => obj.provider === provider.name)
+
+                            // If available, get custom zoom levels from DataProviderTask otherwise use Provider defaults.
+                            const min_zoom = dataProviderTask && dataProviderTask.min_zoom || provider && provider.level_from
+                            const max_zoom = dataProviderTask && dataProviderTask.max_zoom || provider && provider.level_to
+
                             return (
                                 <DropDownListItem
                                     title={provider.name}
                                     key={provider.slug}
                                     alt={ix % 2 !== 0}
                                 >
-                                    {provider.service_description}
+                                    <div>Zoom Levels {min_zoom} - {max_zoom}</div>
+                                    <div>{provider.service_description}</div>
                                 </DropDownListItem>
                             );
                         })}

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.tsx
@@ -21,6 +21,7 @@ export interface Props {
     onProviderCancel: (uid: string) => void;
     maxResetExpirationDays: string;
     providers: Eventkit.Provider[];
+    job: any;
     user: Eventkit.Store.User;
     theme: Eventkit.Theme & Theme;
 }
@@ -133,6 +134,7 @@ export class DataCartDetails extends React.Component<Props, State> {
                         providerTasks={this.props.cartDetails.provider_tasks}
                         onProviderCancel={this.props.onProviderCancel}
                         providers={this.props.providers}
+                        job={this.props.job}
                         zipFileProp={this.props.cartDetails.zipfile_url}
                     />
                 </div>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.tsx
@@ -21,7 +21,7 @@ export interface Props {
     onProviderCancel: (uid: string) => void;
     maxResetExpirationDays: string;
     providers: Eventkit.Provider[];
-    job: any;
+    job: Eventkit.Job;
     user: Eventkit.Store.User;
     theme: Eventkit.Theme & Theme;
 }

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.tsx
@@ -32,7 +32,7 @@ export interface Props {
     providerTasks: Eventkit.ProviderTask[];
     onProviderCancel: (uid: string) => void;
     providers: Eventkit.Provider[];
-    job: any;
+    job: Eventkit.Job;
     zipFileProp: string;
     classes: { [className: string]: string };
     theme: Eventkit.Theme & Theme;

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.tsx
@@ -32,6 +32,7 @@ export interface Props {
     providerTasks: Eventkit.ProviderTask[];
     onProviderCancel: (uid: string) => void;
     providers: Eventkit.Provider[];
+    job: any;
     zipFileProp: string;
     classes: { [className: string]: string };
     theme: Eventkit.Theme & Theme;
@@ -252,6 +253,7 @@ export class DataPackDetails extends React.Component<Props, State> {
                             key={provider.uid}
                             onProviderCancel={this.props.onProviderCancel}
                             provider={provider}
+                            job={this.props.job}
                             selectedProviders={this.state.selectedProviders}
                             providers={this.props.providers}
                         />

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
@@ -410,7 +410,7 @@ export class ProviderRow extends React.Component<Props, State> {
         const dataProviderTask = job && job.provider_tasks.find(obj => obj.provider === provider.name)
         const propsProvider = this.props.providers.find(obj => obj.slug === provider.slug);
 
-        // If available, get custom zoom levels from DataProviderTask othewise use Provider defaults.
+        // If available, get custom zoom levels from DataProviderTask otherwise use Provider defaults.
         const min_zoom = dataProviderTask && dataProviderTask.min_zoom || propsProvider && propsProvider.level_from
         const max_zoom = dataProviderTask && dataProviderTask.max_zoom || propsProvider && propsProvider.level_to
 

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
@@ -24,6 +24,7 @@ import moment from 'moment';
 
 interface Props {
     provider: Eventkit.ProviderTask;
+    job: any;
     selectedProviders: { [uid: string]: boolean };
     onProviderCancel: (uid: string) => void;
     providers: Eventkit.Provider[];
@@ -70,6 +71,14 @@ const jss = (theme: Eventkit.Theme & Theme) => createStyles({
         fontWeight: 'bold',
     },
     taskLinkColumn: {
+        paddingRight: '12px',
+        paddingLeft: '0px',
+        fontSize: '12px',
+        [theme.breakpoints.up('md')]: {
+            fontSize: '14px',
+        },
+    },
+    zoomLevelColumn: {
         paddingRight: '12px',
         paddingLeft: '0px',
         fontSize: '12px',
@@ -396,8 +405,15 @@ export class ProviderRow extends React.Component<Props, State> {
     render() {
         const { classes } = this.props;
         const { provider } = this.props;
+        const { job } = this.props
 
-        const propsProvider = this.props.providers.find(x => x.slug === provider.slug);
+        const dataProviderTask = job.provider_tasks.find(obj => obj.provider === provider.name)
+        const propsProvider = this.props.providers.find(obj => obj.slug === provider.slug);
+
+        // If available, get custom zoom levels from DataProviderTask othewise use Provider defaults.
+        const min_zoom = dataProviderTask.min_zoom || propsProvider && propsProvider.level_from
+        const max_zoom = dataProviderTask.max_zoom || propsProvider && propsProvider.level_to
+
         const licenseData = propsProvider && propsProvider.license ?
             <LicenseRow name={propsProvider.license.name} text={propsProvider.license.text} />
             :
@@ -442,6 +458,23 @@ export class ProviderRow extends React.Component<Props, State> {
                         className="qa-ProviderRow-TableBody"
                     >
                         {licenseData}
+                        <TableRow
+                            className="qa-ProviderRow-TableRow-task"
+                        >
+                            <TableCell classes={{ root: classes.insetColumn }} />
+
+                            <TableCell
+                                className="qa-ProviderRow-TableCell-zoomLevels"
+                                classes={{ root: classes.zoomLevelColumn }}
+                            >
+                                Zoom Levels {min_zoom} - {max_zoom}
+                            </TableCell>
+                            <TableCell classes={{ root: classes.sizeColumnn }}/>
+                            <TableCell classes={{ root: classes.estimatedFinishColumn }}/>
+                            <TableCell classes={{ root: classes.taskStatusColumn }}/>
+                            <TableCell classes={{ root: classes.menuColumn }} />
+                            <TableCell classes={{ root: classes.arrowColumn }} />
+                        </TableRow>
                         {tasks.map(task => (
                             <TableRow
                                 className="qa-ProviderRow-TableRow-task"
@@ -539,6 +572,7 @@ export class ProviderRow extends React.Component<Props, State> {
                                     title={provider.name}
                                     onClose={this.handleProviderClose}
                                 >
+                                    Zoom Levels {min_zoom} - {max_zoom} <br />
                                     {this.state.providerDesc}
                                 </BaseDialog>
                             </TableCell>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
@@ -572,7 +572,7 @@ export class ProviderRow extends React.Component<Props, State> {
                                     title={provider.name}
                                     onClose={this.handleProviderClose}
                                 >
-                                    Zoom Levels {min_zoom} - {max_zoom} <br />
+                                    <div>Zoom Levels {min_zoom} - {max_zoom}</div>
                                     {this.state.providerDesc}
                                 </BaseDialog>
                             </TableCell>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.tsx
@@ -24,7 +24,7 @@ import moment from 'moment';
 
 interface Props {
     provider: Eventkit.ProviderTask;
-    job: any;
+    job: Eventkit.Job;
     selectedProviders: { [uid: string]: boolean };
     onProviderCancel: (uid: string) => void;
     providers: Eventkit.Provider[];
@@ -407,12 +407,12 @@ export class ProviderRow extends React.Component<Props, State> {
         const { provider } = this.props;
         const { job } = this.props
 
-        const dataProviderTask = job.provider_tasks.find(obj => obj.provider === provider.name)
+        const dataProviderTask = job && job.provider_tasks.find(obj => obj.provider === provider.name)
         const propsProvider = this.props.providers.find(obj => obj.slug === provider.slug);
 
         // If available, get custom zoom levels from DataProviderTask othewise use Provider defaults.
-        const min_zoom = dataProviderTask.min_zoom || propsProvider && propsProvider.level_from
-        const max_zoom = dataProviderTask.max_zoom || propsProvider && propsProvider.level_to
+        const min_zoom = dataProviderTask && dataProviderTask.min_zoom || propsProvider && propsProvider.level_from
+        const max_zoom = dataProviderTask && dataProviderTask.max_zoom || propsProvider && propsProvider.level_to
 
         const licenseData = propsProvider && propsProvider.license ?
             <LicenseRow name={propsProvider.license.name} text={propsProvider.license.text} />

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
@@ -63,7 +63,7 @@ export interface State {
     error: any;
     steps: Step[];
     isRunning: boolean;
-    job: any;
+    job: Eventkit.Job;
 }
 
 export class StatusDownload extends React.Component<Props, State> {
@@ -92,7 +92,7 @@ export class StatusDownload extends React.Component<Props, State> {
             error: null,
             steps: [],
             isRunning: false,
-            job: {}
+            job: null,
         };
     }
 

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
@@ -63,6 +63,7 @@ export interface State {
     error: any;
     steps: Step[];
     isRunning: boolean;
+    job: any;
 }
 
 export class StatusDownload extends React.Component<Props, State> {
@@ -78,6 +79,7 @@ export class StatusDownload extends React.Component<Props, State> {
         super(props);
         this.callback = this.callback.bind(this);
         this.getInitialState = this.getInitialState.bind(this);
+        this.getJobDetails = this.getJobDetails.bind(this);
         this.clearError = this.clearError.bind(this);
         this.getErrorMessage = this.getErrorMessage.bind(this);
         this.handleWalkthroughClick = this.handleWalkthroughClick.bind(this);
@@ -90,11 +92,24 @@ export class StatusDownload extends React.Component<Props, State> {
             error: null,
             steps: [],
             isRunning: false,
+            job: {}
         };
+    }
+
+    getJobDetails(jobuid) {
+        fetch('/api/jobs/' + jobuid)
+        .then(res => res.json())
+            .then((result) => {
+                this.setState({
+                    job: result
+                });
+        })
+        .catch(console.log)
     }
 
     componentDidMount() {
         this.onMount();
+        this.getJobDetails(this.props.match.params.jobuid);
     }
 
     shouldComponentUpdate(p: Props) {
@@ -377,6 +392,7 @@ export class StatusDownload extends React.Component<Props, State> {
                     onClone={this.props.cloneExport}
                     onProviderCancel={this.props.cancelProviderTask}
                     providers={this.props.providers}
+                    job={this.state.job}
                     maxResetExpirationDays={this.context.config.MAX_DATAPACK_EXPIRATION_DAYS}
                     user={this.props.user}
                 />

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
@@ -1,6 +1,5 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import axios from 'axios';
 import { connect } from 'react-redux';
 import { withTheme, Theme } from '@material-ui/core/styles';
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
@@ -31,6 +30,7 @@ import { makeDatacartSelector } from '../../selectors/runSelector';
 import { Location } from 'history';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import history from "../../utils/history";
+import { getJobDetails } from "../../utils/generic"
 
 export interface Props {
     runs: Eventkit.FullRun[];
@@ -79,7 +79,6 @@ export class StatusDownload extends React.Component<Props, State> {
         super(props);
         this.callback = this.callback.bind(this);
         this.getInitialState = this.getInitialState.bind(this);
-        this.getJobDetails = this.getJobDetails.bind(this);
         this.clearError = this.clearError.bind(this);
         this.getErrorMessage = this.getErrorMessage.bind(this);
         this.handleWalkthroughClick = this.handleWalkthroughClick.bind(this);
@@ -96,19 +95,13 @@ export class StatusDownload extends React.Component<Props, State> {
         };
     }
 
-    getJobDetails(jobuid) {
-        axios.get('/api/jobs/' + jobuid)
-            .then((result) => {
-                this.setState({
-                    job: result.data
-                });
-        })
-        .catch(console.log)
-    }
-
     componentDidMount() {
         this.onMount();
-        this.getJobDetails(this.props.match.params.jobuid);
+        getJobDetails(this.props.match.params.jobuid).then(data => {
+            this.setState({
+                job: data
+            })
+        })
     }
 
     shouldComponentUpdate(p: Props) {

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.tsx
@@ -1,9 +1,9 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
+import axios from 'axios';
 import { connect } from 'react-redux';
 import { withTheme, Theme } from '@material-ui/core/styles';
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
-import { RouteComponentProps } from 'react-router';
 import Joyride, { Step } from 'react-joyride';
 import Help from '@material-ui/icons/Help';
 import Paper from '@material-ui/core/Paper';
@@ -97,11 +97,10 @@ export class StatusDownload extends React.Component<Props, State> {
     }
 
     getJobDetails(jobuid) {
-        fetch('/api/jobs/' + jobuid)
-        .then(res => res.json())
+        axios.get('/api/jobs/' + jobuid)
             .then((result) => {
                 this.setState({
-                    job: result
+                    job: result.data
                 });
         })
         .catch(console.log)

--- a/eventkit_cloud/ui/static/ui/app/components/common/DropDownListItem.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/common/DropDownListItem.tsx
@@ -54,9 +54,13 @@ export class DropDownListItem extends React.Component<Props, State> {
             </ListItem>,
             <Collapse in={this.state.open} key="list-item-content">
                 <List style={{ backgroundColor, padding: '8px 10px' }}>
-                    <ListItem>
-                        {this.props.children}
-                    </ListItem>
+                    {React.Children.map(this.props.children, (child, index) => {
+                        return (
+                            <ListItem key={index}>
+                                {child}
+                            </ListItem>
+                        )
+                    })}
                 </List>
             </Collapse>,
         ]);

--- a/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
+++ b/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
@@ -67,6 +67,13 @@ declare namespace Eventkit {
         service_description: string;
     }
 
+    interface DataProviderTask {
+        provider: string;
+        formats: string[];
+        min_zoom: number;
+        max_zoom: number;
+    }
+
     interface Job {
         uid: string;
         name: string;
@@ -82,6 +89,7 @@ declare namespace Eventkit {
         created_at: string;
         relationship: Permissions.Level;
         permissions: Permissions;
+        provider_tasks: DataProviderTask[];
     }
 
     interface Run {

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.tsx
@@ -131,8 +131,8 @@ describe('ProviderRow component', () => {
         wrapper.setState({ openTable: true });
         expect(wrapper.find(Table)).toHaveLength(2);
         expect(wrapper.find(TableHead)).toHaveLength(1);
-        expect(wrapper.find(TableRow)).toHaveLength(2);
-        expect(wrapper.find(TableCell)).toHaveLength(13);
+        expect(wrapper.find(TableRow)).toHaveLength(3);
+        expect(wrapper.find(TableCell)).toHaveLength(20);
         expect(wrapper.find(TableBody)).toHaveLength(1);
         expect(wrapper.find(LicenseRow)).toHaveLength(1);
     });
@@ -320,7 +320,7 @@ describe('ProviderRow component', () => {
         expect(stateSpy.called).toBe(true);
         expect(stateSpy.calledWith({ providerDesc: 'provider description', providerDialogOpen: true })).toBe(true);
         wrapper.update();
-        expect(wrapper.find(BaseDialog).childAt(0).text()).toEqual('provider description');
+        expect(wrapper.find(BaseDialog).childAt(1).text()).toContain('provider description');
         stateSpy.restore();
     });
 

--- a/eventkit_cloud/ui/static/ui/app/utils/generic.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/generic.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import numeral from 'numeral';
 import GeoJSON from 'ol/format/geojson';
 
@@ -146,4 +147,12 @@ export function formatMegaBytes(megabytes) {
 export function getCookie(name) {
     var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
     return v ? v[2] : null;
+}
+
+export function getJobDetails(jobuid) {
+    return axios.get('/api/jobs/' + jobuid)
+        .then((result) => {
+            return result.data
+        })
+        .catch(console.log)
 }


### PR DESCRIPTION
This PR fetches the custom zoom levels from the Job, and adds the zoom levels to the Status Page as well as the View Data Source dialog.  If no custom zoom levels were set, it will fall back to the default provider zoom levels and display those.  

![addZoomLevelsToStatusPage](https://user-images.githubusercontent.com/168976/62789727-8e324d00-ba97-11e9-82ed-2a10b9f93273.PNG)

![addZoomLevelsToStatusPageDialog](https://user-images.githubusercontent.com/168976/62789737-938f9780-ba97-11e9-932a-bbf68848dc93.PNG)
