### PR TITLE
Add Export info for source on Export Summary page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
@@ -147,32 +147,36 @@ export class ExportSummary extends React.Component<Props, State> {
             window.location.hash = step.scrollToId;
         }
     }
-    
+
     private getExportInfo(provider: Eventkit.Provider) {
+        // Generate elements to display information about the export options for the specified provider.
         const providerOptions = this.props.exportOptions[provider.slug];
         // Reusable func to add a section of text to the info.
-        let generateSection = (content) => { return (<p className={this.props.classes.exportInfoLine}>{content}</p>)};
-        let exportInfo = [];
-        exportInfo.push((<p className={this.props.classes.exportInfoLine} style={{fontWeight: 'bold'}}>{provider.name}</p>));
-        if(providerOptions) {
+        let index = 0; // Used for keys as React considers this to be a list.
+        const generateSection = (content) => (<p className={this.props.classes.exportInfoLine} key={index++}>{content}</p>);
+        const exportInfo = [];
+        exportInfo.push((<p className={this.props.classes.exportInfoLine} style={{fontWeight: 'bold'}} key="name">{provider.name}</p>));
+        if (providerOptions) {
             if (supportsZoomLevels(provider)) {
-                let minZoom = isZoomLevelInRange(providerOptions.minZoom, provider) ? providerOptions.minZoom : provider.level_from;
-                let maxZoom = isZoomLevelInRange(providerOptions.maxZoom, provider) ? providerOptions.maxZoom : provider.level_to;
+                // For sources that support specifying a zoom level, check for and validate the values, otherwise use from/to
+                const minZoom = isZoomLevelInRange(providerOptions.minZoom, provider) ? providerOptions.minZoom : provider.level_from;
+                const maxZoom = isZoomLevelInRange(providerOptions.maxZoom, provider) ? providerOptions.maxZoom : provider.level_to;
                 exportInfo.push(generateSection(`Zooms: ${minZoom}-${maxZoom}`));
-            }
-            else {
+            } else {
+                // Source does not support zooming
                 exportInfo.push(generateSection(`Zooms: Default zoom selected.`));
             }
             if (providerOptions.formats) {
-                let formatNames = provider.supported_formats.filter(format => providerOptions.formats.indexOf(format.slug) >= 0).map(format => format.name);
+                // Formats should always be specified.
+                const formatNames = provider.supported_formats.filter(
+                    format => providerOptions.formats.indexOf(format.slug) >= 0).map(format => format.name);
                 exportInfo.push(generateSection(`Formats: ${formatNames.join(', ')}`));
             }
-        }
-        else {
+        } else {
             // If we allow no options to be selected, display a default message.
-            exportInfo.push(generateSection(`Default options selected.`))
+            exportInfo.push(generateSection(`Default options selected.`));
         }
-        return (<div style={{paddingBottom: '10px'}} key={provider.uid}>{exportInfo.map((info) => {return info})}</div>)
+        return (<div className="source-info" style={{paddingBottom: '10px'}} key={provider.uid}>{exportInfo.map((info) => info)}</div>);
     }
 
     render() {

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
@@ -182,6 +182,7 @@ export class ExportSummary extends React.Component<Props, State> {
     render() {
         const { classes } = this.props;
         const { steps, isRunning } = this.state;
+        const dataStyle = { color: 'black' };
 
         const providers = this.props.providers.filter(provider => (provider.display !== false));
         return (
@@ -223,16 +224,19 @@ export class ExportSummary extends React.Component<Props, State> {
                                     className="qa-ExportSummary-name"
                                     title="Name"
                                     data={this.props.exportName}
+                                    dataStyle={dataStyle}
                                 />
                                 <CustomTableRow
                                     className="qa-ExportSummary-description"
                                     title="Description"
                                     data={this.props.datapackDescription}
+                                    dataStyle={dataStyle}
                                 />
                                 <CustomTableRow
                                     className="qa-ExportSummary-project"
                                     title="Project / Category"
                                     data={this.props.projectName}
+                                    dataStyle={dataStyle}
                                 />
                                 <CustomTableRow
                                     className="qa-ExportSummary-sources"
@@ -247,6 +251,7 @@ export class ExportSummary extends React.Component<Props, State> {
                                     className="qa-ExportsSummary-area"
                                     title="Area"
                                     data={this.props.areaStr}
+                                    dataStyle={dataStyle}
                                 />
                             </div>
                             <div id="aoi-map" className={`qa-ExportSummary-map ${classes.mapCard}`}>

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
@@ -155,7 +155,7 @@ export class ExportSummary extends React.Component<Props, State> {
         let index = 0; // Used for keys as React considers this to be a list.
         const generateSection = (content) => (<p className={this.props.classes.exportInfoLine} key={index++}>{content}</p>);
         const exportInfo = [];
-        exportInfo.push((<p className={this.props.classes.exportInfoLine} style={{fontWeight: 'bold'}} key="name">{provider.name}</p>));
+        exportInfo.push((<p className={this.props.classes.exportInfoLine} style={{color: 'black'}} key="name">{provider.name}</p>));
         if (providerOptions) {
             if (supportsZoomLevels(provider)) {
                 // For sources that support specifying a zoom level, check for and validate the values, otherwise use from/to

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportSummary.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportSummary.spec.tsx
@@ -27,11 +27,15 @@ describe('Export Summary Component', () => {
         projectName: 'project',
         makePublic: true,
         providers: [
-            { name: 'one', uid: 1, display: true },
-            { name: 'two', uid: 2, display: false },
-            { name: 'three', uid: 3, display: false },
+            { name: 'one', uid: 1, display: true, slug: 'one', type: 'wmts', supported_formats: ['gpkg'] },
+            { name: 'two', uid: 2, display: false, slug: 'two', type: 'wmts', supported_formats: ['gpkg'] },
+            { name: 'three', uid: 3, display: false, slug: 'three', type: 'wmts', supported_formats: ['gpkg'] },
         ],
         areaStr: '12 sq km',
+        exportOptions: {
+            'one': { minZoom: 0, maxZoom: 2, formats: ['gpkg']},
+            'two': {},
+        },
         formats: 'gpkg',
         allFormats: [
             {

--- a/eventkit_cloud/ui/static/ui/app/utils/generic.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/generic.ts
@@ -158,17 +158,11 @@ export function getJobDetails(jobuid) {
 }
 
 export function isZoomLevelInRange(zoomLevel, provider: Eventkit.Provider) {
-    if ((!zoomLevel && zoomLevel !== 0) || (zoomLevel < provider.level_from && zoomLevel > provider.level_to))  {
-        return false;
-    }
-    return true;
+    return !((!zoomLevel && zoomLevel !== 0) || (zoomLevel < provider.level_from && zoomLevel > provider.level_to));
 }
 
 // Not an exhaustive list, just what I'm aware of right now.
 const typesSupportingZoomLevels = [ 'tms', 'wmts', 'wms', 'arcgis-raster'];
 export function supportsZoomLevels(provider: Eventkit.Provider) {
-    if (typesSupportingZoomLevels.indexOf(provider.type.toLowerCase()) >= 0) {
-        return true;
-    }
-    return false;
+    return typesSupportingZoomLevels.indexOf(provider.type.toLowerCase()) >= 0;
 }


### PR DESCRIPTION
This adds information about the Export Options (zoom, formats) to the Export Summary page so users can review the options they have selected for any providers selected.

![image](https://user-images.githubusercontent.com/50183410/63887746-73266f00-c9ab-11e9-9102-d58ad3797a39.png)
