### PR TITLE
fix qgis style to properly include the projection files

### DIFF
--- a/eventkit_cloud/api/utils.py
+++ b/eventkit_cloud/api/utils.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 import rest_framework.status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -24,6 +25,8 @@ def eventkit_exception_handler(exc, context):
     """
     # Call REST framework's default exception handler first,
     # to get the standard error response. Parse the response accordingly.
+    if getattr(settings, "DEBUG"):
+        raise exc
     response = exception_handler(exc, context)
     if response:
 

--- a/eventkit_cloud/tasks/templates/styles/Style.qgs
+++ b/eventkit_cloud/tasks/templates/styles/Style.qgs
@@ -10,7 +10,7 @@
       {% for provider in provider_details %}
       {% if provider.type == "nome" %}
       {% for file_details in provider.files %}
-      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}">
+      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}">
         <customproperties/>
         <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points" name="place label">
           <customproperties/>
@@ -71,7 +71,7 @@
       {%  endif %}
       {% if provider.type == "osm" %}
       {% for file_details in provider.files %}
-      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}">
+      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}">
         <customproperties/>
         <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points" name="place label">
           <customproperties/>
@@ -146,7 +146,7 @@
       {% if provider.type == "raster" %}
       {% for file_details in provider.files %}
           {{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}
-      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify}}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.projection }}-{{ file_details.file_ext|slugify }}">
+      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify}}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}">
         <customproperties/>
       </layer-tree-layer>
       {% endfor %}
@@ -160,7 +160,7 @@
       {% for provider in provider_details %}
       {% if provider.type == "elevation" %}
       {% for file_details in provider.files %}
-      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.projection }}-{{ file_details.file_ext|slugify }}">
+      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}">
         <customproperties/>
       </layer-tree-layer>
       {% endfor %}

--- a/eventkit_cloud/tasks/templates/styles/Style.qgs
+++ b/eventkit_cloud/tasks/templates/styles/Style.qgs
@@ -10,51 +10,51 @@
       {% for provider in provider_details %}
       {% if provider.type == "nome" %}
       {% for file_details in provider.files %}
-      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}_{{ file_details.file_ext|slugify }}">
+      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}">
         <customproperties/>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points" name="place label">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points" name="place label">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_points|subset=&quot;aeroway&quot; = 'aerodrome'" name="airport">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_points|subset=&quot;aeroway&quot; = 'aerodrome'" name="airport">
           <customproperties/>
         </layer-tree-layer>
         <layer-tree-group expanded="1" checked="Qt::Checked" name="points of interest">
           <customproperties/>
-          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_points" name="POI (points)">
+          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_points" name="POI (points)">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="POI (areas)">
+          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="POI (areas)">
             <customproperties/>
           </layer-tree-layer>
         </layer-tree-group>
-        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=roads_lines" name="roads">
+        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=roads_lines" name="roads">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=buildings_polygons" name="building">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=buildings_polygons" name="building">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines" name="waterways">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines" name="waterways">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = 'grassland'" name="grassland">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = 'grassland'" name="grassland">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=leisure_polygons" name="leisure">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=leisure_polygons" name="leisure">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=landuse_polygons" name="landuses">
+        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=landuse_polygons" name="landuses">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="amenities">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="amenities">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_lines" name="aviation lines">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_lines" name="aviation lines">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons" name="aviation polygons">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons" name="aviation polygons">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = &quot;water&quot;" name="water">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = &quot;water&quot;" name="water">
           <customproperties/>
         </layer-tree-layer>
         <layer-tree-group expanded="1" checked="Qt::Checked" name="background">
@@ -71,64 +71,64 @@
       {%  endif %}
       {% if provider.type == "osm" %}
       {% for file_details in provider.files %}
-      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}_{{ file_details.file_ext|slugify }}">
+      <layer-tree-group expanded="0" checked="Qt::Checked" name="{{ provider.name }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}">
         <customproperties/>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points" name="place label">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points" name="place label">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_points|subset=&quot;aeroway&quot; = 'aerodrome'" name="airport">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_points|subset=&quot;aeroway&quot; = 'aerodrome'" name="airport">
           <customproperties/>
         </layer-tree-layer>
         <layer-tree-group expanded="1" checked="Qt::Checked" name="points of interest">
           <customproperties/>
-          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_points" name="POI (points)">
+          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_points" name="POI (points)">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="POI (polygon, set 2)">
+          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="POI (polygon, set 2)">
             <customproperties/>
           </layer-tree-layer>
-          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="POI (polygon, set 1)">
+          <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="POI (polygon, set 1)">
             <customproperties>
               <property key="showFeatureCount" value="0"/>
             </customproperties>
           </layer-tree-layer>
         </layer-tree-group>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=rail_lines" name="railway">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=rail_lines" name="railway">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=roads_lines" name="roads">
+        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=roads_lines" name="roads">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=buildings_polygons" name="building">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=buildings_polygons" name="building">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines" name="waterways">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines" name="waterways">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = 'grassland'" name="grassland">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = 'grassland'" name="grassland">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=leisure_polygons" name="leisure">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=leisure_polygons" name="leisure">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=landuse_polygons" name="landuses">
+        <layer-tree-layer expanded="0" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=landuse_polygons" name="landuses">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="amenities">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons" name="amenities">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_lines" name="aviation lines">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_lines" name="aviation lines">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons" name="aviation polygons">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons" name="aviation polygons">
           <customproperties/>
         </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = &quot;water&quot;" name="water">
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = &quot;water&quot;" name="water">
           <customproperties/>
         </layer-tree-layer>
         <layer-tree-group expanded="1" checked="Qt::Checked" name="background">
           <customproperties/>
-          <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=land_polygons" name="land">
+          <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=land_polygons" name="land">
             <customproperties/>
           </layer-tree-layer>
           <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=boundary" name="boundary">
@@ -145,8 +145,8 @@
       {% for provider in provider_details %}
       {% if provider.type == "raster" %}
       {% for file_details in provider.files %}
-          {{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}
-      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify}}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.file_ext }}">
+          {{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}
+      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify}}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.projection }}-{{ file_details.file_ext|slugify }}">
         <customproperties/>
       </layer-tree-layer>
       {% endfor %}
@@ -160,7 +160,7 @@
       {% for provider in provider_details %}
       {% if provider.type == "elevation" %}
       {% for file_details in provider.files %}
-      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.file_ext }}">
+      <layer-tree-layer expanded="1" providerKey="gdal" checked="Qt::Checked" id="{{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}" name="{{ provider.name }}-{{ file_details.projection }}-{{ file_details.file_ext|slugify }}">
         <customproperties/>
       </layer-tree-layer>
       {% endfor %}
@@ -201,43 +201,43 @@
       {% for provider in provider_details %}
       {% if provider.slug == "nome" %}
       {% for file_details in provider.files %}
-      <item>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_land_polygonsnome{{ job_date_time }}</item>
       <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</item>
       {% endfor %}
       {% endif %}
       {% if provider.slug == "osm" %}
       {% for file_details in provider.files %}
-      <item>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</item>
       {% endfor %}
       {% endif %}
@@ -257,74 +257,74 @@
       <legendgroup open="false" checked="Qt::Checked" name="{{ provider.name }}">
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="place label" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="airport" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendgroup open="true" checked="Qt::Checked" name="points of interest">
           <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="POI (points)" showFeatureCount="0">
             <filegroup open="false" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
           <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="POI (areas)" showFeatureCount="0">
             <filegroup open="false" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
         </legendgroup>
         <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="roads" showFeatureCount="0">
           <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="building" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="waterways" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="grassland" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="leisure" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="landuses" showFeatureCount="0">
           <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="amenities" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="aviation lines" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="aviation polygons" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="water" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendgroup open="true" checked="Qt::Checked" name="background">
@@ -347,90 +347,90 @@
       <legendgroup open="false" checked="Qt::Checked" name="{{ provider.name }}">
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="place label" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="airport" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendgroup open="true" checked="Qt::Checked" name="points of interest">
           <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="POI (points)" showFeatureCount="0">
             <filegroup open="false" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
           <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="POI (polygon, set 2)" showFeatureCount="0">
             <filegroup open="false" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
           <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="POI (polygon, set 1)" showFeatureCount="0">
             <filegroup open="false" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
         </legendgroup>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="railway" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="roads" showFeatureCount="0">
           <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="building" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="waterways" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="grassland" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="leisure" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="false" checked="Qt::Checked" name="landuses" showFeatureCount="0">
           <filegroup open="false" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="amenities" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="aviation lines" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="aviation polygons" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="water" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendgroup open="true" checked="Qt::Checked" name="background">
           <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="land" showFeatureCount="0">
             <filegroup open="true" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
           <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="boundary" showFeatureCount="0">
@@ -449,7 +449,7 @@
       {% for file_details in provider.files %}
           <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ job_date_time|slice:":8" }}}-{{ file_details.file_ext|slugify }}" showFeatureCount="0">
             <filegroup open="true" hidden="false">
-              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}" visible="1"/>
+              <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}" visible="1"/>
             </filegroup>
           </legendlayer>
       {% endfor %}
@@ -462,7 +462,7 @@
         {% for file_details in provider.files %}
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ job_date_time|slice:":8" }}" showFeatureCount="0">
           <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+            <legendlayerfile isInOverview="0" layerid="{{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         {% endfor %}
@@ -778,7 +778,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>osm_bounds_{{ provider.slug}}__{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>osm_bounds_{{ provider.slug}}__{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=boundary</datasource>
       <keywordList>
         <value></value>
@@ -1074,7 +1074,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_points</datasource>
       <keywordList>
         <value></value>
@@ -1724,7 +1724,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons</datasource>
       <keywordList>
         <value></value>
@@ -2165,7 +2165,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons</datasource>
       <keywordList>
         <value></value>
@@ -2954,7 +2954,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_lines</datasource>
       <keywordList>
         <value></value>
@@ -3363,7 +3363,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_points|subset="aeroway" = 'aerodrome'</datasource>
       <keywordList>
         <value></value>
@@ -3709,7 +3709,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons</datasource>
       <keywordList>
         <value></value>
@@ -4109,7 +4109,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=buildings_polygons</datasource>
       <keywordList>
         <value></value>
@@ -4745,7 +4745,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=landuse_polygons</datasource>
       <keywordList>
         <value></value>
@@ -5610,7 +5610,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=leisure_polygons</datasource>
       <keywordList>
         <value></value>
@@ -5973,7 +5973,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset="natural" = 'grassland'</datasource>
       <keywordList>
         <value></value>
@@ -6294,7 +6294,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset="natural" = "water" OR "waterway" = "riverbank"</datasource>
       <keywordList>
         <value></value>
@@ -6617,7 +6617,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points</datasource>
       <keywordList>
         <value></value>
@@ -7132,7 +7132,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=roads_lines</datasource>
       <keywordList>
         <value></value>
@@ -8334,7 +8334,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines</datasource>
       <keywordList>
         <value></value>
@@ -9184,7 +9184,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_points</datasource>
       <keywordList>
         <value></value>
@@ -11729,7 +11729,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons</datasource>
       <keywordList>
         <value></value>
@@ -12552,7 +12552,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons</datasource>
       <keywordList>
         <value></value>
@@ -15151,7 +15151,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=amenities_polygons</datasource>
       <keywordList>
         <value></value>
@@ -15592,7 +15592,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_lines</datasource>
       <keywordList>
         <value></value>
@@ -15981,7 +15981,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_points|subset="aeroway" = 'aerodrome'</datasource>
       <keywordList>
         <value></value>
@@ -16327,7 +16327,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons</datasource>
       <keywordList>
         <value></value>
@@ -16727,7 +16727,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=buildings_polygons</datasource>
       <keywordList>
         <value></value>
@@ -17060,7 +17060,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=land_polygons</datasource>
       <keywordList>
         <value></value>
@@ -17363,7 +17363,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=landuse_polygons</datasource>
       <keywordList>
         <value></value>
@@ -18114,7 +18114,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=leisure_polygons</datasource>
       <keywordList>
         <value></value>
@@ -18466,7 +18466,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset="natural" = 'grassland'</datasource>
       <keywordList>
         <value></value>
@@ -18787,7 +18787,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset="natural" = "water" OR "waterway" = "riverbank"</datasource>
       <keywordList>
         <value></value>
@@ -19110,7 +19110,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=places_points</datasource>
       <keywordList>
         <value></value>
@@ -19625,7 +19625,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=rail_lines</datasource>
       <keywordList>
         <value></value>
@@ -20003,7 +20003,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=roads_lines</datasource>
       <keywordList>
         <value></value>
@@ -21984,7 +21984,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines</datasource>
       <keywordList>
         <value></value>
@@ -22431,12 +22431,12 @@ def my_form_open(dialog, layer, feature):
         <xmax>{{ bbox.2 }}</xmax>
         <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}</layername>
+      <layername>{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
@@ -22516,12 +22516,12 @@ def my_form_open(dialog, layer, feature):
         <xmax>{{ bbox.2 }}</xmax>
         <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>{{ job_name }}_{{ provider.slug }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
+      <id>{{ job_name }}_{{ provider.slug }}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}</datasource>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}</layername>
+      <layername>{{ job_name.split|join:"_" }}-{{ provider.name }}-{{ file_details.projection }}-{{ job_date_time|slice:":8" }}-{{ file_details.file_ext|slugify }}</layername>
       <srs>
         <spatialrefsys>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
@@ -22620,39 +22620,39 @@ def my_form_open(dialog, layer, feature):
       <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
       <LayerSnappingList type="QStringList">
         <value>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_land_polygonsnome{{ job_date_time }}</value>
-        <value>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>osm_bounds_{{ provider.slug}}__{{ provider.slug}}{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_places_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_aviation_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_points_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_rail_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>osm_bounds_{{ provider.slug}}__{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
       </LayerSnappingList>
       <LayerSnappingEnabledList type="QStringList">
         <value>disabled</value>

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -147,6 +147,7 @@ class TestHelpers(TestCase):
         for fname in [sample_file]:
             mps = MagicMock()
             mps.result.filename = fname
+            mps.name = "something EPSG:4326"
             mps.status = TaskStates.COMPLETED.value
             mocked_provider_subtasks.append(mps)
 
@@ -154,7 +155,7 @@ class TestHelpers(TestCase):
         mocked_provider_task.name = expected_provider_task_name = "example_name"
         mocked_provider_task.status = TaskStates.COMPLETED.value
         mocked_provider_task.provider.slug = expected_provider_slug = 'example_slug'
-        mocked_provider_task.tasks.all.return_value = mocked_provider_subtasks
+        mocked_provider_task.tasks.filter.return_value = mocked_provider_subtasks
         mocked_provider_task.uid = expected_provider_task_uid = '5678'
         mock_DataProviderTaskRecord.objects.get.return_value = mocked_provider_task
 
@@ -203,6 +204,7 @@ class TestHelpers(TestCase):
                                "file_ext": split_file[1],
                                "full_file_path": os.path.join(stage_dir, expected_provider_slug,
                                                               sample_file),
+                               "projection": '4326'
                                }],
                     "last_update": expected_last_update,
                     "metadata": expected_metadata_url,


### PR DESCRIPTION
Adds projection to each file detail in the metadata documents.  
It also filters the export tasks to only include ones with projection information in the name to prevent duplicate files.  
Fixed the naming for some qgis layers and make explicit which layers have which projection.
Ensures that both 3857 and 4326 files appear in the qgis map. 

To test create an export for raster, elevation, and osm data and ensure that the layers appear correctly. 

![image](https://user-images.githubusercontent.com/6437951/84898984-0ed9b680-b076-11ea-9a1a-5f89742ba740.png)

