### PR TITLE
Move Estimate Calculations to Celery (r1.6.x)

### DIFF
--- a/eventkit_cloud/tasks/admin.py
+++ b/eventkit_cloud/tasks/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 
 from eventkit_cloud.tasks.models import (
+    DataProviderTaskRecord,
     ExportRun,
     UserDownload,
     ExportTaskRecord,
@@ -11,6 +12,28 @@ import pickle
 import traceback
 
 logger = logging.getLogger(__name__)
+
+
+class DataProviderTaskRecordAdmin(admin.ModelAdmin):
+    model = DataProviderTaskRecord
+
+    readonly_fields = (
+        "name",
+        "slug",
+        "run",
+        "status",
+        "display",
+        "estimated_size",
+        "estimated_duration",
+        "preview",
+        "created_at",
+        "updated_at",
+    )
+    search_fields = ("uid", "name", "status")
+    list_display = ["uid", "name", "run", "status", "updated_at"]
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 class ExportTaskRecordAdmin(admin.ModelAdmin):
@@ -89,6 +112,7 @@ class UserDownloadAdmin(admin.ModelAdmin):
         return False
 
 
+admin.site.register(DataProviderTaskRecord, DataProviderTaskRecordAdmin)
 admin.site.register(ExportRun, ExportRunAdmin)
 admin.site.register(UserDownload, UserDownloadAdmin)
 admin.site.register(ExportTaskRecord, ExportTaskRecordAdmin)

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -11,7 +11,7 @@ from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.export_tasks import reprojection_task, create_datapack_preview
 from eventkit_cloud.tasks.helpers import normalize_name, get_metadata
 from eventkit_cloud.tasks.models import ExportTaskRecord, DataProviderTaskRecord
-from eventkit_cloud.utils.stats.aoi_estimators import AoiEstimator
+from eventkit_cloud.tasks.util_tasks import get_estimates_task
 
 logger = logging.getLogger(__name__)
 
@@ -92,11 +92,6 @@ class TaskChainBuilder(object):
                 msg = "Error importing export task: {0}".format(e)
                 logger.debug(msg)
 
-        # Record estimates for size and time
-        estimator = AoiEstimator(run.job.extents)
-        estimated_size, meta_s = estimator.get_estimate(estimator.Types.SIZE, provider_task.provider)
-        estimated_duration, meta_t = estimator.get_estimate(estimator.Types.TIME, provider_task.provider)
-
         # run the tasks
         data_provider_task_record = DataProviderTaskRecord.objects.create(
             run=run,
@@ -104,8 +99,22 @@ class TaskChainBuilder(object):
             slug=provider_task.provider.slug,
             status=TaskStates.PENDING.value,
             display=True,
-            estimated_size=estimated_size,
-            estimated_duration=estimated_duration,
+        )
+
+        """
+        Create a celery chain which gets the data & runs export formats
+        """
+        queue_group = os.getenv("CELERY_GROUP_NAME", worker)
+
+        # Record estimates for size and time
+        get_estimates_task.apply_async(
+            queue=queue_group,
+            routing_key=queue_group,
+            kwargs={
+                "run_uid": run.uid,
+                "data_provider_task_uid": provider_task.uid,
+                "data_provider_task_record_uid": data_provider_task_record.uid,
+            },
         )
 
         for file_format, task in export_tasks.items():
@@ -122,8 +131,6 @@ class TaskChainBuilder(object):
         """
         Create a celery chain which gets the data & runs export formats
         """
-        queue_group = os.getenv("CELERY_GROUP_NAME", worker)
-
         if export_tasks:
             subtasks = list()
             if provider_task.provider.preview_url:


### PR DESCRIPTION
This PR moves the calculation of estimates to a celery task, this was added in 1.5.2 and this PR brings it over to r1.6.x as well. This PR also adds DataProviderTaskRecord to the admin panel so that we can see them and troubleshoot any issues easier.