### PR TITLE
Fix stuck loading screen when refreshing DataPack Library

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.tsx
@@ -198,7 +198,8 @@ export class DataPackPage extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props) {
-        if (prevProps.runsFetched === null && this.props.runsFetched) {
+        // Runs were being fetched, but now ARE fetched -- we're no longer loading.
+        if (!prevProps.runsFetched && this.props.runsFetched) {
             if (this.state.pageLoading) {
                 this.setState({pageLoading: false});
             }


### PR DESCRIPTION
A bug on the DataPack Library page broke the ability to refresh the page. The page would only work when coming from a distinct page in EventKit.