### PR TITLE
allow changing geotiff compression for specific providers

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -823,12 +823,7 @@ def hfa_export_task(
     hfa_in_dataset = parse_result(result, "source")
     provider_slug = get_provider_slug(task_uid)
     hfa_out_dataset = get_export_filename(stage_dir, job_name, projection, provider_slug, "img")
-    hfa = gdalutils.convert(
-        fmt="hfa",
-        input_file=hfa_in_dataset,
-        output_file=hfa_out_dataset,
-        task_uid=task_uid,
-    )
+    hfa = gdalutils.convert(fmt="hfa", input_file=hfa_in_dataset, output_file=hfa_out_dataset, task_uid=task_uid,)
 
     result["file_extension"] = "img"
     result["file_format"] = "hfa"

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -743,7 +743,6 @@ def geotiff_export_task(
     selection = parse_result(result, "selection")
 
     warp_params, translate_params = get_creation_options(config, "gtiff")
-    logger.error(f"GEOTIFF config: {config}")
 
     if "tif" in os.path.splitext(gtiff_in_dataset)[1]:
         gtiff_in_dataset = f"GTIFF_RAW:{gtiff_in_dataset}"
@@ -821,7 +820,6 @@ def hfa_export_task(
     Class defining Erdas Imagine HFA (.img) export function.
     """
     result = result or {}
-    creation_options = get_creation_options(config, "hfa")
     hfa_in_dataset = parse_result(result, "source")
     provider_slug = get_provider_slug(task_uid)
     hfa_out_dataset = get_export_filename(stage_dir, job_name, projection, provider_slug, "img")
@@ -830,7 +828,6 @@ def hfa_export_task(
         input_file=hfa_in_dataset,
         output_file=hfa_out_dataset,
         task_uid=task_uid,
-        creation_options=creation_options,
     )
 
     result["file_extension"] = "img"
@@ -1770,6 +1767,7 @@ def get_creation_options(config: str, file_format: str) -> Union[list, None]:
         conf = yaml.safe_load(config) or dict()
         params = conf.get("formats", {}).get(file_format, {})
         return params.get("warp_params"), params.get("translate_params")
+    return None, None
 
 
 def make_dirs(path):

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -492,7 +492,6 @@ def get_metadata(data_provider_task_record_uids: List[str]):
                 if export_task.display and ("project file" not in export_task.name.lower()):
                     download_filename = get_download_filename(
                         os.path.splitext(os.path.basename(filename))[0],
-                        timezone.now(),
                         file_ext,
                         data_provider_slug=data_provider_task_record.provider.slug,
                     )

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -147,6 +147,7 @@ class TaskChainBuilder(object):
                         task_uid=task.get("task_uid"),
                         user_details=user_details,
                         locking_task_key=data_provider_task_record.uid,
+                        config=provider_task.provider.config,
                     )
                     .set(queue=queue_group, routing_key=queue_group)
                 )
@@ -183,6 +184,7 @@ class TaskChainBuilder(object):
                             user_details=user_details,
                             locking_task_key=data_provider_task_record.uid,
                             projection=projection,
+                            config=provider_task.provider.config,
                         ).set(queue=queue_group, routing_key=queue_group)
                     )
 

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -195,14 +195,18 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result['result'])
         self.assertEqual(expected_output_path, result['source'])
 
+    @patch('eventkit_cloud.tasks.export_tasks.get_creation_options')
     @patch('eventkit_cloud.tasks.export_tasks.get_provider_slug')
     @patch('eventkit_cloud.tasks.export_tasks.gdalutils')
-    def test_geotiff_export_task(self, mock_gdalutils, mock_get_provider_slug):
+    def test_geotiff_export_task(self, mock_gdalutils, mock_get_provider_slug, mock_get_creation_options):
         # TODO: This can be setup as a way to test the other ExportTasks without all the boilerplate.
         ExportTask.__call__ = lambda *args, **kwargs: celery.Task.__call__(*args, **kwargs)
         example_geotiff = "example.tif"
         example_result = {"source": example_geotiff}
         task_uid = '1234'
+        warp_params = {"warp": "params"}
+        translate_params = {"translate": "params"}
+        mock_get_creation_options.return_value = warp_params, translate_params
         provider_slug = mock_get_provider_slug.return_value = "osm-generic"
         date = default_format_time(timezone.now())
         expected_outfile = f"stage/job-4326-{provider_slug}-{date}.tif"
@@ -210,12 +214,14 @@ class TestExportTasks(ExportTaskBase):
         mock_gdalutils.convert.return_value = expected_outfile
         mock_gdalutils.convert.assert_called_once_with(boundary=None, fmt='gtiff',
                                                        input_file=f'GTIFF_RAW:{example_geotiff}',
-                                                       output_file=expected_outfile, task_uid=task_uid)
+                                                       output_file=expected_outfile, task_uid=task_uid,
+                                                       warp_params=warp_params, translate_params= translate_params)
         mock_gdalutils.reset_mock()
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job')
         mock_gdalutils.convert.assert_called_once_with(boundary=None, fmt='gtiff',
                                                        input_file=f'GTIFF_RAW:{example_geotiff}',
-                                                       output_file=expected_outfile, task_uid=task_uid)
+                                                       output_file=expected_outfile, task_uid=task_uid,
+                                                       warp_params=warp_params, translate_params= translate_params)
         mock_gdalutils.reset_mock()
         example_result = {"source": example_geotiff,
                           "selection": "selection"}
@@ -223,7 +229,8 @@ class TestExportTasks(ExportTaskBase):
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir='stage', job_name='job')
         mock_gdalutils.convert.assert_called_once_with(boundary="selection", fmt='gtiff',
                                                        input_file=f'GTIFF_RAW:{example_geotiff}',
-                                                       output_file=expected_outfile, task_uid=task_uid)
+                                                       output_file=expected_outfile, task_uid=task_uid,
+                                                       warp_params=warp_params, translate_params= translate_params)
 
     @patch('eventkit_cloud.tasks.export_tasks.get_provider_slug')
     @patch('eventkit_cloud.tasks.export_tasks.gdalutils')

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -367,8 +367,6 @@ def convert(
             task_uid=task_uid,
             boundary=boundary,
             bbox=bbox,
-            warp_params=warp_params,
-            translate_params=translate_params,
         )
     try:
         task_process = TaskProcess(task_uid=task_uid)

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -162,7 +162,7 @@ class TestGdalUtils(TestCase):
         get_task_command_mock.assert_called_once_with(convert_vector, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None, src_srs=in_projection,
                                                       dst_srs=in_projection, layers=None, boundary=geojson_file, bbox=None,
-                                                      task_uid=self.task_uid, translate_params=None, warp_params=None)
+                                                      task_uid=self.task_uid)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -120,7 +120,8 @@ class TestGdalUtils(TestCase):
         convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid, projection=3857)
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt, creation_options=None,
                                      band_type=band_type, dst_alpha=dstalpha, boundary=geojson_file,
-                                     src_srs=in_projection, dst_srs=out_projection, task_uid=self.task_uid)
+                                     src_srs=in_projection, dst_srs=out_projection, task_uid=self.task_uid,
+                                     translate_params=None, warp_params=None)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()
@@ -135,7 +136,8 @@ class TestGdalUtils(TestCase):
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None, band_type=band_type, dst_alpha=dstalpha,
                                                       boundary=geojson_file, src_srs=in_projection,
-                                                      dst_srs=in_projection, task_uid=self.task_uid)
+                                                      dst_srs=in_projection, task_uid=self.task_uid,
+                                                      translate_params=None, warp_params=None)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()
@@ -147,7 +149,8 @@ class TestGdalUtils(TestCase):
         get_task_command_mock.assert_called_once_with(convert_raster, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None, band_type=band_type, dst_alpha=dstalpha,
                                                       boundary=geojson_file, src_srs=in_projection,
-                                                      dst_srs=in_projection, task_uid=self.task_uid)
+                                                      dst_srs=in_projection, task_uid=self.task_uid,
+                                                      translate_params=None, warp_params=None)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()
@@ -159,7 +162,7 @@ class TestGdalUtils(TestCase):
         get_task_command_mock.assert_called_once_with(convert_vector, in_dataset, out_dataset, fmt=fmt,
                                                       creation_options=None, src_srs=in_projection,
                                                       dst_srs=in_projection, layers=None, boundary=geojson_file, bbox=None,
-                                                      task_uid=self.task_uid)
+                                                      task_uid=self.task_uid, translate_params=None, warp_params=None)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()
@@ -177,7 +180,7 @@ class TestGdalUtils(TestCase):
                                                       creation_options=extra_parameters,
                                                       band_type=band_type, dst_alpha=dstalpha, boundary=None,
                                                       src_srs=in_projection, dst_srs=out_projection,
-                                                      task_uid=self.task_uid)
+                                                      task_uid=self.task_uid, translate_params=None, warp_params=None)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()
@@ -194,7 +197,7 @@ class TestGdalUtils(TestCase):
                                                       creation_options=None,
                                                       band_type=band_type, dst_alpha=dstalpha, boundary=None,
                                                       src_srs=in_projection, dst_srs=out_projection,
-                                                      task_uid=self.task_uid)
+                                                      task_uid=self.task_uid, translate_params=None, warp_params=None)
         get_task_command_mock.reset_mock()
         self.task_process().start_process.assert_called_once_with(lambda_mock)
         self.task_process.reset_mock()
@@ -275,6 +278,20 @@ class TestGdalUtils(TestCase):
                                                     callback=progress_callback, format=fmt,
                                                     callback_data={'task_uid': task_uid, 'subtask_percentage': 50},
                                                     creationOptions=['COMPRESS=LZW', 'TILED=YES', 'BIGTIFF=YES'])
+        mock_gdal.reset_mock()
+        warp_params = {"warp": "params"}
+        translate_params = {"translate": "params"}
+        convert_raster(input_file, output_file, fmt=fmt, boundary=boundary, src_srs=srs, dst_srs=srs, task_uid=task_uid,
+                       warp_params=warp_params, translate_params=translate_params)
+        mock_gdal.Warp.assert_called_once_with(output_file, [input_file],
+                                               callback=progress_callback,
+                                               callback_data={'task_uid': task_uid, 'subtask_percentage': 50},
+                                               cropToCutline=True, cutlineDSName=boundary, format=fmt, warp="params")
+        mock_gdal.Translate.assert_called_once_with(output_file, input_file,
+                                                    callback=progress_callback, format=fmt,
+                                                    callback_data={'task_uid': task_uid, 'subtask_percentage': 50},
+                                                    translate="params")
+
 
     @patch('eventkit_cloud.utils.gdalutils.gdal')
     def test_convert_vector(self, mock_gdal):


### PR DESCRIPTION
This allows warp or translate params to be passed to providers.  It was first implemented for geotiff, but this could easily be extended to other providers in the future.  To test add a setting to the configuration for a geotiff data provider
```
formats: 
    gtiff: 
        translate_params: {"creationOptions": ["COMPRESS=JPEG", "PHOTOMETRIC=YCBCR", "TILED=YES", "BIGTIFF=YES"], "bandList": [1,2,3]}
```
Export the dataset and observe the correct change. 