### PR TITLE
Cleanup tasks imports

### DIFF
--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -24,7 +24,7 @@ from eventkit_cloud.api.views import get_models, get_provider_task, ExportRunVie
 from eventkit_cloud.core.models import GroupPermission, GroupPermissionLevel
 from eventkit_cloud.jobs.models import ExportFormat, Job, DataProvider, \
     DataProviderType, DataProviderTask, bbox_to_geojson, DatamodelPreset, License, VisibilityState, UserJobActivity
-from eventkit_cloud.tasks import TaskStates
+from eventkit_cloud.tasks.export_tasks import TaskStates
 from eventkit_cloud.tasks.models import ExportRun, ExportTaskRecord, DataProviderTaskRecord, FileProducingTaskResult
 from eventkit_cloud.tasks.task_factory import InvalidLicense
 

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -24,7 +24,7 @@ from eventkit_cloud.api.views import get_models, get_provider_task, ExportRunVie
 from eventkit_cloud.core.models import GroupPermission, GroupPermissionLevel
 from eventkit_cloud.jobs.models import ExportFormat, Job, DataProvider, \
     DataProviderType, DataProviderTask, bbox_to_geojson, DatamodelPreset, License, VisibilityState, UserJobActivity
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.models import ExportRun, ExportTaskRecord, DataProviderTaskRecord, FileProducingTaskResult
 from eventkit_cloud.tasks.task_factory import InvalidLicense
 

--- a/eventkit_cloud/jobs/tests/integration_test_jobs.py
+++ b/eventkit_cloud/jobs/tests/integration_test_jobs.py
@@ -13,7 +13,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from eventkit_cloud.jobs.models import DataProvider, DataProviderType, Job
-from eventkit_cloud.tasks import TaskStates
+from eventkit_cloud.tasks.export_tasks import TaskStates
 from eventkit_cloud.tasks.models import DataProviderTaskRecord
 from eventkit_cloud.utils.geopackage import check_content_exists, check_zoom_levels
 

--- a/eventkit_cloud/jobs/tests/integration_test_jobs.py
+++ b/eventkit_cloud/jobs/tests/integration_test_jobs.py
@@ -13,7 +13,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from eventkit_cloud.jobs.models import DataProvider, DataProviderType, Job
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.models import DataProviderTaskRecord
 from eventkit_cloud.utils.geopackage import check_content_exists, check_zoom_levels
 

--- a/eventkit_cloud/tasks/__init__.py
+++ b/eventkit_cloud/tasks/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from django.core.cache import cache
 from django.apps import apps as django_apps
 

--- a/eventkit_cloud/tasks/__init__.py
+++ b/eventkit_cloud/tasks/__init__.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
-from eventkit_cloud.tasks.debug_tasks import *  # NOQA
-from eventkit_cloud.tasks.export_tasks import *  # NOQA
-from eventkit_cloud.tasks.scheduled_tasks import *  # NOQA
 from django.core.cache import cache
 from django.apps import apps as django_apps
 

--- a/eventkit_cloud/tasks/apps.py
+++ b/eventkit_cloud/tasks/apps.py
@@ -1,12 +1,12 @@
 from django.apps import AppConfig
 
-
 class EventKitTasks(AppConfig):
     name = "eventkit_cloud.tasks"
     verbose_name = "Eventkit-Cloud Tasks"
 
-    def ready(self):
-        from eventkit_cloud.tasks.signals import (  # NOQA
-            exportrun_delete_exports,
-            exporttaskresult_delete_exports,
-        )
+    # def ready(self):
+    #     from eventkit_cloud.tasks.signals import (  # NOQA
+    #         exportrun_delete_exports,
+    #         exporttaskresult_delete_exports,
+    #     )
+

--- a/eventkit_cloud/tasks/apps.py
+++ b/eventkit_cloud/tasks/apps.py
@@ -4,9 +4,8 @@ class EventKitTasks(AppConfig):
     name = "eventkit_cloud.tasks"
     verbose_name = "Eventkit-Cloud Tasks"
 
-    # def ready(self):
-    #     from eventkit_cloud.tasks.signals import (  # NOQA
-    #         exportrun_delete_exports,
-    #         exporttaskresult_delete_exports,
-    #     )
-
+    def ready(self):
+        from eventkit_cloud.tasks.signals import (  # NOQA
+            exportrun_delete_exports,
+            exporttaskresult_delete_exports,
+        )

--- a/eventkit_cloud/tasks/apps.py
+++ b/eventkit_cloud/tasks/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 
+
 class EventKitTasks(AppConfig):
     name = "eventkit_cloud.tasks"
     verbose_name = "Eventkit-Cloud Tasks"

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -165,7 +165,7 @@ class LockingTask(UserDetailsBase):
 
 
 def make_file_downloadable(
-        filepath, run_uid, provider_slug=None, skip_copy=False, download_filename=None, size=None, direct=False,
+    filepath, run_uid, provider_slug=None, skip_copy=False, download_filename=None, size=None, direct=False,
 ):
     """ Construct the filesystem location and url needed to download the file at filepath.
         Copy filepath to the filesystem location required for download.
@@ -186,7 +186,7 @@ def make_file_downloadable(
         download_filename = filename
 
     if getattr(settings, "USE_S3", False):
-        download_url = s3.upload_to_s3(run_uid, os.path.join(staging_dir, filename), download_filename, )
+        download_url = s3.upload_to_s3(run_uid, os.path.join(staging_dir, filename), download_filename,)
     else:
         make_dirs(run_download_dir)
 
@@ -397,16 +397,16 @@ class FormatTask(ExportTask):
 
 @gdalutils.retry
 def osm_data_collection_pipeline(
-        export_task_record_uid,
-        stage_dir,
-        job_name="no_job_name_specified",
-        url=None,
-        slug=None,
-        bbox=None,
-        user_details=None,
-        config=None,
-        eta=None,
-        projection=4326,
+    export_task_record_uid,
+    stage_dir,
+    job_name="no_job_name_specified",
+    url=None,
+    slug=None,
+    bbox=None,
+    user_details=None,
+    config=None,
+    eta=None,
+    projection=4326,
 ):
     """
     Collects data from OSM & produces a thematic gpkg as a subtask of the task referenced by export_provider_task_id.
@@ -484,19 +484,19 @@ def osm_data_collection_pipeline(
 
 @app.task(name="OSM (.gpkg)", bind=True, base=FormatTask, abort_on_error=True, acks_late=True)
 def osm_data_collection_task(
-        self,
-        result=None,
-        stage_dir=None,
-        run_uid=None,
-        provider_slug=None,
-        overpass_url=None,
-        task_uid=None,
-        job_name="no_job_name_specified",
-        bbox=None,
-        user_details=None,
-        config=None,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    stage_dir=None,
+    run_uid=None,
+    provider_slug=None,
+    overpass_url=None,
+    task_uid=None,
+    job_name="no_job_name_specified",
+    bbox=None,
+    user_details=None,
+    config=None,
+    *args,
+    **kwargs,
 ):
     """
     Collects data from OSM & produces a thematic gpkg as a subtask of the task referenced by export_provider_task_id.
@@ -549,7 +549,7 @@ def osm_data_collection_task(
 
 @app.task(name="Add Metadata", bind=True, base=UserDetailsBase, abort_on_error=False)
 def add_metadata_task(
-        self, result=None, job_uid=None, provider_slug=None, user_details=None, *args, **kwargs,
+    self, result=None, job_uid=None, provider_slug=None, user_details=None, *args, **kwargs,
 ):
     """
     Task to create metadata to a geopackage.
@@ -588,16 +588,16 @@ def add_metadata_task(
 
 @app.task(name="ESRI Shapefile (.shp)", bind=True, base=FormatTask)
 def shp_export_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining SHP export function.
@@ -625,16 +625,16 @@ def shp_export_task(
 
 @app.task(name="Keyhole Markup Language (.kml)", bind=True, base=FormatTask)
 def kml_export_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining KML export function.
@@ -658,16 +658,16 @@ def kml_export_task(
 
 @app.task(name="SQLITE Format", bind=True, base=FormatTask)
 def sqlite_export_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining SQLITE export function.
@@ -690,15 +690,15 @@ def sqlite_export_task(
 
 @app.task(name="Area of Interest (.geojson)", bind=True, base=ExportTask)
 def output_selection_geojson_task(
-        self,
-        result=None,
-        task_uid=None,
-        selection=None,
-        stage_dir=None,
-        provider_slug=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    task_uid=None,
+    selection=None,
+    stage_dir=None,
+    provider_slug=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining geopackage export function.
@@ -723,16 +723,16 @@ def output_selection_geojson_task(
 
 @app.task(name="Geopackage (.gpkg)", bind=True, base=FormatTask)
 def geopackage_export_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining geopackage export function.
@@ -742,8 +742,7 @@ def geopackage_export_task(
     gpkg_in_dataset = parse_result(result, "source")
     gpkg_out_dataset = os.path.join(stage_dir, "{0}-{1}.gpkg".format(job_name, projection))
 
-    gpkg = gdalutils.convert(file_format="gpkg", in_file=gpkg_in_dataset, out_file=gpkg_out_dataset,
-                             task_uid=task_uid, )
+    gpkg = gdalutils.convert(file_format="gpkg", in_file=gpkg_in_dataset, out_file=gpkg_out_dataset, task_uid=task_uid,)
 
     result["file_format"] = "gpkg"
     result["result"] = gpkg
@@ -753,8 +752,7 @@ def geopackage_export_task(
 
 @app.task(name="Geotiff (.tif)", bind=True, base=FormatTask)
 def geotiff_export_task(
-        self, result=None, task_uid=None, stage_dir=None, job_name=None, projection=4326, compress=False, *args,
-        **kwargs
+    self, result=None, task_uid=None, stage_dir=None, job_name=None, projection=4326, compress=False, *args, **kwargs
 ):
     """
     Class defining geopackage export function.
@@ -807,16 +805,16 @@ def geotiff_export_task(
 
 @app.task(name="National Imagery Transmission Format (.nitf)", bind=True, base=FormatTask)
 def nitf_export_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining nitf export function.
@@ -839,16 +837,16 @@ def nitf_export_task(
 
 @app.task(name="Erdas Imagine HFA (.img)", bind=True, base=FormatTask)
 def hfa_export_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining Erdas Imagine HFA (.img) export function.
@@ -857,7 +855,7 @@ def hfa_export_task(
 
     hfa_in_dataset = parse_result(result, "source")
     hfa_out_dataset = os.path.join(stage_dir, "{0}-{1}.img".format(job_name, projection))
-    hfa = gdalutils.convert(file_format="hfa", in_file=hfa_in_dataset, out_file=hfa_out_dataset, task_uid=task_uid, )
+    hfa = gdalutils.convert(file_format="hfa", in_file=hfa_in_dataset, out_file=hfa_out_dataset, task_uid=task_uid,)
 
     result["file_format"] = "hfa"
     result["result"] = hfa
@@ -867,17 +865,17 @@ def hfa_export_task(
 
 @app.task(name="Reprojection Task", bind=True, base=FormatTask)
 def reprojection_task(
-        self,
-        result=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        user_details=None,
-        projection=None,
-        compress=False,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    user_details=None,
+    projection=None,
+    compress=False,
+    *args,
+    **kwargs,
 ):
     """
     Class defining a task that will reproject all file formats to the chosen projections.
@@ -922,8 +920,7 @@ def reprojection_task(
 
 @app.task(name="Clip Export", bind=True, base=UserDetailsBase)
 def clip_export_task(
-        self, result=None, run_uid=None, task_uid=None, stage_dir=None, job_name=None, user_details=None, *args,
-        **kwargs,
+    self, result=None, run_uid=None, task_uid=None, stage_dir=None, job_name=None, user_details=None, *args, **kwargs,
 ):
     """
     Clips a dataset to a vector cutline and returns a dataset of the same format.
@@ -950,22 +947,22 @@ def clip_export_task(
 
 @app.task(name="WFSExport", bind=True, base=ExportTask, abort_on_error=True)
 def wfs_export_task(
-        self,
-        result=None,
-        layer=None,
-        config=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        bbox=None,
-        service_url=None,
-        name=None,
-        service_type=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    layer=None,
+    config=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    bbox=None,
+    service_url=None,
+    name=None,
+    service_type=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining geopackage export for WFS service.
@@ -975,7 +972,7 @@ def wfs_export_task(
     gpkg = os.path.join(stage_dir, "{0}-{1}.gpkg".format(job_name, projection))
 
     # Strip out query string parameters that might conflict
-    service_url = re.sub(r"(?i)(?<=[?&])(version|service|request|typename|srsname)=.*?(&|$)", "", service_url, )
+    service_url = re.sub(r"(?i)(?<=[?&])(version|service|request|typename|srsname)=.*?(&|$)", "", service_url,)
     query_str = "SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME={}&SRSNAME=EPSG:4326".format(layer)
     if "?" in service_url:
         if "&" != service_url[-1]:
@@ -998,7 +995,7 @@ def wfs_export_task(
 
     try:
         ogr = OGR(task_uid=task_uid)
-        out = ogr.convert(file_format="GPKG", in_file='WFS:"{}"'.format(url), out_file=gpkg, params=params, )
+        out = ogr.convert(file_format="GPKG", in_file='WFS:"{}"'.format(url), out_file=gpkg, params=params,)
         result["result"] = out
         result["source"] = out
         # Check for geopackage contents; gdal wfs driver fails silently
@@ -1012,22 +1009,22 @@ def wfs_export_task(
 
 @app.task(name="WCS Export", bind=True, base=ExportTask, abort_on_error=True, acks_late=True)
 def wcs_export_task(
-        self,
-        result=None,
-        layer=None,
-        config=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        bbox=None,
-        service_url=None,
-        name=None,
-        service_type=None,
-        user_details=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    layer=None,
+    config=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    bbox=None,
+    service_url=None,
+    name=None,
+    service_type=None,
+    user_details=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining export for WCS services
@@ -1066,16 +1063,16 @@ def wcs_export_task(
 
 @app.task(name="ArcFeatureServiceExport", bind=True, base=FormatTask)
 def arcgis_feature_service_export_task(
-        self,
-        result=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        bbox=None,
-        service_url=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    bbox=None,
+    service_url=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining sqlite export for ArcFeatureService service.
@@ -1114,8 +1111,7 @@ def arcgis_feature_service_export_task(
 
 @app.task(name="Area of Interest (.gpkg)", bind=True, base=ExportTask)
 def bounds_export_task(
-        self, result={}, run_uid=None, task_uid=None, stage_dir=None, provider_slug=None, projection=4326, *args,
-        **kwargs,
+    self, result={}, run_uid=None, task_uid=None, stage_dir=None, provider_slug=None, projection=4326, *args, **kwargs,
 ):
     """
     Class defining geopackage export function.
@@ -1144,23 +1140,23 @@ def bounds_export_task(
     name="Raster export (.gpkg)", bind=True, base=FormatTask, abort_on_error=True, acks_late=True,
 )
 def mapproxy_export_task(
-        self,
-        result=None,
-        layer=None,
-        config=None,
-        run_uid=None,
-        task_uid=None,
-        stage_dir=None,
-        job_name=None,
-        bbox=None,
-        service_url=None,
-        level_from=None,
-        level_to=None,
-        name=None,
-        service_type=None,
-        projection=4326,
-        *args,
-        **kwargs,
+    self,
+    result=None,
+    layer=None,
+    config=None,
+    run_uid=None,
+    task_uid=None,
+    stage_dir=None,
+    job_name=None,
+    bbox=None,
+    service_url=None,
+    level_from=None,
+    level_to=None,
+    name=None,
+    service_type=None,
+    projection=4326,
+    *args,
+    **kwargs,
 ):
     """
     Class defining geopackage export for external raster service.
@@ -1229,8 +1225,8 @@ def pick_up_run_task(self, result=None, run_uid=None, user_details=None, *args, 
 def wait_for_run(run=None, uid=None):
     if run.status:
         while (
-                TaskStates[run.status] not in TaskStates.get_finished_states()
-                and TaskStates[run.status] not in TaskStates.get_incomplete_states()
+            TaskStates[run.status] not in TaskStates.get_finished_states()
+            and TaskStates[run.status] not in TaskStates.get_incomplete_states()
         ):
             time.sleep(10)
             run.refresh_from_db()
@@ -1248,7 +1244,7 @@ def wait_for_providers_task(result=None, apply_args=None, run_uid=None, callback
     if run:
         provider_tasks = run.provider_tasks.filter(~Q(slug="run"))
         if all(
-                TaskStates[provider_task.status] in TaskStates.get_finished_states() for provider_task in provider_tasks
+            TaskStates[provider_task.status] in TaskStates.get_finished_states() for provider_task in provider_tasks
         ):
             callback_task.apply_async(**apply_args)
         else:
@@ -1620,7 +1616,7 @@ def cancel_synchronous_task_chain(data_provider_task_uid=None):
 
 @app.task(name="Create preview", base=UserDetailsBase)
 def create_datapack_preview(
-        result=None, run_uid=None, task_uid=None, stage_dir=None, task_record_uid=None, *args, **kwargs,
+    result=None, run_uid=None, task_uid=None, stage_dir=None, task_record_uid=None, *args, **kwargs,
 ):
     """
     Attempts to add a MapImageSnapshot (Preview Image) to a provider task.
@@ -1661,7 +1657,7 @@ def create_datapack_preview(
 
 @app.task(name="Cancel Export Provider Task", base=UserDetailsBase)
 def cancel_export_provider_task(
-        result=None, data_provider_task_uid=None, canceling_username=None, delete=False, error=False, *args, **kwargs,
+    result=None, data_provider_task_uid=None, canceling_username=None, delete=False, error=False, *args, **kwargs,
 ):
     """
     Cancels an DataProviderTaskRecord and terminates each subtasks execution.
@@ -1727,7 +1723,7 @@ def cancel_export_provider_task(
 
 @app.task(name="Cancel Run", base=UserDetailsBase)
 def cancel_run(
-        result=None, export_run_uid=None, canceling_username=None, delete=False, *args, **kwargs,
+    result=None, export_run_uid=None, canceling_username=None, delete=False, *args, **kwargs,
 ):
     result = result or {}
 
@@ -1774,7 +1770,7 @@ def kill_task(result=None, task_pid=None, celery_uid=None, *args, **kwargs):
 
 
 def update_progress(
-        task_uid, progress=None, subtask_percentage=100.0, subtask_start=0, estimated_finish=None, eta=None, msg=None,
+    task_uid, progress=None, subtask_percentage=100.0, subtask_start=0, estimated_finish=None, eta=None, msg=None,
 ):
     """
     Updates the progress of the ExportTaskRecord from the given task_uid.

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -22,6 +22,11 @@ from eventkit_cloud.utils import auth_requests
 from eventkit_cloud.utils.gdalutils import get_band_statistics
 from eventkit_cloud.utils.generic import cd, get_file_paths  # NOQA
 
+from eventkit_cloud.jobs.models import DataProvider
+from eventkit_cloud.tasks.models import (
+    DataProviderTaskRecord,
+)
+
 logger = logging.getLogger()
 
 
@@ -144,7 +149,6 @@ def get_style_files():
 
 def create_license_file(provider_task):
     # checks a DataProviderTaskRecord's license file and adds it to the file list if it exists
-    from eventkit_cloud.jobs.models import DataProvider
     from eventkit_cloud.tasks.helpers import normalize_name
 
     data_provider_license = DataProvider.objects.get(slug=provider_task.slug).license
@@ -348,9 +352,8 @@ def get_metadata(data_provider_task_uid):
     }
     """
 
-    from eventkit_cloud.jobs.models import DataProvider
-    from eventkit_cloud.tasks.models import DataProviderTaskRecord
-    from eventkit_cloud.tasks.enumerations import TaskStates, create_zip_task
+    from eventkit_cloud.tasks.enumerations import TaskStates
+    from eventkit_cloud.tasks.export_tasks import create_zip_task
 
     data_provider_task = DataProviderTaskRecord.objects.get(uid=data_provider_task_uid)
 
@@ -385,11 +388,9 @@ def get_metadata(data_provider_task_uid):
         "has_raster": False,
         "has_elevation": False,
     }
-
     for provider_task in provider_tasks:
         if TaskStates[provider_task.status] in TaskStates.get_incomplete_states():
             continue
-
         data_provider = DataProvider.objects.get(slug=provider_task.slug)
         provider_type = data_provider.export_provider_type.type_name
         if TaskStates[provider_task.status] not in TaskStates.get_incomplete_states():
@@ -489,8 +490,6 @@ def get_arcgis_metadata(metadata):
 
 
 def get_data_type_from_provider(provider_slug: str) -> str:
-    from eventkit_cloud.jobs.models import DataProvider
-
     data_types = {
         "wms": "raster",
         "tms": "raster",

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -350,7 +350,7 @@ def get_metadata(data_provider_task_uid):
 
     from eventkit_cloud.jobs.models import DataProvider
     from eventkit_cloud.tasks.models import DataProviderTaskRecord
-    from eventkit_cloud.tasks.export_tasks import TaskStates, create_zip_task
+    from eventkit_cloud.tasks.enumerations import TaskStates, create_zip_task
 
     data_provider_task = DataProviderTaskRecord.objects.get(uid=data_provider_task_uid)
 

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -23,9 +23,7 @@ from eventkit_cloud.utils.gdalutils import get_band_statistics
 from eventkit_cloud.utils.generic import cd, get_file_paths  # NOQA
 
 from eventkit_cloud.jobs.models import DataProvider
-from eventkit_cloud.tasks.models import (
-    DataProviderTaskRecord,
-)
+from eventkit_cloud.tasks.models import DataProviderTaskRecord
 
 logger = logging.getLogger()
 

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -7,7 +7,7 @@ from celery import chain  # required for tests
 from django.db import DatabaseError
 
 from eventkit_cloud.jobs.models import DataProviderTask, ExportFormat
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.export_tasks import reprojection_task, create_datapack_preview
 from eventkit_cloud.tasks.helpers import normalize_name, get_metadata
 from eventkit_cloud.tasks.models import ExportTaskRecord, DataProviderTaskRecord

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -7,7 +7,7 @@ from celery import chain  # required for tests
 from django.db import DatabaseError
 
 from eventkit_cloud.jobs.models import DataProviderTask, ExportFormat
-from eventkit_cloud.tasks import TaskStates
+from eventkit_cloud.tasks.export_tasks import TaskStates
 from eventkit_cloud.tasks.export_tasks import reprojection_task, create_datapack_preview
 from eventkit_cloud.tasks.helpers import normalize_name, get_metadata
 from eventkit_cloud.tasks.models import ExportTaskRecord, DataProviderTaskRecord

--- a/eventkit_cloud/tasks/task_factory.py
+++ b/eventkit_cloud/tasks/task_factory.py
@@ -30,7 +30,7 @@ from eventkit_cloud.tasks.export_tasks import (
     wcs_export_task,
     arcgis_feature_service_export_task,
 )
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.helpers import (
     get_run_staging_dir,
     get_provider_staging_dir,

--- a/eventkit_cloud/tasks/task_factory.py
+++ b/eventkit_cloud/tasks/task_factory.py
@@ -30,7 +30,7 @@ from eventkit_cloud.tasks.export_tasks import (
     wcs_export_task,
     arcgis_feature_service_export_task,
 )
-from eventkit_cloud.tasks import TaskStates
+from eventkit_cloud.tasks.export_tasks import TaskStates
 from eventkit_cloud.tasks.helpers import (
     get_run_staging_dir,
     get_provider_staging_dir,

--- a/eventkit_cloud/tasks/task_process.py
+++ b/eventkit_cloud/tasks/task_process.py
@@ -20,7 +20,7 @@ class TaskProcess(object):
 
     def start_process(self, command=None, billiard=False, *args, **kwargs):
         from eventkit_cloud.tasks.models import ExportTaskRecord
-        from eventkit_cloud.tasks.export_tasks import TaskStates
+        from eventkit_cloud.tasks.enumerations import TaskStates
 
         if billiard:
             proc = Process(daemon=False, *args, **kwargs)

--- a/eventkit_cloud/tasks/task_process.py
+++ b/eventkit_cloud/tasks/task_process.py
@@ -20,7 +20,7 @@ class TaskProcess(object):
 
     def start_process(self, command=None, billiard=False, *args, **kwargs):
         from eventkit_cloud.tasks.models import ExportTaskRecord
-        from eventkit_cloud.tasks import TaskStates
+        from eventkit_cloud.tasks.export_tasks import TaskStates
 
         if billiard:
             proc = Process(daemon=False, *args, **kwargs)

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -24,7 +24,8 @@ from eventkit_cloud.tasks.export_tasks import (ExportTask,
     pick_up_run_task, cancel_export_provider_task, kill_task, bounds_export_task, parse_result, finalize_export_provider_task,
     FormatTask, wait_for_providers_task, create_zip_task, default_format_time, geotiff_export_task
 )
-from eventkit_cloud.tasks import TaskStates, zip_files
+from eventkit_cloud.tasks.enumerations import TaskStates
+from eventkit_cloud.tasks.export_tasks import zip_files
 from eventkit_cloud.tasks.models import (
     ExportRun,
     ExportTaskRecord,
@@ -462,7 +463,7 @@ class TestExportTasks(ExportTaskBase):
         rmtree.assert_called_once_with(stage_dir)
         email().send.assert_called_once()
 
-    @patch('eventkit_cloud.tasks.set_cache_value')
+    @patch('eventkit_cloud.tasks.export_tasks.set_cache_value')
     @patch('django.db.connection.close')
     @patch('eventkit_cloud.tasks.models.ExportTaskRecord')
     def test_update_progress(self, export_task, mock_close, mock_set_cache_value):

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -100,8 +100,8 @@ class TestHelpers(TestCase):
     @patch('eventkit_cloud.tasks.helpers.create_license_file')
     @patch('eventkit_cloud.tasks.helpers.get_metadata_url')
     @patch('eventkit_cloud.tasks.helpers.get_last_update')
-    @patch('eventkit_cloud.jobs.models.DataProvider')
-    @patch('eventkit_cloud.tasks.models.DataProviderTaskRecord')
+    @patch('eventkit_cloud.tasks.helpers.DataProvider')
+    @patch('eventkit_cloud.tasks.helpers.DataProviderTaskRecord')
     def test_get_metadata(self, mock_DataProviderTaskRecord, mock_DataProvider, mock_get_last_update,
                           mock_get_metadata_url, mock_create_license_file, mock_isfile):
         run_uid = '1234'

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -14,7 +14,7 @@ import signal
 from eventkit_cloud.tasks.helpers import get_style_files, get_file_paths, get_last_update, get_metadata_url, \
     get_osm_last_update, cd, get_arcgis_metadata, get_metadata, get_message_count, \
     get_all_rabbitmq_objects
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 
 from eventkit_cloud.tasks.helpers import progressive_kill
 from unittest import skip

--- a/eventkit_cloud/tasks/tests/test_models.py
+++ b/eventkit_cloud/tasks/tests/test_models.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 from mock import patch
 
 from eventkit_cloud.jobs.models import ExportFormat, Job, DataProviderTask, DataProvider
-from eventkit_cloud.tasks import TaskStates
+from eventkit_cloud.tasks.export_tasks import TaskStates
 from eventkit_cloud.tasks.models import ExportRun, ExportTaskRecord, FileProducingTaskResult, DataProviderTaskRecord
 
 logger = logging.getLogger(__name__)

--- a/eventkit_cloud/tasks/tests/test_models.py
+++ b/eventkit_cloud/tasks/tests/test_models.py
@@ -11,7 +11,7 @@ from django.test import TestCase
 from mock import patch
 
 from eventkit_cloud.jobs.models import ExportFormat, Job, DataProviderTask, DataProvider
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.models import ExportRun, ExportTaskRecord, FileProducingTaskResult, DataProviderTaskRecord
 
 logger = logging.getLogger(__name__)

--- a/eventkit_cloud/tasks/tests/test_styles.py
+++ b/eventkit_cloud/tasks/tests/test_styles.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.test import TestCase
 from mock import patch, MagicMock
 
-from eventkit_cloud.tasks import TaskStates
+from eventkit_cloud.tasks.export_tasks import TaskStates
 from eventkit_cloud.tasks.helpers import generate_qgs_style, get_metadata
 
 

--- a/eventkit_cloud/tasks/tests/test_styles.py
+++ b/eventkit_cloud/tasks/tests/test_styles.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.test import TestCase
 from mock import patch, MagicMock
 
-from eventkit_cloud.tasks.export_tasks import TaskStates
+from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.helpers import generate_qgs_style, get_metadata
 
 

--- a/eventkit_cloud/tasks/tests/test_task_builders.py
+++ b/eventkit_cloud/tasks/tests/test_task_builders.py
@@ -115,7 +115,7 @@ class TestTaskBuilder(TestCase):
 
     @patch('eventkit_cloud.tasks.task_builders.ExportTaskRecord')
     def test_create_export_task_record(self, mock_export_task):
-        from eventkit_cloud.tasks.export_tasks import TaskStates
+        from eventkit_cloud.tasks.enumerations import TaskStates
 
         task_name = "TaskName"
         export_provider_task_name = "ExportProviderTaskName"

--- a/eventkit_cloud/tasks/tests/test_task_builders.py
+++ b/eventkit_cloud/tasks/tests/test_task_builders.py
@@ -115,7 +115,7 @@ class TestTaskBuilder(TestCase):
 
     @patch('eventkit_cloud.tasks.task_builders.ExportTaskRecord')
     def test_create_export_task_record(self, mock_export_task):
-        from eventkit_cloud.tasks import TaskStates
+        from eventkit_cloud.tasks.export_tasks import TaskStates
 
         task_name = "TaskName"
         export_provider_task_name = "ExportProviderTaskName"


### PR DESCRIPTION
Rework imports, particular model imports, inside the export_tasks code to prevent AppsNotReady error when moving these imports to the top of the file. Reduces the usage of in function imports of these models inside celery tasks.