### PR TITLE
Add OAuth class information to the UserAdmin page.

### DIFF
--- a/eventkit_cloud/auth/admin.py
+++ b/eventkit_cloud/auth/admin.py
@@ -26,13 +26,14 @@ class OAuthAdmin(admin.ModelAdmin):
         actions.pop('delete_selected', None)
         return actions
 
+class OAuthInline(admin.StackedInline):
+    model = OAuth
 
 class UserLicenseInline(admin.TabularInline):
     model = UserLicense
     extra = 0
 
-
-UserAdmin.inlines = [UserLicenseInline]
+UserAdmin.inlines = [OAuthInline, UserLicenseInline]
 UserAdmin.readonly_fields += 'last_login', 'date_joined'
 
 


### PR DESCRIPTION
This PR adds an inline of the OAuth information on the user page so it's easier to see all of a user's information without having to go back and forth between various admin pages.  