### PR TITLE
Cancel mapproxy task

### DIFF
--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -1276,8 +1276,6 @@ class RunZipFileViewSet(viewsets.ModelViewSet):
         )
         if run_zip_files:
             serializer = self.get_serializer(run_zip_files.first(), context={"request": request})
-        else:
-            serializer = self.get_serializer(filtered_run_zip_files.first(), context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -1375,6 +1375,7 @@ class DataProviderTaskRecordViewSet(viewsets.ModelViewSet):
         cancel_export_provider_task.run(
             data_provider_task_uid=data_provider_task_record.uid, canceling_username=request.user.username,
         )
+
         return Response({"success": True}, status=status.HTTP_200_OK)
 
     def list(self, request, *args, **kwargs):

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1681,6 +1681,7 @@ def cancel_export_provider_task(
 
     return result
 
+
 @app.task(name="Cancel Run", base=EventKitBaseTask)
 def cancel_run(
     result=None, export_run_uid=None, canceling_username=None, delete=False, *args, **kwargs,

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -35,6 +35,7 @@ from eventkit_cloud.core.helpers import (
 )
 
 from eventkit_cloud.feature_selection.feature_selection import FeatureSelection
+from eventkit_cloud.tasks import set_cache_value
 from eventkit_cloud.tasks.enumerations import TaskStates
 from eventkit_cloud.tasks.exceptions import CancelException, DeleteException
 from eventkit_cloud.tasks.helpers import (
@@ -372,13 +373,14 @@ class ZipFileTask(FormatTask):
         else:
             data_provider_task_record_uids = kwargs["data_provider_task_record_uids"]
 
-        data_provider_task_records = DataProviderTaskRecord.objects.filter(uid__in=data_provider_task_record_uids)
-        downloadable_file = FileProducingTaskResult.objects.get(id=retval["file_producing_task_result_id"])
-        run_zip_file.downloadable_file = downloadable_file
-        run_zip_file.data_provider_task_records.set(data_provider_task_records)
-        run_zip_file.finished_at = timezone.now()
-        run_zip_file.message = "Completed"
-        run_zip_file.save()
+        if retval.get("file_producing_task_result_id"):
+            data_provider_task_records = DataProviderTaskRecord.objects.filter(uid__in=data_provider_task_record_uids)
+            downloadable_file = FileProducingTaskResult.objects.get(id=retval["file_producing_task_result_id"])
+            run_zip_file.downloadable_file = downloadable_file
+            run_zip_file.data_provider_task_records.set(data_provider_task_records)
+            run_zip_file.finished_at = timezone.now()
+            run_zip_file.message = "Completed"
+            run_zip_file.save()
         return retval
 
 
@@ -1665,6 +1667,11 @@ def cancel_export_provider_task(
                 routing_key="{0}.priority".format(export_task.worker),
             )
 
+        # Add canceled to the cache so processes can check in to see if they should abort.
+        set_cache_value(
+            uid=export_task.uid, attribute="status", model_name="ExportTaskRecord", value=TaskStates.CANCELED.value,
+        )
+
     if TaskStates[data_provider_task_record.status] not in TaskStates.get_finished_states():
         if error:
             data_provider_task_record.status = TaskStates.FAILED.value
@@ -1673,7 +1680,6 @@ def cancel_export_provider_task(
     data_provider_task_record.save()
 
     return result
-
 
 @app.task(name="Cancel Run", base=EventKitBaseTask)
 def cancel_run(

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1213,6 +1213,7 @@ def create_zip_task(
     :param data_provider_task_record_uids: A list of data provider task record UIDs to zip.
     :return: The run files, or a single zip file if data_provider_task_record_uid is passed.
     """
+
     if not result:
         result = {}
 

--- a/eventkit_cloud/tasks/models.py
+++ b/eventkit_cloud/tasks/models.py
@@ -361,3 +361,11 @@ class RunZipFile(UIDMixin, TimeStampedModelMixin, TimeTrackingModelMixin):
     @message.setter
     def message(self, value, expiration=DEFAULT_CACHE_EXPIRATION):
         return set_cache_value(obj=self, attribute="message", value=value, expiration=expiration)
+
+    @property
+    def status(self):
+        return get_cache_value(obj=self, attribute="status", default="")
+
+    @status.setter
+    def status(self, value, expiration=DEFAULT_CACHE_EXPIRATION):
+        return set_cache_value(obj=self, attribute="status", value=value, expiration=expiration)

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
@@ -80,11 +80,10 @@ const jss = (theme: Eventkit.Theme & Theme) => ({
 
 interface Props {
     fontSize: string;  // Pass through font size to be consistent with parent.
-    classes: { [className: string]: string; }
+    classes: { [className: string]: string; };
     providerTaskUids: string[];
     theme: Eventkit.Theme & Theme;
 }
-
 
 function CreateDataPackButton(props: Props) {
     const {fontSize, providerTaskUids, classes, theme} = props;
@@ -104,7 +103,7 @@ function CreateDataPackButton(props: Props) {
     const requestOptions = {
         url: `/api/runs/zipfiles`,
         headers: {'X-CSRFToken': getCookie('csrftoken')},
-    }
+    };
     const [{status: zipAvailableStatus, response: zipAvailableResponse}, zipAvailAbleCall, clearZipAvailable] = useAsyncRequest();
     const checkZipAvailable = () => {
         // Returned promise is ignored, we don't need it.
@@ -159,11 +158,11 @@ function CreateDataPackButton(props: Props) {
                 !isZipAvailable()
             ) {
                 // Request completed, check to see if we're already at the limit for bad responses
-                if (badResponseCount >= 2) {
+                if (badResponseCount >= 3) {
                     setBadResponse(true);
                 } else {
                     // Deal with bad responses, increase the count.
-                    if (!zipAvailableResponse.data.length || zipAvailableStatus === ApiStatuses.hookActions.SUCCESS) {
+                    if (!zipAvailableResponse.data.length) {
                         setBadResponseCount(count => count + 1);
                     }
                     // Set a time out to re-poll for the status of the zip after five seconds.
@@ -177,7 +176,7 @@ function CreateDataPackButton(props: Props) {
             if (timeoutId) {
                 clearTimeout(timeoutId);
             }
-        }
+        };
     }, [zipAvailableStatus]);
 
     function isRunCompleted() {
@@ -196,9 +195,8 @@ function CreateDataPackButton(props: Props) {
         return zipAvailableStatus === ApiStatuses.hookActions.SUCCESS &&
             zipAvailableResponse.data.length &&
             zipAvailableResponse.data[0].status && (
-                [ApiStatuses.files.PENDING,
-                    ApiStatuses.files.RUNNING].includes(zipAvailableResponse.data[0].status as FileStatus)
-            )
+                ApiStatuses.inProgressStates.includes(zipAvailableResponse.data[0].status as FileStatus)
+            );
     }
 
     function isZipAvailable() {
@@ -213,17 +211,16 @@ function CreateDataPackButton(props: Props) {
         // We do this to prevent the text from rapidly flickering between different states when we fire
         // off a request.
         if (
-            zipAvailableStatus === ApiStatuses.hookActions.FETCHING ||
-            requestZipFileStatus === ApiStatuses.hookActions.FETCHING
+            (zipAvailableStatus === ApiStatuses.hookActions.FETCHING) ||
+            (requestZipFileStatus === ApiStatuses.hookActions.FETCHING)
         ) {
             if (previousFrameText.current === '') {
-                previousFrameText.current = 'Processing Zip...'
+                previousFrameText.current = 'Processing Zip...';
             }
             return previousFrameText.current;
         }
-
-        if(isRunCanceled()){
-            return 'Zip Canceled'
+        if (isRunCanceled()) {
+            return 'Zip Canceled';
         }
         if (!isRunCompleted()) {
             return 'Job Processing...';
@@ -233,8 +230,6 @@ function CreateDataPackButton(props: Props) {
         }
         if (badResponse) {
             return 'Zip Error';
-        } else if (!!zipAvailableResponse && zipAvailableResponse.status === 'PENDING') {
-            return 'Processing Zip...';
         }
         if (requestZipFileStatus === ApiStatuses.hookActions.NOT_FIRED) {
             return 'CREATE DATAPACK (.ZIP)';
@@ -247,16 +242,22 @@ function CreateDataPackButton(props: Props) {
 
     function getPopoverMessage() {
         if (!isRunCompleted()) {
-            return 'The DataPack is being built. Downloads will be available for request upon completion.'
+            return 'The DataPack is being built. Downloads will be available for request upon completion.';
         }
         if (badResponse) {
-            return 'Could not retrieve zip information, please try again or contact an administrator.'
+            return 'Could not retrieve zip information, please try again or contact an administrator.';
         }
-        if (buttonText === 'Processing Zip...') {
-            if (zipIsProcessing()) {
-                return zipAvailableResponse.data[0].message;
-            }
-            return 'Processing zip file.'
+        if (isRunCanceled()) {
+            return (
+                <p>
+                    The datapack was canceled, so no zip is available. You can Rerun the datapack,
+                    to generate the files. If you don't have permission to rerun you can clone this
+                    datapack to generate the files.
+                </p>
+            );
+        }
+        if (zipIsProcessing()) {
+            return zipAvailableResponse.data[0].message || 'Processing zip file.';
         }
         return '';
     }
@@ -274,6 +275,7 @@ function CreateDataPackButton(props: Props) {
         }
         return isRunCompleted() && requestZipFileStatus === ApiStatuses.hookActions.NOT_FIRED;
     }
+
     const buttonEnabled = shouldEnableButton();
 
     const [displayCreatingMessage, setDisplayCreatingMessage] = useState(false);
@@ -298,19 +300,19 @@ function CreateDataPackButton(props: Props) {
                 fill: colors.primary
             },
             className: 'qa-DataPack-button-enabled',
-        }
+        };
         if (!buttonEnabled) {
             iconProps = {
                 style: {fill: colors.white, color: colors.primary},
                 className: 'qa-DataPack-button-disabled"',
-            }
+            };
         }
         iconProps.style = {
             ...iconProps.style,
             ...{
                 verticalAlign: 'middle', marginRight: '5px',
             },
-        }
+        };
         let IconComponent: React.ComponentType<any> = CloudDownload;
         if (badResponse) {
             // This case controls for when we get no response back at all, usually an empty array.
@@ -319,7 +321,7 @@ function CreateDataPackButton(props: Props) {
             iconProps.style = {
                 ...iconProps.style,
                 fill: colors.warning,
-            }
+            };
         } else if (!isRunCompleted() ||
             zipAvailableStatus === ApiStatuses.hookActions.FETCHING ||
             zipIsProcessing() ||
@@ -343,7 +345,7 @@ function CreateDataPackButton(props: Props) {
                 className={`qa-CreateDataPackButton-Button-zipButton`}
                 classes={{root: (buttonEnabled) ? classes.button : classes.buttonDisabled}}
                 disabled={!buttonEnabled}
-                style={{fontSize: fontSize, lineHeight: 'initial', width: '250px'}}
+                style={{fontSize, lineHeight: 'initial', width: '250px'}}
                 onClick={buttonAction}
                 {...(() => {
                     // If the zip file is available, set the href of the button to the URL.
@@ -351,7 +353,7 @@ function CreateDataPackButton(props: Props) {
                     if (isZipAvailable()) {
                         extraProps.href = zipAvailableResponse.data[0].url;
                     }
-                    return extraProps
+                    return extraProps;
                 })()}
             >
                 {!buttonEnabled && (
@@ -390,7 +392,6 @@ function CreateDataPackButton(props: Props) {
                                         DataPack (.ZIP) ready for download.
                                     </p>
                                 )}
-
                             </div>
                         </div>
                     </CenteredPopup>
@@ -447,8 +448,7 @@ function CreateDataPackButton(props: Props) {
                 </div>
             </InfoDialog>
         </div>
-    )
+    );
 }
-
 
 export default withTheme()(withStyles(jss)(CreateDataPackButton));

--- a/eventkit_cloud/ui/static/ui/app/utils/hooks/api.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/hooks/api.ts
@@ -26,7 +26,8 @@ export class ApiStatuses {
     static readonly hookActions = ACTIONS;
     static readonly files = FileStatus;
     static readonly finishedStates = [FileStatus.COMPLETED, FileStatus.INCOMPLETE, FileStatus.CANCELED,
-        FileStatus.SUCCESS, FileStatus.FAILED]
+        FileStatus.SUCCESS, FileStatus.FAILED];
+    static readonly inProgressStates = [FileStatus.PENDING, FileStatus.RUNNING, FileStatus.SUBMITTED];
 }
 
 interface RequestState {

--- a/eventkit_cloud/ui/static/ui/app/utils/hooks/api.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/hooks/api.ts
@@ -10,16 +10,23 @@ export enum ACTIONS {
     NOT_FIRED='not_fired',
 }
 
-enum FileStatus {
-    PENDING='PENDING',
-    RUNNING='RUNNING',
-    SUCCESS='SUCCESS',
-    FAILED='FAILED',
+export enum FileStatus {
+    COMPLETED = "COMPLETED",  // Used for runs when all tasks were successful
+    INCOMPLETE = "INCOMPLETE",  // Used for runs when one or more tasks were unsuccessful
+    SUBMITTED = "SUBMITTED",  // Used for runs that have not been started
+
+    PENDING = "PENDING",  // Used for tasks that have not been started
+    RUNNING = "RUNNING", // Used for tasks that have been started
+    CANCELED = "CANCELED",  // Used for tasks that have been CANCELED by the user
+    SUCCESS = "SUCCESS",  // Used for tasks that have successfully completed
+    FAILED = "FAILED"
 }
 
 export class ApiStatuses {
     static readonly hookActions = ACTIONS;
     static readonly files = FileStatus;
+    static readonly finishedStates = [FileStatus.COMPLETED, FileStatus.INCOMPLETE, FileStatus.CANCELED,
+        FileStatus.SUCCESS, FileStatus.FAILED]
 }
 
 interface RequestState {

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -17,6 +17,8 @@ from mapproxy.seed.util import ProgressLog, exp_backoff, timestamp, ProgressStor
 from mapproxy.wsgiapp import MapProxyApp
 from webtest import TestApp
 from eventkit_cloud.core.helpers import get_cached_model
+from eventkit_cloud.tasks import get_cache_value
+from eventkit_cloud.tasks.enumerations import TaskStates
 
 import os
 import sqlite3
@@ -53,6 +55,10 @@ class CustomLogger(ProgressLog):
         # better eta estimates
 
         if self.task_uid:
+            if get_cache_value(uid=self.task_uid, attribute="status", model_name="ExportTaskRecord") == TaskStates.CANCELED.value:
+                logger.error(f"The task uid: {self.task_uid} was canceled. Exiting...")
+                exit(1)
+
             if self.log_step_counter == 0:
                 update_progress(self.task_uid, progress=progress.progress * 100, eta=self.eta)
                 self.log_step_counter = self.log_step_step
@@ -64,18 +70,21 @@ class CustomLogger(ProgressLog):
             return
         if (self._laststep + 0.5) < time.time():
             # log progress at most every 500ms
-            self.out.write(
-                "[%s] %6.2f%%\t%-20s ETA: %s\r"
-                % (timestamp(), progress.progress * 100, progress.progress_str, self.eta,)
+            logger.info(
+                f"[{timestamp()}] {progress.progress * 100:6.2f}%\t{progress.progress_str.ljust(20)} ETA: {self.eta}\r"
             )
-            self.out.flush()
+            # [12:24:08] 100.00%     000000               ETA: 2020-08-06-12:22:30-UTC
             self._laststep = time.time()
 
 
-def get_custom_exp_backoff(max_repeat=None):
+def get_custom_exp_backoff(max_repeat=None, task_uid=None):
     def custom_exp_backoff(*args, **kwargs):
         if max_repeat:
             kwargs["max_repeat"] = max_repeat
+        if get_cache_value(uid=task_uid, attribute="status",
+                           model_name="ExportTaskRecord") == TaskStates.CANCELED.value:
+            logger.error(f"The task uid: {task_uid} was canceled. Exiting...")
+            exit(1)
         exp_backoff(*args, **kwargs)
 
     return custom_exp_backoff
@@ -202,7 +211,8 @@ class MapproxyGeopackage(object):
 
         conf_dict, seed_configuration, mapproxy_configuration = self.get_check_config()
         #  Customizations...
-        mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(max_repeat=int(conf_dict.get("max_repeat", 5)))
+        mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(max_repeat=int(conf_dict.get("max_repeat", 5)),
+                                                                  task_uid=self.task_uid)
 
         logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -55,14 +55,15 @@ class CustomLogger(ProgressLog):
         # better eta estimates
 
         if self.task_uid:
-            if (
-                get_cache_value(uid=self.task_uid, attribute="status", model_name="ExportTaskRecord")
-                == TaskStates.CANCELED.value
-            ):
-                logger.error(f"The task uid: {self.task_uid} was canceled. Exiting...")
-                exit(1)
 
             if self.log_step_counter == 0:
+                if (
+                    get_cache_value(uid=self.task_uid, attribute="status", model_name="ExportTaskRecord")
+                    == TaskStates.CANCELED.value
+                ):
+                    logger.error(f"The task uid: {self.task_uid} was canceled. Exiting...")
+                    raise Exception("The task was canceled.")
+
                 update_progress(self.task_uid, progress=progress.progress * 100, eta=self.eta)
                 self.log_step_counter = self.log_step_step
             self.log_step_counter -= 1
@@ -89,7 +90,7 @@ def get_custom_exp_backoff(max_repeat=None, task_uid=None):
             == TaskStates.CANCELED.value
         ):
             logger.error(f"The task uid: {task_uid} was canceled. Exiting...")
-            exit(1)
+            raise Exception("The task was canceled.")
         exp_backoff(*args, **kwargs)
 
     return custom_exp_backoff

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -55,7 +55,10 @@ class CustomLogger(ProgressLog):
         # better eta estimates
 
         if self.task_uid:
-            if get_cache_value(uid=self.task_uid, attribute="status", model_name="ExportTaskRecord") == TaskStates.CANCELED.value:
+            if (
+                get_cache_value(uid=self.task_uid, attribute="status", model_name="ExportTaskRecord")
+                == TaskStates.CANCELED.value
+            ):
                 logger.error(f"The task uid: {self.task_uid} was canceled. Exiting...")
                 exit(1)
 
@@ -81,8 +84,10 @@ def get_custom_exp_backoff(max_repeat=None, task_uid=None):
     def custom_exp_backoff(*args, **kwargs):
         if max_repeat:
             kwargs["max_repeat"] = max_repeat
-        if get_cache_value(uid=task_uid, attribute="status",
-                           model_name="ExportTaskRecord") == TaskStates.CANCELED.value:
+        if (
+            get_cache_value(uid=task_uid, attribute="status", model_name="ExportTaskRecord")
+            == TaskStates.CANCELED.value
+        ):
             logger.error(f"The task uid: {task_uid} was canceled. Exiting...")
             exit(1)
         exp_backoff(*args, **kwargs)
@@ -211,8 +216,9 @@ class MapproxyGeopackage(object):
 
         conf_dict, seed_configuration, mapproxy_configuration = self.get_check_config()
         #  Customizations...
-        mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(max_repeat=int(conf_dict.get("max_repeat", 5)),
-                                                                  task_uid=self.task_uid)
+        mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(
+            max_repeat=int(conf_dict.get("max_repeat", 5)), task_uid=self.task_uid
+        )
 
         logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:


### PR DESCRIPTION
Fixes canceling mapproxy tasks.  Additionally some fixes for zipfile status were added, and slight changes to the createzipfilebutton component. 

To test create a mapproxy task and ensure that when you cancel the task it stops the process on the backend and properly reports it canceled.  Additionally ensure that if ALL of the tasks are canceled the zip file button gives a proper status and message. 