### PR TITLE
Add size to download button

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
@@ -206,18 +206,19 @@ function CreateDataPackButton(props: Props) {
             zipAvailableResponse.data[0].status === ApiStatuses.files.SUCCESS;
     }
 
-    const previousFrameText = useRef('');
+    const previousFrameText = useRef((<></>));
 
     function getButtonText() {
         const sizeText = (props.zipSize) ? formatMegaBytes(props.zipSize, 1) + ' ' : '';
+        const zipText = (<span style={{whiteSpace: 'nowrap'}}>({sizeText}.ZIP)</span>)
         // We do this to prevent the text from rapidly flickering between different states when we fire
         // off a request.
         if (
             (zipAvailableStatus === ApiStatuses.hookActions.FETCHING) ||
             (requestZipFileStatus === ApiStatuses.hookActions.FETCHING)
         ) {
-            if (previousFrameText.current === '') {
-                previousFrameText.current = 'Processing Zip...';
+            if (previousFrameText.current === (<></>)) {
+                previousFrameText.current = (<>'Processing Zip...'</>);
             }
             return previousFrameText.current;
         }
@@ -228,18 +229,18 @@ function CreateDataPackButton(props: Props) {
             return 'Job Processing...';
         }
         if (isZipAvailable()) {
-            return `DOWNLOAD DATAPACK (${sizeText}.ZIP)`;
+            return (<>DOWNLOAD DATAPACK {zipText}</>);
         }
         if (badResponse) {
             return 'Zip Error';
         }
         if (requestZipFileStatus === ApiStatuses.hookActions.NOT_FIRED) {
-            return `CREATE DATAPACK (${sizeText}.ZIP)`;
+            return (<>CREATE DATAPACK {zipText}</>);
         }
         return 'Processing Zip...';
     }
 
-    const buttonText = getButtonText();
+    const buttonText = (<>{getButtonText()}</>);
     previousFrameText.current = buttonText;
 
     function getPopoverMessage() {
@@ -327,7 +328,7 @@ function CreateDataPackButton(props: Props) {
         } else if (!isRunCompleted() ||
             zipAvailableStatus === ApiStatuses.hookActions.FETCHING ||
             zipIsProcessing() ||
-            buttonText === 'Processing Zip...'
+            buttonText === (<>'Processing Zip...'</>)
         ) {
             IconComponent = CircularProgress;
             iconProps.size = 18;
@@ -347,7 +348,7 @@ function CreateDataPackButton(props: Props) {
                 className={`qa-CreateDataPackButton-Button-zipButton`}
                 classes={{root: (buttonEnabled) ? classes.button : classes.buttonDisabled}}
                 disabled={!buttonEnabled}
-                style={{fontSize, lineHeight: 'initial', width: '250px'}}
+                style={{fontSize, lineHeight: 'initial', width: 'max-content'}}
                 onClick={buttonAction}
                 {...(() => {
                     // If the zip file is available, set the href of the button to the URL.

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
@@ -4,7 +4,7 @@ import InfoDialog from "../Dialog/InfoDialog";
 import {Theme, withStyles, withTheme} from "@material-ui/core/styles";
 import CloudDownload from "@material-ui/icons/CloudDownload";
 import {useAsyncRequest, ApiStatuses} from "../../utils/hooks/api";
-import {getCookie} from "../../utils/generic";
+import {formatMegaBytes, getCookie} from "../../utils/generic";
 import {useRunContext} from "./RunFileContext";
 import {useEffect, useRef, useState} from "react";
 import {DepsHashers, usePrevious} from "../../utils/hooks/hooks";
@@ -79,6 +79,7 @@ const jss = (theme: Eventkit.Theme & Theme) => ({
 });
 
 interface Props {
+    zipSize: number;
     fontSize: string;  // Pass through font size to be consistent with parent.
     classes: { [className: string]: string; }
     providerTaskUids: string[];
@@ -205,6 +206,7 @@ function CreateDataPackButton(props: Props) {
     const previousFrameText = useRef('');
 
     function getButtonText() {
+        const sizeText = (props.zipSize) ? formatMegaBytes(props.zipSize, 1) + ' ' : '';
         // We do this to prevent the text from rapidly flickering between different states when we fire
         // off a request.
         if (
@@ -220,7 +222,7 @@ function CreateDataPackButton(props: Props) {
             return 'Job Processing...';
         }
         if (isZipAvailable()) {
-            return 'DOWNLOAD DATAPACK (.ZIP)';
+            return `DOWNLOAD DATAPACK (${sizeText}.ZIP)`;
         }
         if (badResponse) {
             return 'Zip Error';
@@ -228,7 +230,7 @@ function CreateDataPackButton(props: Props) {
             return 'Processing Zip...';
         }
         if (requestZipFileStatus === ApiStatuses.hookActions.NOT_FIRED) {
-            return 'CREATE DATAPACK (.ZIP)';
+            return `CREATE DATAPACK (${sizeText}.ZIP)`;
         }
         return 'Processing Zip...';
     }

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.tsx
@@ -219,11 +219,20 @@ export class DataPackDetails extends React.Component<Props, State> {
                         this.props.providerTasks.filter(
                             providerTask => shouldDisplay(providerTask)
                         ).map(providerTask => {
+                            // Use the zip task if it exists, otherwise calc based on all available.
                             const zipTask = providerTask.tasks.find(task => task.name === ZIP_TASK_NAME);
-                            if (!!zipTask) {
+                            if (!!zipTask && !!zipTask.result.size) {
                                 return Number(zipTask.result.size.replace(' MB', ''));
                             }
-                            return 0;
+                            let fileSize = 0;
+                            providerTask.tasks.forEach((task) => {
+                                if (task.result != null) {
+                                    if (task.display !== false && task.result.size) {
+                                        fileSize = fileSize + Number(task.result.size.replace(' MB', ''));
+                                    }
+                                }
+                            });
+                            return fileSize;
                         })}
                     setFileSize={(value: number) => this.setState({zipSize: value})}
                 />

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/CreateDataPackButton.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/CreateDataPackButton.spec.tsx
@@ -54,11 +54,11 @@ describe('CreateDataPackButton component', () => {
                 }
             }
         });
-        expect(wrapper.find(Button).html()).toContain('CREATE DATAPACK (.ZIP)');
+        expect(wrapper.find(Button).html()).toContain('CREATE DATAPACK');
     });
 
     it('should display create text by default when job is done.', () => {
-        expect(wrapper.find(Button).html()).toContain('CREATE DATAPACK (.ZIP)');
+        expect(wrapper.find(Button).html()).toContain('CREATE DATAPACK');
     });
 
     it('should disable button after click and render fake button.', () => {

--- a/eventkit_cloud/ui/static/ui/app/utils/generic.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/generic.ts
@@ -131,7 +131,7 @@ export function getDuration(seconds, capEstimate = true) {
     return `${days}${hours}${minutes}`;
 }
 
-export function formatMegaBytes(megabytes) {
+export function formatMegaBytes(megabytes, digits=2) {
     // format a size so that it is reasonably displayed.
     // megabytes = 40 => 40 MB
     // megabytes = 1337 => 1.34 GB
@@ -141,7 +141,7 @@ export function formatMegaBytes(megabytes) {
     while (mb / (10 ** ((order + 1) * 3)) >= 1) {
         order += 1;
     }
-    return `${Number(mb / (10 ** (order * 3))).toFixed(2)} ${units[order]}`;
+    return `${Number(mb / (10 ** (order * 3))).toFixed(digits)} ${units[order]}`;
 }
 
 export function getCookie(name) {

--- a/eventkit_cloud/ui/static/ui/app/utils/hooks/hooks.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/hooks/hooks.ts
@@ -64,12 +64,13 @@ export class DepsHashers {
 
     private static readonly emptyEstimate = DepsHashers.stringHash('-1:-1');
 
-    static stringHash(value: string): number {
+    static stringHash(value: string | number): number {
         let h;
-        if (value) {
-            for (let i = 0; i < value.length; i += 1) {
+        if (!!value || value === 0) {
+            let valueToString = value.toString();
+            for (let i = 0; i < valueToString.length; i += 1) {
                 // eslint-disable-next-line no-bitwise
-                h = Math.imul(31, h) + value.charCodeAt(i) | 0;
+                h = Math.imul(31, h) + valueToString.charCodeAt(i) | 0;
             }
             return h;
         }


### PR DESCRIPTION
Adds the cumulative size of the data pack to the download button on the Status and Download page.

![image](https://user-images.githubusercontent.com/50183410/90044399-9705c200-dc9b-11ea-96cb-247c56477942.png)
