### PR TITLE
compress all geotiff with lzw

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -679,7 +679,7 @@ def geopackage_export_task(
 
 @app.task(name="Geotiff (.tif)", bind=True, base=FormatTask)
 def geotiff_export_task(
-    self, result=None, task_uid=None, stage_dir=None, job_name=None, projection=4326, compress=False, *args, **kwargs,
+    self, result=None, task_uid=None, stage_dir=None, job_name=None, projection=4326, *args, **kwargs,
 ):
     """
     Class defining geopackage export function.
@@ -694,12 +694,7 @@ def geotiff_export_task(
         gtiff_in_dataset = f"GTIFF_RAW:{gtiff_in_dataset}"
 
     gtiff_out_dataset = gdalutils.convert(
-        fmt="gtiff",
-        input_file=gtiff_in_dataset,
-        output_file=gtiff_out_dataset,
-        task_uid=task_uid,
-        compress=compress,
-        boundary=selection,
+        fmt="gtiff", input_file=gtiff_in_dataset, output_file=gtiff_out_dataset, task_uid=task_uid, boundary=selection,
     )
 
     result["file_extension"] = "tif"
@@ -784,7 +779,6 @@ def reprojection_task(
     job_name=None,
     user_details=None,
     projection=None,
-    compress=False,
     *args,
     **kwargs,
 ):
@@ -815,7 +809,6 @@ def reprojection_task(
         input_file=in_dataset,
         output_file=out_dataset,
         task_uid=task_uid,
-        compress=compress,
         projection=projection,
         boundary=selection,
     )

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -74,6 +74,10 @@ class TaskChainBuilder(object):
         formats = [provider_task_format.slug for provider_task_format in provider_task.formats.all()]
         export_tasks = {}
 
+        # If WCS we will want geotiff...
+        if "wcs" in primary_export_task.name.lower():
+            formats += ["gtiff"]
+
         # build a list of celery tasks based on the export formats...
         for file_format in formats:
             try:

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -74,14 +74,6 @@ class TaskChainBuilder(object):
         formats = [provider_task_format.slug for provider_task_format in provider_task.formats.all()]
         export_tasks = {}
 
-        # If WCS we will want geotiff...
-
-        if "wcs" in primary_export_task.name.lower():
-            formats += ["gtiff"]
-            compress = False
-        else:
-            compress = True
-
         # build a list of celery tasks based on the export formats...
         for file_format in formats:
             try:
@@ -151,7 +143,6 @@ class TaskChainBuilder(object):
                         run_uid=run.uid,
                         stage_dir=stage_dir,
                         job_name=job_name,
-                        compress=compress,
                         task_uid=task.get("task_uid"),
                         user_details=user_details,
                         locking_task_key=data_provider_task_record.uid,
@@ -187,7 +178,6 @@ class TaskChainBuilder(object):
                             run_uid=run.uid,
                             stage_dir=stage_dir,
                             job_name=job_name,
-                            compress=compress,
                             task_uid=projection_task.uid,
                             user_details=user_details,
                             locking_task_key=data_provider_task_record.uid,
@@ -234,7 +224,6 @@ class TaskChainBuilder(object):
             layer=provider_task.provider.layer,
             level_from=min_zoom,
             level_to=max_zoom,
-            compress=compress,
             service_type=service_type,
             service_url=provider_task.provider.url,
             config=provider_task.provider.config,

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -203,21 +203,20 @@ class TestExportTasks(ExportTaskBase):
         expected_outfile = 'stage/job-4326.tif'
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job')
         mock_gdalutils.convert.return_value = expected_outfile
-        mock_gdalutils.convert.assert_called_once_with(boundary=None, compress=False, fmt='gtiff',
+        mock_gdalutils.convert.assert_called_once_with(boundary=None, fmt='gtiff',
                                                        input_file=f'GTIFF_RAW:{example_geotiff}',
                                                        output_file=expected_outfile, task_uid=task_uid)
         mock_gdalutils.reset_mock()
-        geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job', compress=True)
-        mock_gdalutils.convert.assert_called_once_with(boundary=None, compress=True, fmt='gtiff',
+        geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job')
+        mock_gdalutils.convert.assert_called_once_with(boundary=None, fmt='gtiff',
                                                        input_file=f'GTIFF_RAW:{example_geotiff}',
                                                        output_file=expected_outfile, task_uid=task_uid)
         mock_gdalutils.reset_mock()
         example_result = {"source": example_geotiff,
                           "selection": "selection"}
         mock_gdalutils.convert.return_value = expected_outfile
-        geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job',
-                            compress=True)
-        mock_gdalutils.convert.assert_called_once_with(boundary="selection", compress=True, fmt='gtiff',
+        geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job')
+        mock_gdalutils.convert.assert_called_once_with(boundary="selection", fmt='gtiff',
                                                        input_file=f'GTIFF_RAW:{example_geotiff}',
                                                        output_file=expected_outfile, task_uid=task_uid)
 

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -119,7 +119,7 @@ class TestGdalUtils(TestCase):
         is_envelope_mock.return_value = False
         convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid, projection=3857)
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt, creation_options=None,
-                                     band_type=band_type, dst_alpha=dstalpha, boundary=geojson_file, compress=False,
+                                     band_type=band_type, dst_alpha=dstalpha, boundary=geojson_file,
                                      src_srs=in_projection, dst_srs=out_projection, task_uid=self.task_uid)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
@@ -134,7 +134,7 @@ class TestGdalUtils(TestCase):
         convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid)
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None, band_type=band_type, dst_alpha=dstalpha,
-                                                      boundary=geojson_file, compress=False, src_srs=in_projection,
+                                                      boundary=geojson_file, src_srs=in_projection,
                                                       dst_srs=in_projection, task_uid=self.task_uid)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
@@ -146,7 +146,7 @@ class TestGdalUtils(TestCase):
         convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid)
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None, band_type=band_type, dst_alpha=dstalpha,
-                                                      boundary=geojson_file, compress=False, src_srs=in_projection,
+                                                      boundary=geojson_file, src_srs=in_projection,
                                                       dst_srs=in_projection, task_uid=self.task_uid)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
@@ -176,7 +176,7 @@ class TestGdalUtils(TestCase):
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=extra_parameters,
                                                       band_type=band_type, dst_alpha=dstalpha, boundary=None,
-                                                      compress=False,  src_srs=in_projection, dst_srs=out_projection,
+                                                      src_srs=in_projection, dst_srs=out_projection,
                                                       task_uid=self.task_uid)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
@@ -193,7 +193,6 @@ class TestGdalUtils(TestCase):
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None,
                                                       band_type=band_type, dst_alpha=dstalpha, boundary=None,
-                                                      compress=False,
                                                       src_srs=in_projection, dst_srs=out_projection,
                                                       task_uid=self.task_uid)
         get_task_command_mock.reset_mock()
@@ -261,24 +260,21 @@ class TestGdalUtils(TestCase):
         task_uid = '123'
         input_file = '/test/test.gpkg'
         output_file = '/test/test.tif'
-        compress = True
         boundary = '/test/test.json'
         fmt = 'gtiff'
         srs = "EPSG:4326"
 
         mock_get_dataset_names.return_value = (input_file, output_file)
-        convert_raster(input_file, output_file, fmt=fmt, boundary=boundary,
-                       compress=compress, src_srs=srs, dst_srs=srs, task_uid=task_uid)
+        convert_raster(input_file, output_file, fmt=fmt, boundary=boundary, src_srs=srs, dst_srs=srs, task_uid=task_uid)
         mock_gdal.Warp.assert_called_once_with(output_file, [input_file],
                                                callback=progress_callback,
                                                callback_data={'task_uid': task_uid, 'subtask_percentage': 50},
                                                cropToCutline=True, cutlineDSName=boundary,
                                                dstSRS=srs, format=fmt, srcSRS=srs)
-        mock_gdal.Translate.assert_called_once_with(output_file, input_file, bandList=[1, 2, 3],
+        mock_gdal.Translate.assert_called_once_with(output_file, input_file,
                                                     callback=progress_callback, format=fmt,
                                                     callback_data={'task_uid': task_uid, 'subtask_percentage': 50},
-                                                    creationOptions=['COMPRESS=JPEG',
-                                                                      'PHOTOMETRIC=YCBCR',
+                                                    creationOptions=['COMPRESS=LZW',
                                                                       'TILED=YES'])
 
     @patch('eventkit_cloud.utils.gdalutils.gdal')


### PR DESCRIPTION
Compresses all geotiffs using the same compression (LZW).  
To tes,t ensure that geotiff exports work.  Clipping out an area (not a rectangle) should result in transparency instead of black pixels. 