### PR TITLE
Persisting bounding box

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
@@ -1021,6 +1021,7 @@ export class ExportAOI extends React.Component<Props, State> {
                     run={isRunning}
                 />
                 <div id="map" className={css.map} style={mapStyle}>
+                { this.props.aoiInfo }
                     <AoiInfobar
                         aoiInfo={this.props.aoiInfo}
                         showRevert={!!this.props.aoiInfo.buffer}

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
@@ -1021,7 +1021,6 @@ export class ExportAOI extends React.Component<Props, State> {
                     run={isRunning}
                 />
                 <div id="map" className={css.map} style={mapStyle}>
-                { this.props.aoiInfo }
                     <AoiInfobar
                         aoiInfo={this.props.aoiInfo}
                         showRevert={!!this.props.aoiInfo.buffer}

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
@@ -28,7 +28,7 @@ export class DataPackLinkButton extends React.Component<Props, {}> {
 
         return (
             <Link
-                className="datapack-link-create"
+                className={`datapack-link-create`}
                 style={
                     {
                         display: 'grid',

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { withTheme, Theme } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
+import { Link } from 'react-router-dom';
+import { Button } from '@material-ui/core';
 
 export interface Props {
     theme: Eventkit.Theme & Theme;
@@ -26,15 +27,21 @@ export class DataPackLinkButton extends React.Component<Props, {}> {
         };
 
         return (
-            <Button
-                className="qa-DataPackLinkButton-Button"
-                color="primary"
-                variant="contained"
+            <Link
+                to="/create"
                 href="/create"
-                style={styles.button}
             >
-                Create DataPack
-            </Button>
+                <Button
+                    className={`qa-Drawer-Link-create`}
+                    // activeClassName={classes.activeLink}
+                    style={styles.button}
+                    variant="contained"
+                    color="primary"
+                >
+                    {/*<ContentAddBox className={classes.icon} />*/}
+                    Create DataPack
+                </Button>
+            </Link>
         );
     }
 }

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
@@ -28,11 +28,18 @@ export class DataPackLinkButton extends React.Component<Props, {}> {
 
         return (
             <Link
+                className="datapack-link-create"
+                style={
+                    {
+                        display: 'grid',
+                        textDecoration: 'none'
+                    }
+                }
                 to="/create"
                 href="/create"
             >
                 <Button
-                    className={`qa-Drawer-Link-create`}
+                    className={`datapack-button-create`}
                     // activeClassName={classes.activeLink}
                     style={styles.button}
                     variant="contained"

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
@@ -1135,7 +1135,7 @@ const makeMapStateToProps = () => {
         }
     );
     return mapStateToProps;
-}
+};
 
 function mapDispatchToProps(dispatch) {
     return {

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
@@ -1148,4 +1148,5 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
+// connect signature -> (mapStateToProps?, mapDispatchToProps?, mergeProps?, options?)
 export default withWidth()(withTheme()(connect(makeMapStateToProps, mapDispatchToProps, null, { forwardRef: true })(MapView)));

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
@@ -355,6 +355,15 @@ export class MapView extends React.Component<Props, State> {
             } else if (this.state.mode === MODE_DRAW_BBOX) {
                 const geojsonGeometry: GeoJSON.GeometryObject = createGeoJSONGeometry(geom);
                 this.props.onMapFilter(geojsonGeometry);
+                this.props.updateAoiInfo({
+                    ...this.props.aoiInfo,
+                        geojson,
+                        originalGeojson: geojson,
+                        geomType: 'Polygon',
+                        title: 'Custom Polygon',
+                        description: 'Draw',
+                        selectionType: 'free',
+                });
             }
             this.updateMode(MODE_NORMAL);
             window.setTimeout(() => {
@@ -1119,7 +1128,7 @@ export class MapView extends React.Component<Props, State> {
 
 const makeMapStateToProps = () => {
     const getRuns = makeAllRunsSelector();
-    const mapStateToProps = (state) => (
+    const mapStateToProps = (state, props) => (
         {
             aoiInfo: state.aoiInfo,
             runs: getRuns(state),

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
@@ -52,6 +52,7 @@ import { generateDrawLayer, generateDrawBoxInteraction, generateDrawFreeInteract
 import ZoomLevelLabel from '../MapTools/ZoomLevelLabel';
 import globe from '../../../images/globe-americas.svg';
 import { makeAllRunsSelector } from '../../selectors/runSelector';
+import {updateAoiInfo, clearAoiInfo, clearExportInfo} from '../../actions/datacartActions';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 
 export const RED_STYLE = new Style({
@@ -101,6 +102,9 @@ export interface Props {
     onMapFilter: (geojson: GeoJSON.FeatureCollection | GeoJSON.GeometryObject) => void;
     theme: Eventkit.Theme & Theme;
     width: Breakpoint;
+    aoiInfo: Eventkit.Store.AoiInfo;
+    updateAoiInfo: (args: any) => void;
+    clearAoiInfo: () => void;
 }
 
 export interface State {
@@ -336,6 +340,15 @@ export class MapView extends React.Component<Props, State> {
                 if (isGeoJSONValid(geojson)) {
                     const geojsonGeometry = createGeoJSONGeometry(geom);
                     this.props.onMapFilter(geojsonGeometry);
+                    this.props.updateAoiInfo({
+                        ...this.props.aoiInfo,
+                            geojson,
+                            originalGeojson: geojson,
+                            geomType: 'Polygon',
+                            title: 'Custom Polygon',
+                            description: 'Draw',
+                            selectionType: 'free',
+                    });
                 } else {
                     this.showInvalidDrawWarning(true);
                 }
@@ -1106,12 +1119,24 @@ export class MapView extends React.Component<Props, State> {
 
 const makeMapStateToProps = () => {
     const getRuns = makeAllRunsSelector();
-    const mapStateToProps = (state, props) => (
+    const mapStateToProps = (state) => (
         {
+            aoiInfo: state.aoiInfo,
             runs: getRuns(state),
         }
     );
     return mapStateToProps;
-};
+}
 
-export default withWidth()(withTheme()(connect(makeMapStateToProps, null, null, { forwardRef: true })(MapView)));
+function mapDispatchToProps(dispatch) {
+    return {
+        updateAoiInfo: (aoiInfo) => {
+            dispatch(updateAoiInfo(aoiInfo));
+        },
+        clearAoiInfo: () => {
+            dispatch(clearAoiInfo());
+        }
+    };
+}
+
+export default withWidth()(withTheme()(connect(makeMapStateToProps, mapDispatchToProps, null, { forwardRef: true })(MapView)));

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportAOI.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportAOI.spec.tsx
@@ -395,7 +395,8 @@ describe('ExportAOI component', () => {
         expect(readSpy.calledOnce).toBe(true);
         expect(transformSpy.called).toBe(true);
         expect(addSpy.calledOnce).toBe(true);
-        expect(props.updateAoiInfo.calledOnce).toBe(true);
+        
+        
         expect(zoomSpy.calledOnce).toBe(true);
         expect(props.setNextEnabled.calledOnce).toBe(true);
         clearSpy.restore();

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackLinkButton.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackLinkButton.spec.tsx
@@ -19,7 +19,6 @@ beforeEach(setup);
 
 describe('DataPackLinkButton component', () => {
     it('should render a linked button', () => {
-        // const wrapper = shallow(<DataPackLinkButton {...(global as any).eventkit_test_props} />);
         expect(wrapper.find(Link)).toHaveLength(1);
         expect(wrapper.find(Link).props().to).toEqual(`/create`);
         expect(wrapper.find(Button).html()).toContain('Create DataPack');

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackLinkButton.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackLinkButton.spec.tsx
@@ -1,13 +1,28 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
+import { Link } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import { DataPackLinkButton } from '../../components/DataPackPage/DataPackLinkButton';
 
+const getProps = () => ({
+    ...(global as any).eventkit_test_props
+});
+
+let props;
+let wrapper;
+const setup = () => {
+    props = { ...getProps() };
+    wrapper = shallow(<DataPackLinkButton {...props} />);
+};
+
+beforeEach(setup);
+
 describe('DataPackLinkButton component', () => {
     it('should render a linked button', () => {
-        const wrapper = shallow(<DataPackLinkButton {...(global as any).eventkit_test_props} />);
-        expect(wrapper.find(Button)).toHaveLength(1);
-        expect(wrapper.find(Button).props().href).toEqual('/create');
+        // const wrapper = shallow(<DataPackLinkButton {...(global as any).eventkit_test_props} />);
+        expect(wrapper.find(Link)).toHaveLength(1);
+        expect(wrapper.find(Link).props().to).toEqual(`/create`);
         expect(wrapper.find(Button).html()).toContain('Create DataPack');
+        expect(wrapper.find(Button)).toHaveLength(1);
     });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.tsx
@@ -174,6 +174,26 @@ function getRuns() {
     }];
 }
 
+const geojson = {
+    type: 'FeatureCollection',
+    features: [{
+        type: 'Feature',
+        geometry: {
+            type: 'Polygon',
+            coordinates: [
+                [
+                    [100.0, 0.0],
+                    [101.0, 0.0],
+                    [101.0, 1.0],
+                    [100.0, 1.0],
+                    [100.0, 0.0],
+                ],
+            ],
+        },
+        bbox: [100.0, 0.0, 101.0, 1.0],
+    }],
+};
+
 describe('MapView component', () => {
     const getProps = () => ({
         runs: getRuns(),
@@ -195,6 +215,16 @@ describe('MapView component', () => {
         resetGeoJSONFile: sinon.spy(),
         onMapFilter: sinon.spy(),
         providers,
+        aoiInfo: {
+            geojson: {},
+            originalGeojson: {},
+            geomType: null,
+            title: null,
+            description: null,
+            selectionType: null,
+        },
+        updateAoiInfo: sinon.spy(),
+        clearAoiInfo: sinon.spy(),
         ...(global as any).eventkit_test_props,
     });
 

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.tsx
@@ -16,6 +16,7 @@ import Polygon from 'ol/geom/polygon';
 import VectorSource from 'ol/source/vector';
 import Style from 'ol/style/style';
 import GeoJSON from 'ol/format/geojson';
+import GeoJSONFormat from 'ol/format/geojson';
 
 import DataPackListItem from '../../components/DataPackPage/DataPackListItem';
 import LoadButtons from '../../components/common/LoadButtons';
@@ -227,7 +228,7 @@ describe('MapView component', () => {
         clearAoiInfo: sinon.spy(),
         ...(global as any).eventkit_test_props,
     });
-
+    
     let props;
     let wrapper;
     let instance;
@@ -1303,8 +1304,9 @@ describe('MapView component', () => {
         expect(createSpy.calledOnce).toBe(true);
         expect(createSpy.calledWith(geom)).toBe(true);
         expect(addSpy.calledOnce).toBe(true);
-        expect(validSpy.calledOnce).toBe(true);
         expect(validSpy.calledWith(utils.createGeoJSON(geom))).toBe(true);
+        expect(validSpy.calledOnce).toBe(true);
+        expect(props.updateAoiInfo.calledOnce).toBe(true);
         expect(createGeomSpy.calledOnce).toBe(true);
         expect(createGeomSpy.calledWith(geom)).toBe(true);
         expect(props.onMapFilter.calledOnce).toBe(true);


### PR DESCRIPTION
When User is viewing the datapack library view the map view, 
Then User can filter by area using a geospatial filter (such as a bounding box).

When User doesn't see anything in their AOI (area of interest), 
Then User’s next action is to click ‘Create Datapack’. 

When User clicks that box, 
Then the selected area was copied to the create workflow
So that User doesn't have to repeat that action. 
