### PR TITLE
Fix increment in for loop to prevent infinite loop

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/utils/mapUtils.js
+++ b/eventkit_cloud/ui/static/ui/app/utils/mapUtils.js
@@ -581,7 +581,7 @@ export function getResolutions(levels, startingResolution) {
     // Default to EPSG:4326 resolution supporting 2 tiles at level 0.
     const startResolution = startingResolution || 0.703125;
     const resolutions = new Array(levels);
-    for (let i = 0; i < resolutions.length; i++) {
+    for (let i = 0; i < resolutions.length; i += 1) {
         resolutions[i] = startResolution / (2 ** i);
     }
     return resolutions;

--- a/eventkit_cloud/ui/static/ui/app/utils/mapUtils.js
+++ b/eventkit_cloud/ui/static/ui/app/utils/mapUtils.js
@@ -581,7 +581,7 @@ export function getResolutions(levels, startingResolution) {
     // Default to EPSG:4326 resolution supporting 2 tiles at level 0.
     const startResolution = startingResolution || 0.703125;
     const resolutions = new Array(levels);
-    for (let i = 0; i < resolutions.length; i + 1) {
+    for (let i = 0; i < resolutions.length; i++) {
         resolutions[i] = startResolution / (2 ** i);
     }
     return resolutions;


### PR DESCRIPTION
One line fix for a increment issue in mapUtils leading to an infinite loop. 