### PR TITLE
Fix HFA (IMG) reprojection bug.

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -758,6 +758,7 @@ def hfa_export_task(
     hfa_out_dataset = os.path.join(stage_dir, "{0}-{1}.img".format(job_name, projection))
     hfa = gdalutils.convert(fmt="hfa", input_file=hfa_in_dataset, output_file=hfa_out_dataset, task_uid=task_uid,)
 
+    result["file_extension"] = "img"
     result["file_format"] = "hfa"
     result["result"] = hfa
     result["hfa"] = hfa


### PR DESCRIPTION
Resolves a bug where HFA (IMG) files weren't being given the proper file extension during reprojection.  

To test this, create a DataPack before checking out this branch, and make sure to include an Elevation Provider using the Erdas Imagine HFA Format in 4326 and 3857.  If you download the zip file for the DataPack, you'll see that the IMG file for 3857 is missing.  Check out this branch, and then rerun the same export.  The zip file will now include the IMG files for both 4326 and 3857. 