### PR TITLE
make upload_to_s3 params more explicit

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.s
     echo "y" | conda update -n root --all && \
     conda config --add channels local && \
     conda config --add channels file://var/lib/eventkit/conda/repo && \
-    conda config --set channel_priority strict && \
+    conda config --set channel_priority flexible && \
     conda env create --file environment-dev.yml python=3.6 && \
     conda clean --yes --all && \
     /home/eventkit/miniconda3/envs/eventkit-cloud/bin/python \

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -108,7 +108,8 @@ def make_file_downloadable(
         download_filename = filename
 
     if getattr(settings, "USE_S3", False):
-        download_url = s3.upload_to_s3(run_uid, os.path.join(staging_dir, filename), download_filename,)
+        download_path = f"{run_uid}/{download_filename}"
+        download_url = s3.upload_to_s3(os.path.join(staging_dir, filename), download_path)
     else:
         make_dirs(run_download_dir)
 
@@ -1493,7 +1494,8 @@ def create_datapack_preview(
         fit_to_area(preview)
         preview.save(filepath)
 
-        snapshot = make_snapshot_downloadable(filepath, copy=True)
+        download_filename = f"{run_uid}/{provider.slug}/{PREVIEW_TAIL}"
+        snapshot = make_snapshot_downloadable(filepath, download_filename=download_filename, copy=True)
         provider_task_record.preview = snapshot
         provider_task_record.save()
         result["result"] = filepath

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -173,8 +173,6 @@ class ExportTask(EventKitBaseTask):
             try:
                 add_metadata(task.export_provider_task.run.job, task.export_provider_task.slug, retval)
             except Exception:
-                import traceback
-
                 logger.error(traceback.format_exc())
                 logger.error("Failed to add metadata.")
 
@@ -261,8 +259,6 @@ class ExportTask(EventKitBaseTask):
             task.finished_at = timezone.now()
             task.save()
         except Exception:
-            import traceback
-
             logger.error(traceback.format_exc())
             logger.error(
                 "Cannot update the status of ExportTaskRecord object: no such object has been created for "

--- a/eventkit_cloud/utils/image_snapshot.py
+++ b/eventkit_cloud/utils/image_snapshot.py
@@ -140,7 +140,7 @@ def make_thumbnail_downloadable(filepath, provider_uid, download_filename=None):
     filesize = os.stat(filepath).st_size
     thumbnail_snapshot = MapImageSnapshot.objects.create(download_url="", filename=filepath, size=filesize)
     if getattr(settings, "USE_S3", False):
-        download_url = s3.upload_to_s3(thumbnail_snapshot.uid, filepath, download_filename,)
+        download_url = s3.upload_to_s3(filepath, download_filename)
         os.remove(filepath)
     else:
         download_path = os.path.join(get_provider_image_download_dir(provider_uid), download_filename)
@@ -170,12 +170,14 @@ def make_snapshot_downloadable(staging_filepath, relative_path=None, download_fi
 
     filesize = os.stat(staging_filepath).st_size
     thumbnail_snapshot = MapImageSnapshot.objects.create(download_url="", filename=filename, size=filesize)
+
     if getattr(settings, "USE_S3", False):
-        download_url = s3.upload_to_s3(thumbnail_snapshot.uid, staging_filepath, download_filename,)
+        download_url = s3.upload_to_s3(staging_filepath, download_filename)
     else:
         if relative_path is None:
             relative_path = os.path.split(get_relative_path_from_staging(staging_filepath))[0]
         download_path, download_url = get_download_paths(relative_path)
+        download_url = os.path.join(download_url, filename)
         make_dirs(download_path)
         # Source location (from) gets moved/copied to the destination (to)
         from_to = [staging_filepath, os.path.join(download_path, filename)]
@@ -183,8 +185,7 @@ def make_snapshot_downloadable(staging_filepath, relative_path=None, download_fi
             shutil.copy(*from_to)
         else:
             shutil.move(*from_to)
-
-    thumbnail_snapshot.download_url = os.path.join(download_url, filename)
+    thumbnail_snapshot.download_url = download_url
     thumbnail_snapshot.save()
 
     return thumbnail_snapshot

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -204,7 +204,7 @@ class MapproxyGeopackage(object):
         #  Customizations...
         mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(max_repeat=int(conf_dict.get("max_repeat", 5)))
 
-        logger.error("Beginning seeding to {0}".format(self.gpkgfile))
+        logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:
             conf = yaml.safe_load(self.config) or dict()
             cert_var = conf.get("cert_var")

--- a/eventkit_cloud/utils/s3.py
+++ b/eventkit_cloud/utils/s3.py
@@ -3,6 +3,7 @@ import os
 
 import boto3
 from django.conf import settings
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +12,7 @@ def get_s3_client():
     return boto3.client("s3", aws_access_key_id=settings.AWS_ACCESS_KEY, aws_secret_access_key=settings.AWS_SECRET_KEY,)
 
 
-def upload_to_s3(run_uuid, source_path, destination_filename, client=None, user_details=None):
+def upload_to_s3(source_path, destination_filename, client=None, user_details=None):
     # This is just to make it easier to trace when user_details haven't been sent
     if user_details is None:
         user_details = {"username": "unknown-upload_to_s3"}
@@ -22,15 +23,13 @@ def upload_to_s3(run_uuid, source_path, destination_filename, client=None, user_
     if not os.path.isfile(source_path):
         raise Exception("The file path given to upload to S3:\n {0} \n Does not exist.".format(source_path))
 
-    asset_remote_path = os.path.join(str(run_uuid), destination_filename)
-
     from audit_logging.file_logging import logging_open
 
     with logging_open(source_path, "rb", user_details=user_details) as asset_file:
-        client.upload_fileobj(Bucket=settings.AWS_BUCKET_NAME, Key=asset_remote_path, Fileobj=asset_file)
+        client.upload_fileobj(Bucket=settings.AWS_BUCKET_NAME, Key=destination_filename, Fileobj=asset_file)
 
     return client.generate_presigned_url(
-        "get_object", Params={"Bucket": settings.AWS_BUCKET_NAME, "Key": asset_remote_path},
+        "get_object", Params={"Bucket": settings.AWS_BUCKET_NAME, "Key": destination_filename},
     ).split("?")[0]
 
 
@@ -66,8 +65,7 @@ def get_presigned_url(download_url=None, client=None):
     if not client:
         client = get_s3_client()
 
-    parts = download_url.split("/")
-    key = "{0}/{1}".format(parts[-2], parts[-1])
+    parsed = urlparse(download_url)
     return client.generate_presigned_url(
-        "get_object", Params={"Bucket": settings.AWS_BUCKET_NAME, "Key": key}, ExpiresIn=300,
+        "get_object", Params={"Bucket": settings.AWS_BUCKET_NAME, "Key": parsed.path.lstrip('/')}, ExpiresIn=300,
     )

--- a/eventkit_cloud/utils/s3.py
+++ b/eventkit_cloud/utils/s3.py
@@ -67,5 +67,5 @@ def get_presigned_url(download_url=None, client=None):
 
     parsed = urlparse(download_url)
     return client.generate_presigned_url(
-        "get_object", Params={"Bucket": settings.AWS_BUCKET_NAME, "Key": parsed.path.lstrip('/')}, ExpiresIn=300,
+        "get_object", Params={"Bucket": settings.AWS_BUCKET_NAME, "Key": parsed.path.lstrip("/")}, ExpiresIn=300,
     )

--- a/eventkit_cloud/utils/tests/test_s3.py
+++ b/eventkit_cloud/utils/tests/test_s3.py
@@ -35,12 +35,13 @@ class TestS3Util(TestCase):
         mock_client = MagicMock()
         mock_get_s3_client.return_value = mock_client
         example_filename = os.path.join(settings.EXPORT_STAGING_ROOT, self._uuid, self._filename)
+        expected_download_path = f"{self._uuid}/self._filename"
         with patch('audit_logging.file_logging.logging_open', mock_open(read_data='test'), create=True) as mock_open_obj:
-            upload_to_s3(self._uuid, example_filename, self._filename)
+            upload_to_s3(example_filename, expected_download_path)
 
         mock_client.upload_fileobj.assert_called_once()
         mock_isfile.assert_called_once_with(example_filename)
-        mock_client.generate_presigned_url.assert_called_once_with('get_object', Params={'Bucket': 'test-bucket', 'Key': 'd34db33f/cool.pbf'})
+        mock_client.generate_presigned_url.assert_called_once_with('get_object', Params={'Bucket': 'test-bucket', 'Key': expected_download_path})
 
 
     @patch('eventkit_cloud.utils.s3.get_s3_client')


### PR DESCRIPTION
Fixes pathing issues with upload to s3 for the image preview.  

Fixes get presigned url by allowing keys of multiple "folders" instead of just two.

Also makes conda build in the dockerfile use flexible channel resolution. 

To test ensure that file downloads and image previews work with local files and when using s3.