### PR TITLE
Fix tour on library page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.tsx
@@ -39,8 +39,7 @@ export class DataPackLinkButton extends React.Component<Props, {}> {
                 href="/create"
             >
                 <Button
-                    className={`datapack-button-create`}
-                    // activeClassName={classes.activeLink}
+                    className={"qa-DataPackLinkButton-Button datapack-button-create"}
                     style={styles.button}
                     variant="contained"
                     color="primary"

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
@@ -55,6 +55,8 @@ import globe from '../../../images/globe-americas.svg';
 import {makeAllRunsSelector} from '../../selectors/runSelector';
 import {updateAoiInfo, clearAoiInfo, clearExportInfo} from '../../actions/datacartActions';
 import {Breakpoint} from '@material-ui/core/styles/createBreakpoints';
+import withRef from '../../utils/withRef';
+
 
 export const RED_STYLE = new Style({
     stroke: new Stroke({
@@ -75,6 +77,7 @@ export const BLUE_STYLE = new Style({
 });
 
 export interface Props {
+    customRef?: any;
     runIds: string[];
     runs: Eventkit.Run[];
     user: Eventkit.Store.User;
@@ -1157,4 +1160,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withWidth()(withTheme()(connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(MapView)));
+export default withWidth()(withTheme()(withRef()(connect(makeMapStateToProps, mapDispatchToProps, null, {forwardRef: true})(MapView))));


### PR DESCRIPTION
This fixes a regression on the DataPack Library page map view, where the forward ref wasn't properly being passed, preventing the page tour to work.  Additionally it adds a classname back to the create button which fixes step 8.  

To test ensure that all of the steps work for each view on the page tour for the datapack library.