### PR TITLE
Ensure provider is fully represented when cloning

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.tsx
@@ -166,7 +166,7 @@ export class ExportSummary extends React.Component<Props, State> {
                 // Source does not support zooming
                 exportInfo.push(generateSection(`Zooms: Default zoom selected.`));
             }
-            if (providerOptions.formats) {
+            if (providerOptions.formats && !!provider.supported_formats) {
                 // Formats should always be specified.
                 const formatNames = provider.supported_formats.filter(
                     format => providerOptions.formats.indexOf(format.slug) >= 0).map(format => format.name);

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.tsx
@@ -148,6 +148,7 @@ export class DataCartDetails extends React.Component<Props, State> {
                         onDelete={this.props.onRunDelete}
                         dataPack={this.props.cartDetails}
                         job={this.props.job}
+                        providers={this.props.providers}
                         adminPermissions={this.props.cartDetails.job.relationship === 'ADMIN'}
                     />
                 </div>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackOptions.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackOptions.tsx
@@ -11,6 +11,7 @@ export interface Props {
     onDelete: (uid: string) => void;
     dataPack: Eventkit.FullRun;
     job: Eventkit.Job;
+    providers: Eventkit.Provider[];
 }
 
 export interface State {
@@ -79,20 +80,25 @@ export class DataPackOptions extends React.Component<Props, State> {
     private handleClone() {
         const providerArray = [];
         let exportOptions = {};
-        this.props.dataPack.provider_tasks.forEach((provider) => {
-            if (provider.display === true) {
-                let providerTask = this.props.job.provider_tasks.find((providerTask) =>
+        this.props.dataPack.provider_tasks.forEach((providerTask) => {
+            if (providerTask.display === true) {
+                // Map the provider task to its Provider to ensure we have all needed data for the Provider.
+                const fullProvider = this.props.providers.find((provider) => providerTask.slug === provider.slug);
+                const dataProviderTask = this.props.job.provider_tasks.find((d) =>
                     // Currently `provider` is the provider name
                     // The backend should be updated in the future to make it point to a uuid or the slug
                     // this change will need to happen here as well
-                    provider.name === providerTask.provider
+                    providerTask.name === d.provider
                 );
-                exportOptions[provider.slug] = {
-                    minZoom: (providerTask) ? providerTask.min_zoom : null,
-                    maxZoom: (providerTask) ? providerTask.max_zoom : null,
-                    formats: (providerTask) ? providerTask.formats: null,
+                exportOptions[fullProvider.slug] = {
+                    minZoom: (dataProviderTask) ? dataProviderTask.min_zoom : null,
+                    maxZoom: (dataProviderTask) ? dataProviderTask.max_zoom : null,
+                    formats: (dataProviderTask) ? dataProviderTask.formats: null,
                 } as Eventkit.Store.ProviderExportOptions;
-                providerArray.push(provider);
+                // Cannot clone a provider without the full set of info.
+                if (fullProvider) {
+                    providerArray.push(fullProvider);
+                }
             }
         });
         this.props.onClone(this.props.dataPack, providerArray, exportOptions);

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackOptions.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackOptions.tsx
@@ -90,7 +90,7 @@ export class DataPackOptions extends React.Component<Props, State> {
                     // this change will need to happen here as well
                     providerTask.name === d.provider
                 );
-                exportOptions[fullProvider.slug] = {
+                exportOptions[providerTask.slug] = {
                     minZoom: (dataProviderTask) ? dataProviderTask.min_zoom : null,
                     maxZoom: (dataProviderTask) ? dataProviderTask.max_zoom : null,
                     formats: (dataProviderTask) ? dataProviderTask.formats: null,

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackOptions.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackOptions.spec.tsx
@@ -51,6 +51,18 @@ describe('DataPackOptions component', () => {
                 max_zoom: 3,
             }]
         },
+        providers: [{
+            uid: '123',
+            slug: 'test1',
+            name: 'test1',
+            max_selection: '10000',
+            type: 'wmts',
+            service_description: 'test description',
+            license: {
+                text: 'test license text',
+                name: 'test license',
+            },
+        }],
         ...(global as any).eventkit_test_props,
     });
 
@@ -155,7 +167,7 @@ describe('DataPackOptions component', () => {
         };
         instance.handleClone();
         expect(props.onClone.calledOnce).toBe(true);
-        expect(props.onClone.calledWith(props.dataPack, [props.dataPack.provider_tasks[0]], exportInfo)).toBe(true);
+        expect(props.onClone.calledWith(props.dataPack, [props.providers[0]], exportInfo)).toBe(true);
         expect(stateStub.calledOnce).toBe(true);
         expect(stateStub.calledWith({ showCloneDialog: false })).toBe(true);
         stateStub.restore();

--- a/eventkit_cloud/ui/static/ui/app/utils/generic.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/generic.ts
@@ -162,7 +162,10 @@ export function isZoomLevelInRange(zoomLevel, provider: Eventkit.Provider) {
 }
 
 // Not an exhaustive list, just what I'm aware of right now.
-const typesSupportingZoomLevels = [ 'tms', 'wmts', 'wms', 'arcgis-raster'];
+const typesSupportingZoomLevels = ['tms', 'wmts', 'wms', 'arcgis-raster'];
 export function supportsZoomLevels(provider: Eventkit.Provider) {
+    if (provider.type === null || provider.type === undefined) {
+        return false;
+    }
     return typesSupportingZoomLevels.indexOf(provider.type.toLowerCase()) >= 0;
 }


### PR DESCRIPTION
This fixes a bug where missing provider info would cause a crash on the Review & Submit step of DataPack creation.