### PR TITLE
Modify the Jobs API to use the DataProvider slug instead of it's name.

### DIFF
--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -76,7 +76,7 @@ class ProviderTaskSerializer(serializers.ModelSerializer):
 
         """Creates an export DataProviderTask."""
         formats = validated_data.pop("formats")
-        provider_model = DataProvider.objects.get(name=validated_data.get("provider"))
+        provider_model = DataProvider.objects.get(slug=validated_data.get("provider"))
         provider_task = DataProviderTask.objects.create(provider=provider_model)
         provider_task.formats.add(*formats)
         provider_task.min_zoom = validated_data.pop("min_zoom", None)

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -147,7 +147,7 @@ class TestJobViewSet(APITestCase):
                 "name": "TestJob",
                 "url": 'http://testserver{0}'.format(url),
                 "description": "Test Description",
-                "exports": [{'provider': 'OpenStreetMap Data (Generic)',
+                "exports": [{'provider': 'osm-generic',
                              'formats': [
                                  {"uid": "8611792d-3d99-4c8f-a213-787bc7f3066",
                                   "url": "http://testserver/api/formats/gpkg",
@@ -220,7 +220,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}],
             'preset': self.job.preset.id,
             'published': True,
             'tags': self.tags,
@@ -249,7 +249,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}],
             'preset': self.job.preset.id,
             'published': True,
             'tags': self.tags,
@@ -315,7 +315,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}],
             'preset': self.job.preset.id,
             'transform': '',
             'translation': ''
@@ -355,7 +355,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}],
             'preset': self.job.preset.id,
             'transform': '',
             'translate': '',
@@ -390,7 +390,7 @@ class TestJobViewSet(APITestCase):
             'event': 'Test Activation',
             'selection':  {},
             'preset': self.job.preset.id,
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}]
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}]
         }
         response = self.client.post(url, request_data, format='json')
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -423,7 +423,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test event',
             'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}]
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}]
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -439,7 +439,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)'}]  # 'formats': formats}]# missing
+            'provider_tasks': [{'provider': 'osm-generic'}]  # 'formats': formats}]# missing
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
         self.assertEqual(response['Content-Type'], 'application/json')
@@ -453,7 +453,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': ''}]  # invalid
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': ''}]  # invalid
         }
         response = self.client.post(url, request_data, format='json')
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
@@ -469,7 +469,7 @@ class TestJobViewSet(APITestCase):
             'event': 'Test Activation',
             'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [
-                {'provider': 'OpenStreetMap Data (Generic)', 'formats': ['broken-format-one', 'broken-format-two']}]
+                {'provider': 'osm-generic', 'formats': ['broken-format-one', 'broken-format-two']}]
         }
         response = self.client.post(url, request_data, format='json')
 
@@ -487,7 +487,7 @@ class TestJobViewSet(APITestCase):
             'description': 'Test description',
             'event': 'Test Activation',
             'selection':  bbox_to_geojson([-180, -90, 180, 90]),
-            'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}]
+            'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}]
         }
 
         with self.settings(JOB_MAX_EXTENT=100000):
@@ -565,7 +565,7 @@ class TestBBoxSearch(APITestCase):
                 'description': 'Test description',
                 'event': 'Test Activation',
                 'selection': bbox_to_geojson(extent),
-                'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}]
+                'provider_tasks': [{'provider': 'osm-generic', 'formats': formats}]
             }
             response = self.client.post(url, request_data, format='json')
             expected_user_details = {'username': 'demo', 'is_superuser': True, 'is_staff': False}

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -250,7 +250,7 @@ class JobViewSet(viewsets.ModelViewSet):
                     "tags" : [],
                     "projections" : [4326],
                     "provider_tasks" : [{
-                            "provider" : "OpenStreetMap Data (Themes)",
+                            "provider" : "osm",
                             "formats" : ["shp", "gpkg"]
                         }
                     ]
@@ -267,7 +267,7 @@ class JobViewSet(viewsets.ModelViewSet):
                 {
                   "provider_tasks": [
                     {
-                      "provider": "OpenStreetMap Tiles",
+                      "provider": "osm",
                       "formats": [
                         "gpkg"
                       ]

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/BreadcrumbStepper.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/BreadcrumbStepper.tsx
@@ -585,7 +585,7 @@ export class BreadcrumbStepper extends React.Component<Props, State> {
 
             providerTasks.push({
                 formats,
-                provider: provider.name, max_zoom: maxZoom, min_zoom: minZoom,
+                provider: provider.slug, max_zoom: maxZoom, min_zoom: minZoom,
             });
         });
 

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/BreadcrumbStepper.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/BreadcrumbStepper.spec.tsx
@@ -23,7 +23,7 @@ const providers = [
         created_at: '2017-03-24T17:44:22.940611Z',
         updated_at: '2017-03-24T17:44:22.940629Z',
         uid: 'be401b02-63d3-4080-943a-0093c1b5a914',
-        name: 'OpenStreetMap Data (Themes)',
+        name: 'OpenStreetMap Data (Generic)',
         slug: 'osm-generic',
         preview_url: '',
         service_copyright: '',
@@ -328,7 +328,7 @@ describe('BreadcrumbStepper component', () => {
             event: 'test event',
             include_zipfile: false,
             provider_tasks: [{
-                provider: 'OpenStreetMap Data (Themes)',
+                provider: 'osm-generic',
                 formats: ['gpkg'],
                 min_zoom: 0, max_zoom: 10
             }],

--- a/eventkit_cloud/utils/client.py
+++ b/eventkit_cloud/utils/client.py
@@ -93,7 +93,7 @@ class EventKitClient(object):
         :param provider_tasks: A list of providers (data sources).
            Example:
               [{
-                "provider": "OpenStreetMap Data (Themes)",
+                "provider": "osm",
                 "formats": ["shp", "gpkg"]
               }]
         :return:


### PR DESCRIPTION
In order to test this PR, just try running any job with a DataProvider(s) chosen.