### PR TITLE
allow users to view and download data if the job permissions are PUBLIC

### DIFF
--- a/eventkit_cloud/jobs/models.py
+++ b/eventkit_cloud/jobs/models.py
@@ -679,7 +679,12 @@ class JobPermission(TimeStampedModelMixin):
         if level != JobPermissionLevel.READ.value:
             user_query.append(Q(permissions__permission=level))
 
-        return jobs.filter(Q(*user_query) | Q(*group_query))
+        # If not requesting Admin level permission (i.e. to make admin changes), then also include public datasets.
+        public_query = Q()
+        if level == JobPermissionLevel.READ.value:
+            public_query = Q(visibility=VisibilityState.PUBLIC.value)
+
+        return jobs.filter(Q(*user_query) | Q(*group_query) | public_query)
 
     @staticmethod
     def groupjobs(group, level):
@@ -691,7 +696,12 @@ class JobPermission(TimeStampedModelMixin):
         if level != JobPermissionLevel.READ.value:
             query.append(Q(permissions__permission=level))
 
-        return Job.objects.filter(*query)
+        # If not requesting Admin level permission (i.e. to make admin changes), then also include public datasets.
+        public_query = Q()
+        if level == JobPermissionLevel.READ.value:
+            public_query = Q(visibility=VisibilityState.PUBLIC.value)
+
+        return Job.objects.filter(Q(*query) | public_query)
 
     @staticmethod
     def get_user_permissions(user, job_id):


### PR DESCRIPTION
Fixes a regression which prevents users from downloading data from public datasets.  

To reproduce the bug, on master create a dataset with a user and then update the permissions to public (go to members tab and click the select all checkbox, when prompted select 'all users in the system').  Then with a separate user, try to view the dataset and download the files. 

To check the fix switch to this branch and try to download the file with the user that doesn't have specific permissions to the job. 