### PR TITLE
Fixes DataPack Preview Image Creation

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1504,7 +1504,7 @@ def create_datapack_preview(
 
         filepath = get_provider_staging_preview(export_run.uid, provider.slug)
         make_dirs(stage_dir)
-        preview = get_wmts_snapshot_image(provider.preview_url, provider_task.max_zoom, bbox=job.extents)
+        preview = get_wmts_snapshot_image(provider.preview_url, bbox=job.extents)
         fit_to_area(preview)
         preview.save(filepath)
 

--- a/eventkit_cloud/utils/image_snapshot.py
+++ b/eventkit_cloud/utils/image_snapshot.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 WGS84_FULL_WORLD = [-180, -90, 180, 90]
 
 
-def get_wmts_snapshot_image(base_url, zoom_level=None, bbox=None):
+def get_wmts_snapshot_image(base_url: str, zoom_level: int = None, bbox: list = None):
     """
     Returns an image comprised of all tiles touched by bbox at a given zoom_level for the provided provider URL.
 
@@ -190,7 +190,7 @@ def make_snapshot_downloadable(staging_filepath, relative_path=None, download_fi
     return thumbnail_snapshot
 
 
-def get_resolution_for_extent(extent, size=None):
+def get_resolution_for_extent(extent: list, size: tuple = None):
     """
     :param extent: A bounding box as a list [w,s,e,n].
     :param optional size: The pixel size of the image to get the resolution for as a tuple.
@@ -205,7 +205,7 @@ def get_resolution_for_extent(extent, size=None):
     return max([x_resolution, y_resolution])
 
 
-def get_width(extent):
+def get_width(extent: list):
     """
     :param extent: A bounding box as a list [w,s,e,n].
     :return: The width of the given extent.
@@ -213,7 +213,7 @@ def get_width(extent):
     return extent[2] - extent[0]
 
 
-def get_height(extent):
+def get_height(extent: list):
     """
     :param extent: A bounding box as a list [w,s,e,n].
     :return: The height of the given extent.

--- a/eventkit_cloud/utils/image_snapshot.py
+++ b/eventkit_cloud/utils/image_snapshot.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 WGS84_FULL_WORLD = [-180, -90, 180, 90]
 
 
-def get_wmts_snapshot_image(base_url, zoom_level, bbox=None):
+def get_wmts_snapshot_image(base_url, zoom_level=None, bbox=None):
     """
     Returns an image comprised of all tiles touched by bbox at a given zoom_level for the provided provider URL.
 
@@ -40,7 +40,7 @@ def get_wmts_snapshot_image(base_url, zoom_level, bbox=None):
     small regions or high level (low zoom) snapshots of a map. Full world, zoom level 0 is used to generate Thumbnails.
 
     :param base_url: URL that tiles are to be requested from, must be formatted with {x], {y}, and {z}
-    :param zoom_level: level to look for tiles at.
+    :param zoom_level: level to look for tiles at, will be determined automatically based on extent if one isn't passed.
     :param bbox: region of the world to get tiles for
     :return: A Pillow Image object built for the collected tiles.
     """
@@ -48,6 +48,10 @@ def get_wmts_snapshot_image(base_url, zoom_level, bbox=None):
         bbox = copy.copy(WGS84_FULL_WORLD)
     # Creates and returns a TileGrid object, let's us specify min_res instead of supplying the resolution list.
     mapproxy_grid = tile_grid(srs=4326, min_res=0.703125, bbox_srs=4326, bbox=copy.copy(WGS84_FULL_WORLD), origin="ul",)
+
+    if zoom_level is None:
+        resolution = get_resolution_for_extent(bbox)
+        zoom_level = mapproxy_grid.closest_level(resolution)
 
     tiles = mapproxy_grid.get_affected_level_tiles(bbox, zoom_level)
     dim_col, dim_row = tiles[1]
@@ -184,3 +188,34 @@ def make_snapshot_downloadable(staging_filepath, relative_path=None, download_fi
     thumbnail_snapshot.save()
 
     return thumbnail_snapshot
+
+
+def get_resolution_for_extent(extent, size=None):
+    """
+    :param extent: A bounding box as a list [w,s,e,n].
+    :param optional size: The pixel size of the image to get the resolution for as a tuple.
+    :return: The resolution at which the extent will render at the given size.
+    """
+    if size is None:
+        size = (1024, 512)
+
+    size_x, size_y = size
+    x_resolution = get_width(extent) / size_x
+    y_resolution = get_height(extent) / size_y
+    return max([x_resolution, y_resolution])
+
+
+def get_width(extent):
+    """
+    :param extent: A bounding box as a list [w,s,e,n].
+    :return: The width of the given extent.
+    """
+    return extent[2] - extent[0]
+
+
+def get_height(extent):
+    """
+    :param extent: A bounding box as a list [w,s,e,n].
+    :return: The height of the given extent.
+    """
+    return extent[3] - extent[1]

--- a/eventkit_cloud/utils/tests/test_image_snapshot.py
+++ b/eventkit_cloud/utils/tests/test_image_snapshot.py
@@ -4,7 +4,7 @@ import logging
 from mock import patch, Mock, MagicMock
 from django.test import TestCase
 from eventkit_cloud.utils.image_snapshot import get_tile, get_wmts_snapshot_image, save_thumbnail, \
-    make_thumbnail_downloadable
+    make_thumbnail_downloadable, get_width, get_height, get_resolution_for_extent
 
 from eventkit_cloud.utils.geocoding.geocode import Geocode, GeocodeAdapter, expand_bbox, is_valid_bbox
 
@@ -86,3 +86,22 @@ class TestImageSnapshot(TestCase):
             mock_shutil.copy.assert_called_once()
             mock_snapshot.save.assert_called_once()
             self.assertEquals(returned_snapshot, mock_snapshot)
+
+    @patch("eventkit_cloud.utils.image_snapshot.get_height")
+    @patch("eventkit_cloud.utils.image_snapshot.get_width")
+    def test_get_resolution_for_extent(self, mock_get_width, mock_get_height):
+        extent = (-180, -90, 180, 90)
+        mock_get_width.return_value = 360
+        mock_get_height.return_value = 180
+        resolution = get_resolution_for_extent(extent)
+        self.assertEqual(resolution, 0.3515625)
+
+    def test_get_width(self):
+        extent = (-180, -90, 180, 90)
+        width = get_width(extent)
+        self.assertEqual(width, 360)
+
+    def test_get_height(self):
+        extent = (-180, -90, 180, 90)
+        height = get_height(extent)
+        self.assertEqual(height, 180)


### PR DESCRIPTION
Fix an issue where the preview image was always using the max zoom, instead of an appropriate zoom level based on the given extents.

This issue was causing the preview images to be so large that the celery workers trying to generate them would crash.

In order to test this PR, pull down the changes locally and run a large datapack (greater than 1000km seemed to be causing issues before and have now been fixed).  You may want to do this on a second machine, as it will take quite some time to finish a datapack of that size.  