### PR TITLE
Fix NITF exports by updating to the correct creation_options.

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -721,13 +721,13 @@ def nitf_export_task(
     nitf_in_dataset = parse_result(result, "source")
     nitf_out_dataset = os.path.join(stage_dir, "{0}-{1}.nitf".format(job_name, projection))
 
-    params = "-co ICORDS=G"
+    creation_options = ["ICORDS=G"]
     nitf = gdalutils.convert(
         fmt="nitf",
         input_file=nitf_in_dataset,
         output_file=nitf_out_dataset,
         task_uid=task_uid,
-        creation_options=params,
+        creation_options=creation_options,
     )
 
     result["file_format"] = "nitf"

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -427,7 +427,7 @@ def convert_raster(
     :param output_file: The file to convert.
     :param fmt: The file format to convert.
     :param creation_options: Special GDAL options for conversion.
-        Seardh for "gdal driver <format> creation options" creation options for driver specific implementation.
+        Search for "gdal driver <format> creation options" creation options for driver specific implementation.
     :param band_type: The GDAL data type (e.g. gdal.GDT_BYTE).
     :param dst_alpha: If including an alpha band in the destination file.
     :param boundary: The boundary to be used for clipping, this must be a file.
@@ -492,7 +492,7 @@ def convert_vector(
     :param output_file: The file to convert.
     :param fmt: The file format to convert.
     :param creation_options: Special GDAL options for conversion.
-        Seardh for "gdal driver <format> creation options" creation options for driver specific implementation.
+        Search for "gdal driver <format> creation options" creation options for driver specific implementation.
     :param access_mode: The access mode for the file (e.g. "append" or "overwrite")
     :param bbox: A bounding box as a list (w,s,e,n) to be used for limiting the AOI that is used during conversion.
     :param boundary: The boundary to be used for clipping.


### PR DESCRIPTION
To test this, try to export any DataPack on the master branch with NITF selected and it will fail.  

Then check out this branch and run the same export again.  The NITF should properly export.