### PR TITLE
Refactoring GDAL Utils Convert

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -840,33 +840,6 @@ def reprojection_task(
     return result
 
 
-@app.task(name="Clip Export", bind=True, base=EventKitBaseTask)
-def clip_export_task(
-    self, result=None, run_uid=None, task_uid=None, stage_dir=None, job_name=None, user_details=None, *args, **kwargs,
-):
-    """
-    Clips a dataset to a vector cutline and returns a dataset of the same format.
-    :param self:
-    :param result:
-    :param run_uid:
-    :param task_uid:
-    :param stage_dir:
-    :param job_name:
-    :param user_details:
-    :return:
-    """
-    result = result or {}
-    # self.update_task_state(result=result, task_uid=task_uid)
-
-    dataset = parse_result(result, "result")
-    selection = parse_result(result, "selection")
-    if selection:
-        dataset = gdalutils.clip_dataset(boundary=selection, in_dataset=dataset, fmt=None)
-
-    result["result"] = dataset
-    return result
-
-
 @app.task(name="WFSExport", bind=True, base=ExportTask, abort_on_error=True)
 def wfs_export_task(
     self,

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -186,8 +186,8 @@ class TestExportTasks(ExportTaskBase):
         result = geopackage_export_task.run(run_uid=self.run.uid, result=previous_task_result,
                                             task_uid=str(saved_export_task.uid),
                                             stage_dir=stage_dir, job_name=job_name, projection=projection)
-        mock_convert.assert_called_once_with(file_format='gpkg', in_file=expected_output_path,
-                                             out_file=expected_output_path, task_uid=str(saved_export_task.uid))
+        mock_convert.assert_called_once_with(fmt='gpkg', in_dataset=expected_output_path,
+                                             out_dataset=expected_output_path, task_uid=str(saved_export_task.uid))
 
         self.assertEqual(expected_output_path, result['result'])
         self.assertEqual(expected_output_path, result['source'])
@@ -202,27 +202,27 @@ class TestExportTasks(ExportTaskBase):
         expected_outfile = 'stage/job-4326.tif'
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job')
         mock_gdalutils.convert.return_value = expected_outfile
-        mock_gdalutils.convert.assert_called_once_with(file_format='gtiff', in_file=example_geotiff,
-                                                       out_file=expected_outfile, task_uid='1234')
+        mock_gdalutils.convert.assert_called_once_with(fmt='gtiff', in_dataset=example_geotiff,
+                                                       out_dataset=expected_outfile, task_uid='1234')
         mock_gdalutils.reset_mock()
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job', compress=True)
         params = "-co COMPRESS=JPEG -co PHOTOMETRIC=YCBCR -co TILED=YES -b 1 -b 2 -b 3"
-        mock_gdalutils.convert.assert_has_calls([call(file_format='gtiff', in_file=example_geotiff,
-                                                      out_file=expected_outfile, task_uid='1234'),
-                                                 call(file_format='gtiff', in_file=expected_outfile,
-                                                      out_file=expected_outfile,
+        mock_gdalutils.convert.assert_has_calls([call(fmt='gtiff', in_dataset=example_geotiff,
+                                                      out_dataset=expected_outfile, task_uid='1234'),
+                                                 call(fmt='gtiff', in_dataset=expected_outfile,
+                                                      out_dataset=expected_outfile,
                                                       params=params, task_uid='1234', use_translate=True)
                                                  ])
         mock_gdalutils.reset_mock()
         example_result = {"source": example_geotiff,
                           "selection": "selection"}
-        mock_gdalutils.clip_dataset.return_value = expected_outfile
+        mock_gdalutils.convert.return_value = expected_outfile
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job',
                             compress=True)
-        mock_gdalutils.convert.assert_has_calls([call(file_format='gtiff', in_file=expected_outfile,
-                                                      out_file=expected_outfile, task_uid='1234'),
-                                                 call(file_format='gtiff', in_file=expected_outfile,
-                                                      out_file=expected_outfile,
+        mock_gdalutils.convert.assert_has_calls([call(fmt='gtiff', in_dataset=expected_outfile,
+                                                      out_dataset=expected_outfile, task_uid='1234'),
+                                                 call(fmt='gtiff', in_dataset=expected_outfile,
+                                                      out_dataset=expected_outfile,
                                                       params=params, task_uid='1234', use_translate=True)
                                                  ])
 


### PR DESCRIPTION
This PR merges the clip_dataset and convert functionality to prepare for a larger refactor to using Python bindings.  It eliminates a lot of duplication between these two functions.  The convert function will now handle converting to a new projection and clipping the dataset in one call.  If you don't pass in a boundary, it will simply convert the data to a new projection.  If you do pass in a boundary it will both clip the dataset and convert it to the new projection.