### PR TITLE
Clear estimate value on zoom update; fix issue with loading icon bein…

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
@@ -95,6 +95,7 @@ interface Props {
     updateExportInfo: (args: any) => void;
     provider: ProviderData;
     checkProvider: (args: any) => void;
+    clearEstimate: (provider: ProviderData) => void;
     checked: boolean;
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     alt: boolean;
@@ -189,7 +190,7 @@ export class DataProvider extends React.Component<Props, State> {
         });
 
         if (minZoom !== lastMin || maxZoom !== lastMax) {
-            // Only trigger an estimate update if the value is new.
+            this.props.clearEstimate(this.props.provider);
             this.estimateDebouncer(this.props.provider);
         }
     }
@@ -380,11 +381,12 @@ export class DataProvider extends React.Component<Props, State> {
         // Only set this if we want to display the estimate
         let secondary;
         if (this.props.renderEstimate) {
-            if (this.formatEstimate(provider.estimate)) {
+            const estimate = this.formatEstimate(provider.estimate);
+            if (estimate) {
                 secondary =
-                    <Typography style={{fontSize: "0.7em"}}>{this.formatEstimate(provider.estimate)}</Typography>;
+                    <Typography style={{fontSize: "0.7em"}}>{estimate}</Typography>;
             } else {
-                secondary = <CircularProgress size={10}/>;
+                secondary = <CircularProgress style={{display: 'grid'}} size={11}/>;
             }
         }
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -175,6 +175,7 @@ export class ExportInfo extends React.Component<Props, State> {
         this.checkProvider = this.checkProvider.bind(this);
         this.handlePopoverOpen = this.handlePopoverOpen.bind(this);
         this.handlePopoverClose = this.handlePopoverClose.bind(this);
+        this.clearEstimate = this.clearEstimate.bind(this);
 
         this.joyride = React.createRef();
     }
@@ -446,6 +447,17 @@ export class ExportInfo extends React.Component<Props, State> {
             });
             return newProvider;
         }
+    }
+
+    private clearEstimate(provider: ProviderData) {
+        const newProvider = {...provider} as ProviderData;
+        newProvider.estimate = null;
+        this.setState((prevState) => {
+            // make a copy of state providers and replace the one we updated
+            const providers = [...prevState.providers];
+            providers.splice(providers.indexOf(provider), 1, newProvider);
+            return {providers};
+        });
     }
 
     private checkProviders(providers: ProviderData[]) {
@@ -728,6 +740,7 @@ export class ExportInfo extends React.Component<Props, State> {
                                             alt={ix % 2 === 0}
                                             renderEstimate={this.context.config.SERVE_ESTIMATES}
                                             checkProvider={this.checkProvider}
+                                            clearEstimate={this.clearEstimate}
                                         />
                                     ))}
                                 </List>

--- a/eventkit_cloud/ui/static/ui/app/utils/generic.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/generic.ts
@@ -135,13 +135,13 @@ export function formatMegaBytes(megabytes) {
     // format a size so that it is reasonably displayed.
     // megabytes = 40 => 40 MB
     // megabytes = 1337 => 1.34 GB
-    let units = ['MB', 'GB', 'TB']; // More can be added, obviously
+    const units = ['MB', 'GB', 'TB']; // More can be added, obviously
     let order = 0;
-    megabytes = Number(megabytes);
-    while(megabytes / 10 ** ((order + 1) * 3) >= 1) {
+    const mb = Number(megabytes);
+    while (mb / (10 ** ((order + 1) * 3)) >= 1) {
         order += 1;
     }
-    return `${Number(megabytes / 10 ** (order * 3)).toFixed(2)} ${units[order]}`
+    return `${Number(mb / (10 ** (order * 3))).toFixed(2)} ${units[order]}`;
 }
 
 export function getCookie(name) {


### PR DESCRIPTION
Update the DataProvider component to display the loading icon for estimates after a zoom level update (to indicate that a new estimate is being fetched).

Additionally fixes the loading icon to rotate around its own center; it was previously off by a few pixels.