### PR TITLE
Update yaml.load to yaml.safe_load to remove deprecation warnings.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ import yaml
 
 data = {}
 with open('environment-dev.yml', 'r') as yaml_file:
-    data = yaml.load(yaml_file)
+    data = yaml.safe_load(yaml_file)
 data['channels'] = ['local', '$CONDA_REPO']
 
 with open('environment-dev.yml', 'w') as outfile:
@@ -144,7 +144,7 @@ def removeVolumes() {
 import yaml
 data = {}
 with open('docker-compose.yml', 'r') as yaml_file:
-    data = yaml.load(yaml_file)
+    data = yaml.safe_load(yaml_file)
 for service in data.get('services'):
     data['services'][service].pop('volumes', "")
 with open('docker-compose.yml', 'w') as outfile:

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -393,7 +393,7 @@ def get_metadata(data_provider_task_uid):
         provider_type = data_provider.export_provider_type.type_name
         if TaskStates[provider_task.status] not in TaskStates.get_incomplete_states():
             provider_staging_dir = get_provider_staging_dir(run.uid, provider_task.slug)
-            conf = yaml.load(data_provider.config) or dict()
+            conf = yaml.safe_load(data_provider.config) or dict()
             cert_var = conf.get("cert_var", data_provider.slug)
             metadata["data_sources"][provider_task.slug] = {
                 "uid": str(provider_task.uid),
@@ -553,7 +553,7 @@ def clean_config(config):
         "overpass_query",
     ]
 
-    conf = yaml.load(config) or dict()
+    conf = yaml.safe_load(config) or dict()
 
     for service_key in service_keys:
         conf.pop(service_key, None)

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -139,7 +139,7 @@ class MapproxyGeopackage(object):
         Create a MapProxy configuration object and verifies its validity
         """
         if self.config:
-            conf_dict = yaml.load(self.config) or dict()
+            conf_dict = yaml.safe_load(self.config) or dict()
         else:
             raise ConfigurationError("MapProxy configuration is required for raster data providers")
 
@@ -217,7 +217,7 @@ class MapproxyGeopackage(object):
 
         logger.error("Beginning seeding to {0}".format(self.gpkgfile))
         try:
-            conf = yaml.load(self.config) or dict()
+            conf = yaml.safe_load(self.config) or dict()
             cert_var = conf.get("cert_var")
             auth_requests.patch_https(slug=self.name, cert_var=cert_var)
 
@@ -386,7 +386,7 @@ def get_conf_dict(slug: str) -> dict:
 
         # Load and "clean" mapproxy config for displaying a map.
     try:
-        conf_dict = yaml.load(provider.config)
+        conf_dict = yaml.safe_load(provider.config)
         conf_dict.pop("caches", "")
         conf_dict.pop("layers", "")
         ssl_verify = getattr(settings, "SSL_VERIFICATION", True)

--- a/eventkit_cloud/utils/overpass.py
+++ b/eventkit_cloud/utils/overpass.py
@@ -62,7 +62,7 @@ class Overpass(object):
 
         # extract all nodes / ways and relations within the bounding box
         # see: http://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL
-        conf: dict = yaml.load(self.config) or dict()
+        conf: dict = yaml.safe_load(self.config) or dict()
         self.default_template = (
             "[maxsize:$maxsize][timeout:$timeout];relation($bbox);way($bbox);node($bbox);<;(._;>;);out body;"
         )
@@ -115,7 +115,7 @@ class Overpass(object):
                 eta=eta,
                 msg="Querying provider data",
             )
-            conf: dict = yaml.load(self.config) or dict()
+            conf: dict = yaml.safe_load(self.config) or dict()
             cert_var = conf.get("cert_var") or self.slug
             req = auth_requests.post(self.url, cert_var=cert_var, data=q, stream=True, verify=self.verify_ssl)
 

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -650,7 +650,7 @@ def perform_provider_check(provider: DataProvider, geojson):
         url = settings.OVERPASS_API_URL
 
     provider_checker = get_provider_checker(provider_type)
-    conf = yaml.load(provider.config) or dict()
+    conf = yaml.safe_load(provider.config) or dict()
     checker = provider_checker(
         service_url=url,
         layer=provider.layer,

--- a/eventkit_cloud/utils/tests/test_mapproxy.py
+++ b/eventkit_cloud/utils/tests/test_mapproxy.py
@@ -38,7 +38,7 @@ class TestGeopackage(TransactionTestCase):
                      patch_https):
         gpkgfile = '/var/lib/eventkit/test.gpkg'
         config = "layers:\r\n - name: default\r\n   title: imagery\r\n   sources: [default]\r\n\r\nsources:\r\n  default:\r\n    type: tile\r\n    grid: default\r\n    url: http://a.tile.openstreetmap.fr/hot/%(z)s/%(x)s/%(y)s.png\r\n\r\ngrids:\r\n  default:\r\n    srs: WGS84:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
-        json_config = real_yaml.load(config)
+        json_config = real_yaml.safe_load(config)
         mapproxy_config = load_default_config()
         bbox = [-2, -2, 2, 2]
         cache_template.return_value = {'sources': ['default'], 'cache': {'type': 'geopackage', 'filename': '/var/lib/eventkit/test.gpkg'}, 'grids': ['default']}

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -47,7 +47,7 @@ class WCSConverter(object):
         :param eta: ETA estimator
         :param task_uid:
         """
-        self.config = yaml.load(config) if config is not None else None
+        self.config = yaml.safe_load(config) if config is not None else None
         self.out = out
         self.bbox = bbox
         self.service_url = service_url

--- a/selenium/JenkinsFile.Selenium
+++ b/selenium/JenkinsFile.Selenium
@@ -37,7 +37,7 @@ def removeVolumes() {
 import yaml
 data = {}
 with open('docker-compose.yml', 'r') as yaml_file:
-    data = yaml.load(yaml_file)
+    data = yaml.safe_load(yaml_file)
 for service in data.get('services'):
     if data['services'][service].get('volumes'):
         data['services'][service].pop('volumes')


### PR DESCRIPTION
Using safe_load removes the risk of yaml.load and the deprecation warnings.  I've changed all places where we call yaml.load to yaml.safe_load instead.  We were already using yaml.safe_load in a few places before as well.