### PR TITLE
Fixing zoom button bug to be in sync with zoom slider

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ZoomLevelSlider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ZoomLevelSlider.tsx
@@ -4,6 +4,7 @@ import {
 } from '@material-ui/core/styles';
 import Slider from '@material-ui/lab/Slider';
 import TextField from '@material-ui/core/TextField';
+import {useEffect, useState} from "react";
 
 
 const jss = (theme: Theme & Eventkit.Theme) => createStyles({
@@ -47,133 +48,106 @@ interface Props {
     classes: { [className: string]: string };
 }
 
-interface State {
-    maxZoom: number;
-    minZoom: number;
-}
+export function ZoomLevelSlider(props: Props) {
+    const [minZoom, setMinZoom] = useState(props.selectedMinZoom);
+    const [maxZoom, setMaxZoom] = useState(props.selectedMaxZoom);
 
-export class ZoomLevelSlider extends React.Component<Props, State> {
-    static defaultProps;
+    useEffect(() => {
+        setMinZoom(props.selectedMinZoom);
+    }, [props.selectedMinZoom]);
 
-    constructor(props: Props) {
-        super(props);
+    useEffect(() => {
+        setMaxZoom(props.selectedMaxZoom);
+    }, [props.selectedMaxZoom]);
 
-        this.state = {
-            minZoom: props.selectedMinZoom,
-            maxZoom: props.selectedMaxZoom,
-        };
 
-        this.updateMax = this.updateMax.bind(this);
-        this.updateMin = this.updateMin.bind(this);
-    }
-
-    componentDidUpdate(prevProps: Readonly<Props>): void {
-        const { selectedMinZoom, selectedMaxZoom } = this.props;
-        const prevMinZoom = prevProps.selectedMinZoom;
-        const prevMaxZoom = prevProps.selectedMaxZoom;
-        if (selectedMinZoom !== prevMinZoom) {
-            // Deprecated rule
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({ minZoom: selectedMinZoom });
-        }
-        if (selectedMaxZoom !== prevMaxZoom) {
-            // Deprecated rule
-            // eslint-disable-next-line react/no-did-update-set-state
-            this.setState({ maxZoom: selectedMaxZoom });
-        }
-    }
-
-    updateMax = (event, value) => {
+    function updateMax(event, value) {
         const zoomValue = Number(value);
-        if (zoomValue >= this.props.minZoom && zoomValue <= this.props.maxZoom) {
-            if (zoomValue < this.props.selectedMinZoom) {
-                this.props.updateZoom(zoomValue, this.props.minZoom);
+        if (zoomValue >= props.minZoom && zoomValue <= props.maxZoom) {
+            if (zoomValue < props.selectedMinZoom) {
+                props.updateZoom(zoomValue, props.minZoom);
             } else {
-                this.props.updateZoom(null, zoomValue);
+                props.updateZoom(null, zoomValue);
             }
         } else {
             // Send null for min and max zoom to force the prop to reupdate with the last valid value
-            this.props.updateZoom(null, null);
+            props.updateZoom(null, null);
         }
-    };
+    }
 
-    updateMin = (event, value) => {
+    function updateMin(event, value) {
         const zoomValue = Number(value);
-        if (zoomValue >= this.props.minZoom && zoomValue <= this.props.maxZoom) {
-            if (zoomValue > this.props.selectedMaxZoom) {
-                this.props.updateZoom(this.props.selectedMaxZoom, zoomValue);
+        if (zoomValue >= props.minZoom && zoomValue <= props.maxZoom) {
+            if (zoomValue > props.selectedMaxZoom) {
+                props.updateZoom(props.selectedMaxZoom, zoomValue);
             } else {
-                this.props.updateZoom(zoomValue, null);
+                props.updateZoom(zoomValue, null);
             }
         } else {
             // Send null for min and max zoom to force the prop to reupdate with the last valid value
-            this.props.updateZoom(null, null);
+            props.updateZoom(null, null);
         }
-    };
+    }
 
-    render() {
-        const { classes } = this.props;
-        const { minZoom, maxZoom } = this.state;
+    const { classes } = props;
 
-        return (
-            <div className={classes.container}>
-                <>
-                    <span>
-                        <TextField
-                            className={classes.textField}
-                            type="number"
-                            name="zoom-value"
-                            value={minZoom}
-                            disabled
-                            onChange={e => this.updateMin(e, e.target.value)}
-                            // MUI uses the case of the i to distinguish between Input component and input html element
-                            InputProps={{ style: { bottom: '5px' } }}
-                            // eslint-disable-next-line react/jsx-no-duplicate-props
-                            inputProps={{ style: { textAlign: 'center', fontWeight: 'bold', fontSize: '16px' } }}
-                        />
-                        <span style={{ fontSize: '16px' }}> to </span>
-                        <TextField
-                            className={classes.textField}
-                            type="number"
-                            name="zoom-value"
-                            value={maxZoom}
-                            onChange={e => this.updateMax(e, e.target.value)}
-                            // MUI uses the case of the i to distinguish between Input component and input html element
-                            InputProps={{ style: { bottom: '5px' } }}
-                            // eslint-disable-next-line react/jsx-no-duplicate-props
-                            inputProps={{ style: { textAlign: 'center', fontWeight: 'bold', fontSize: '16px' } }}
-                        />
-                        <span style={{ fontSize: '16px' }}>Selected Zoom</span>
+    return (
+        <div className={classes.container}>
+            <>
+                <span>
+                    <TextField
+                        className={classes.textField}
+                        type="number"
+                        name="zoom-value"
+                        value={minZoom}
+                        disabled
+                        onChange={e => updateMin(e, e.target.value)}
+                        // MUI uses the case of the i to distinguish between Input component and input html element
+                        InputProps={{ style: { bottom: '5px' } }}
+                        // eslint-disable-next-line react/jsx-no-duplicate-props
+                        inputProps={{ style: { textAlign: 'center', fontWeight: 'bold', fontSize: '16px' } }}
+                    />
+                    <span style={{ fontSize: '16px' }}> to </span>
+                    <TextField
+                        className={classes.textField}
+                        type="number"
+                        name="zoom-value"
+                        value={maxZoom}
+                        onChange={e => updateMax(e, e.target.value)}
+                        // MUI uses the case of the i to distinguish between Input component and input html element
+                        InputProps={{ style: { bottom: '5px' } }}
+                        // eslint-disable-next-line react/jsx-no-duplicate-props
+                        inputProps={{ style: { textAlign: 'center', fontWeight: 'bold', fontSize: '16px' } }}
+                    />
+                    <span style={{ fontSize: '16px' }}>Selected Zoom</span>
+                </span>
+                <br/>
+            </>
+            <strong className={classes.zoomHeader}>Zoom</strong>
+            <div style={{ display: 'block' }}>
+                <div style={{ display: 'flex', position: 'relative', margin: '0 30px' }}>
+                    <Slider
+                        className={classes.slider}
+                        value={maxZoom}
+                        aria-labelledby="label"
+                        onChange={(e, v) => setMaxZoom(Number(v))}
+                        onDragEnd={() => updateMax(null, maxZoom)}
+                        min={props.minZoom}
+                        max={props.maxZoom}
+                        step={1}
+                    />
+                </div>
+                <div id="labels" style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <span style={{ textAlign: 'left' }}>
+                        {props.minZoom}
                     </span>
-                    {this.props.children}
-                    <br/>
-                </>
-                <strong className={classes.zoomHeader}>Zoom</strong>
-                <div style={{ display: 'block' }}>
-                    <div style={{ display: 'flex', position: 'relative', margin: '0 30px' }}>
-                        <Slider
-                            className={classes.slider}
-                            value={maxZoom}
-                            aria-labelledby="label"
-                            onChange={(e, v) => this.setState({ maxZoom: Number(v) })}
-                            onDragEnd={() => this.updateMax(null, maxZoom)}
-                            min={this.props.minZoom}
-                            max={this.props.maxZoom}
-                            step={1}
-                        />
-                    </div>
-                    <div id="labels" style={{ display: 'flex', justifyContent: 'space-between' }}>
-                        <span style={{ textAlign: 'left' }}>
-                            {this.props.minZoom}
-                        </span>
-                        <span style={{ textAlign: 'right' }}>
-                            {this.props.maxZoom}
-                        </span>
-                    </div>
+                    <span style={{ textAlign: 'right' }}>
+                        {props.maxZoom}
+                    </span>
                 </div>
             </div>
-        );
-    }
+        </div>
+    );
 }
 
 export default withTheme()(withStyles<any, any>(jss)(ZoomLevelSlider));

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ZoomLevelSlider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ZoomLevelSlider.tsx
@@ -61,7 +61,7 @@ export function ZoomLevelSlider(props: Props) {
     }, [props.selectedMaxZoom]);
 
 
-    function updateMax(event, value) {
+    const updateMax = (event, value) => {
         const zoomValue = Number(value);
         if (zoomValue >= props.minZoom && zoomValue <= props.maxZoom) {
             if (zoomValue < props.selectedMinZoom) {
@@ -73,9 +73,9 @@ export function ZoomLevelSlider(props: Props) {
             // Send null for min and max zoom to force the prop to reupdate with the last valid value
             props.updateZoom(null, null);
         }
-    }
+    };
 
-    function updateMin(event, value) {
+    const updateMin = (event, value) => {
         const zoomValue = Number(value);
         if (zoomValue >= props.minZoom && zoomValue <= props.maxZoom) {
             if (zoomValue > props.selectedMaxZoom) {
@@ -87,7 +87,7 @@ export function ZoomLevelSlider(props: Props) {
             // Send null for min and max zoom to force the prop to reupdate with the last valid value
             props.updateZoom(null, null);
         }
-    }
+    };
 
     const { classes } = props;
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ZoomUpdater.ts
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ZoomUpdater.ts
@@ -9,11 +9,11 @@ function ZoomUpdater(props: Props) {
     const zoomContext = useOlZoom();
     const initialRender = useRef(true);
     useEffect(() => {
-        if (!initialRender) {
+        if (!initialRender.current) {
             props.setZoom(null, zoomContext.zoomLevel);
         }
         initialRender.current = false;
-    }, [zoomContext.zoomLevel, props.setZoom]);
+    }, [zoomContext.zoomLevel]);
 
     return null;
 }


### PR DESCRIPTION
This PR:
- Fixes bug where zoom buttons on the map of step 2 should also update the zoom level's slider by adding the current property so that useRef knows the value it has stored on initial render.
- Converts the ZoomLevelSlider component from class to functional using react hooks.
- All tests pass.
