### PR TITLE
Hide Basemaps for providers that should not be displayed

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -204,7 +204,8 @@ export class MapDrawer extends React.Component<Props, State> {
         const {selectedTab, selectedBaseMap} = this.state;
         const sources = [
             ...this.state.sources,
-            ...this.props.providers.filter(provider => !!provider.preview_url).map(provider => {
+            // Filter for providers with a preview_url AND marked to display
+            ...this.props.providers.filter(provider => !!provider.preview_url && !!provider.display).map(provider => {
                 return {
                     url: provider.preview_url,
                     name: provider.name,

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/MapDrawer.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/MapDrawer.spec.tsx
@@ -6,7 +6,7 @@ import {BaseMapSource, MapDrawer} from "../../components/CreateDataPack/MapDrawe
 import CustomScrollbar from "../../components/CustomScrollbar";
 import {Tabs} from "@material-ui/core";
 import Tab from "@material-ui/core/Tab";
-import Checkbox from "@material-ui/core/Checkbox";
+import ListItem from '@material-ui/core/ListItem';
 
 describe('FilterDrawer component', () => {
     const providers = [
@@ -16,9 +16,39 @@ describe('FilterDrawer component', () => {
             license: null,
             created_at: '2017-08-15T19:25:10.844911Z',
             updated_at: '2017-08-15T19:25:10.844919Z',
-            uid: 'bc9a834a-727a-4779-8679-2500880a8526',
+            uid: 'bc9a834a-727a-7777-8679-2500880a8526',
             name: 'OpenStreetMap Data (Themes)',
             slug: 'osm',
+            service_description: 'OpenStreetMap vector data.',
+            display: true,
+            export_provider_type: 2,
+            supported_formats: ['fmt1'],
+            preview_url: 'url/path/1'
+        },
+        {
+            id: 3,
+            type: 'osm',
+            license: null,
+            created_at: '2017-08-15T19:25:10.844911Z',
+            updated_at: '2017-08-15T19:25:10.844919Z',
+            uid: 'bc9a834a-727a-6666-8679-2500880a8526',
+            name: 'OpenStreetMap Data (Themes)',
+            slug: 'osm4',
+            service_description: 'OpenStreetMap vector data.',
+            display: false,
+            export_provider_type: 2,
+            supported_formats: ['fmt1'],
+            preview_url: 'url/path/2'
+        },
+        {
+            id: 1337,
+            type: 'osm',
+            license: null,
+            created_at: '2017-08-15T19:25:10.844911Z',
+            updated_at: '2017-08-15T19:25:10.844919Z',
+            uid: 'bc9a834a-727a-5555-8679-2500880a8526',
+            name: 'OpenStreetMap Data (Themes)',
+            slug: 'osm5',
             service_description: 'OpenStreetMap vector data.',
             display: true,
             export_provider_type: 2,
@@ -49,6 +79,9 @@ describe('FilterDrawer component', () => {
         expect(wrapper.find(Tabs)).toHaveLength(1);
         expect(wrapper.find(Tab)).toHaveLength(1);
         expect(wrapper.find(Drawer)).toHaveLength(wrapper.find(Tab).length);
+        // Of the 3 providers, only one should be displayed
+        // BaseMaps are only added when a preview_url exists AND the provider should be displayed.
+        expect(wrapper.find(ListItem)).toHaveLength(1);
     });
 
     it('tab should have appropriate values', () => {


### PR DESCRIPTION
This makes sure that providers that should not be displayed are hidden from the basemap tab even if they have a preview url.