### PR TITLE
Pin React Swipeable Views Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-swipeable-views": "0.13.3",
+    "react-swipeable-views-core": "0.13.1",
+    "react-swipeable-views-utils": "0.13.4",
     "redux": "4.0.1",
     "redux-auth-wrapper": "2.1.0",
     "redux-thunk": "2.3.0",


### PR DESCRIPTION
Pin the versions of react-swipeable-views for now as newer versions have breaking issues.