### PR TITLE
Patch Expire Runs PR to r1.6.x

### DIFF
--- a/eventkit_cloud/core/helpers.py
+++ b/eventkit_cloud/core/helpers.py
@@ -122,6 +122,7 @@ class NotificationVerb(Enum):
     ADDED_TO_GROUP = "added_to_group"
     SET_AS_GROUP_ADMIN = "set_as_group_admin"
     REMOVED_AS_GROUP_ADMIN = "removed_as_group_admin"
+    RUN_EXPIRING = "run_expiring"
 
 
 def sendnotification(actor, recipient, verb, action_object, target, level, description):

--- a/eventkit_cloud/settings/celery.py
+++ b/eventkit_cloud/settings/celery.py
@@ -32,12 +32,12 @@ CELERY_ACCEPT_CONTENT = ["json"]
 # configure periodic task
 
 BEAT_SCHEDULE = {
-    "expire-runs": {"task": "Expire Runs", "schedule": crontab(minute="0", hour="0", day_of_week="*")},
+    "expire-runs": {"task": "Expire Runs", "schedule": crontab(minute="0", hour="0")},
     "provider-statuses": {
         "task": "Check Provider Availability",
         "schedule": crontab(minute="*/{}".format(os.getenv("PROVIDER_CHECK_INTERVAL", "30"))),
     },
-    "clean-up-queues": {"task": "Clean Up Queues", "schedule": crontab(minute="0", hour="0", day_of_week="*")},
+    "clean-up-queues": {"task": "Clean Up Queues", "schedule": crontab(minute="0", hour="0")},
 }
 
 PCF_SCALING = os.getenv("PCF_SCALING", False)

--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -11,7 +11,13 @@ from django.template.loader import get_template
 from django.utils import timezone
 
 from eventkit_cloud.celery import app
+from eventkit_cloud.core.helpers import (
+    sendnotification,
+    NotificationVerb,
+    NotificationLevel,
+)
 from eventkit_cloud.tasks.helpers import get_all_rabbitmq_objects
+
 
 logger = get_task_logger(__name__)
 
@@ -27,7 +33,7 @@ def expire_runs():
     from eventkit_cloud.tasks.models import ExportRun
 
     site_url = getattr(settings, "SITE_URL")
-    runs = ExportRun.objects.all()
+    runs = ExportRun.objects.filter(deleted=False)
 
     for run in runs:
         expiration = run.expiration
@@ -40,17 +46,35 @@ def expire_runs():
         now = timezone.now()
         # if expired delete the run:
         if expiration <= now:
-            run.delete()
+            run.soft_delete()
 
         # if two days left and most recent notification was at the 7 day mark email user
         elif expiration - now <= timezone.timedelta(days=2):
             if not notified or (notified and notified < expiration - timezone.timedelta(days=2)):
+                sendnotification(
+                    run,
+                    run.job.user,
+                    NotificationVerb.RUN_EXPIRING.value,
+                    None,
+                    None,
+                    NotificationLevel.WARNING.value,
+                    run.status,
+                )
                 send_warning_email(date=expiration, url=url, addr=email, job_name=run.job.name)
                 run.notified = now
                 run.save()
 
         # if one week left and no notification yet email the user
         elif expiration - now <= timezone.timedelta(days=7) and not notified:
+            sendnotification(
+                run,
+                run.job.user,
+                NotificationVerb.RUN_EXPIRING.value,
+                None,
+                None,
+                NotificationLevel.WARNING.value,
+                run.status,
+            )
             send_warning_email(date=expiration, url=url, addr=email, job_name=run.job.name)
             run.notified = now
             run.save()

--- a/eventkit_cloud/tasks/tests/test_scheduled_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_scheduled_tasks.py
@@ -57,8 +57,9 @@ class TestExpireRunsTask(TestCase):
                                        addr=job.user.email, job_name=job.name)
             send_email.assert_any_call(date=now_time + timezone.timedelta(days=6), url=expected_url,
                                        addr=job.user.email, job_name=job.name)
-            self.assertEqual(3, ExportRun.objects.all().count())
-            self.assertEqual(0, Notification.objects.all().count())
+            self.assertEqual(3, ExportRun.objects.filter(deleted=False).count())
+            self.assertEqual(1, ExportRun.objects.filter(deleted=True).count())
+            self.assertEqual(2, Notification.objects.all().count())
 
 
 class TestPcfScaleCeleryTask(TestCase):

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationIcon.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationIcon.js
@@ -61,6 +61,7 @@ export class NotificationIcon extends Component {
                 );
                 break;
             case verbs.runDeleted:
+            case verbs.runExpiring:
             case verbs.removedFromGroup:
             case verbs.removedAsGroupAdmin:
                 icon = (

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationMessage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationMessage.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import moment from 'moment';
 import { withTheme } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import {
@@ -93,6 +94,11 @@ export class NotificationMessage extends Component {
             case verbs.runDeleted: {
                 data = notification.actor.details.job.name;
                 text = '\xa0has been deleted.';
+                break;
+            }
+            case verbs.runExpiring: {
+                data = notification.actor.details.job.name;
+                text = `\xa0is expiring on ${ moment(notification.actor.details.expiration).format('M/D/YY') }.`;
                 break;
             }
             case verbs.addedToGroup: {

--- a/eventkit_cloud/ui/static/ui/app/utils/notificationUtils.js
+++ b/eventkit_cloud/ui/static/ui/app/utils/notificationUtils.js
@@ -5,6 +5,7 @@ export const verbs = {
     runCompleted: 'run_completed',
     runFailed: 'run_failed',
     runDeleted: 'run_deleted',
+    runExpiring: 'run_expiring',
     removedFromGroup: 'removed_from_group',
     addedToGroup: 'added_to_group',
     setAsGroupAdmin: 'set_as_group_admin',
@@ -16,6 +17,7 @@ export const requiresActorDetails = [
     verbs.runCanceled,
     verbs.runCompleted,
     verbs.runDeleted,
+    verbs.runExpiring,
     verbs.runFailed,
 ];
 
@@ -33,6 +35,7 @@ export function getNotificationViewPath(notification) {
         case verbs.runCanceled:
         case verbs.runCompleted:
         case verbs.runDeleted:
+        case verbs.runExpiring:
         case verbs.runFailed: {
             const run = notification.actor.details;
             if (!run) {


### PR DESCRIPTION
Update expire_runs to use soft_delete and add site notifications to warn users that their DataPacks are expiring soon.