### PR TITLE
Remove duplicate JSON keys in RegionalPolicy

### DIFF
--- a/eventkit_cloud/jobs/examples/justification_options_example.json
+++ b/eventkit_cloud/jobs/examples/justification_options_example.json
@@ -1,30 +1,28 @@
-{
-    "justification_options": [
-        {
-            "id": 1,
-            "name": "Justification Option with Dropdown Suboption",
-            "display": true,
-            "suboption": {
-                "type": "dropdown",
-                "options": [
-                    "Option 1",
-                    "Option 2"
-                ]
-            }
-        },
-        {
-            "id": 2,
-            "name": "Justification Option with Text Suboption",
-            "display": true,
-            "suboption": {
-                "type": "text",
-                "label": "Label"
-            }
-        },
-        {
-            "id": 3,
-            "name": "Justification Option without Suboption",
-            "display": true
+[
+    {
+        "id": 1,
+        "name": "Justification Option with Dropdown Suboption",
+        "display": true,
+        "suboption": {
+            "type": "dropdown",
+            "options": [
+                "Option 1",
+                "Option 2"
+            ]
         }
-    ]
-}
+    },
+    {
+        "id": 2,
+        "name": "Justification Option with Text Suboption",
+        "display": true,
+        "suboption": {
+            "type": "text",
+            "label": "Label"
+        }
+    },
+    {
+        "id": 3,
+        "name": "Justification Option without Suboption",
+        "display": true
+    }
+]

--- a/eventkit_cloud/jobs/examples/policies_example.json
+++ b/eventkit_cloud/jobs/examples/policies_example.json
@@ -1,12 +1,10 @@
-{
-    "policies": [
-        {
-            "title": "Policy A Title",
-            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et nulla sollicitudin, malesuada lectus vitae, imperdiet lorem. Morbi egestas, lectus non ultrices pretium, mi leo egestas purus, sit amet varius felis tortor sed lorem. Integer in lacus ut lectus rhoncus condimentum. Cras vel elementum sapien. Aenean tristique imperdiet tortor non sollicitudin. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec et porttitor diam. Praesent interdum felis quis gravida varius. Praesent quis risus eu tortor posuere egestas. In justo eros, eleifend non purus vel, pellentesque bibendum mauris. Phasellus accumsan nibh a felis rhoncus efficitur. Praesent malesuada suscipit sem eget fringilla. Mauris aliquam sit amet mi vitae fringilla."
-        },
-        {
-            "title": "Policy B Title",
-            "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras blandit risus quis dolor imperdiet, sed elementum enim ullamcorper. Donec at erat vestibulum, pharetra nibh porttitor, iaculis nisl. Mauris finibus tincidunt luctus. Donec consectetur eget massa pretium sagittis. Praesent nec semper ante. Ut feugiat suscipit pellentesque. In orci orci, ornare condimentum dui eget, rutrum tempor quam. Vivamus venenatis ante ut odio lacinia luctus. In eros lorem, mollis ut euismod sed, lobortis ac ligula. Pellentesque ut ex magna. Curabitur dictum tempor magna quis commodo. Etiam a efficitur urna. Donec feugiat nunc non porta mollis. Proin a elit placerat, euismod sem non, vehicula tortor."
-        }
-    ]
-}
+[
+    {
+        "title": "Policy A Title",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et nulla sollicitudin, malesuada lectus vitae, imperdiet lorem. Morbi egestas, lectus non ultrices pretium, mi leo egestas purus, sit amet varius felis tortor sed lorem. Integer in lacus ut lectus rhoncus condimentum. Cras vel elementum sapien. Aenean tristique imperdiet tortor non sollicitudin. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec et porttitor diam. Praesent interdum felis quis gravida varius. Praesent quis risus eu tortor posuere egestas. In justo eros, eleifend non purus vel, pellentesque bibendum mauris. Phasellus accumsan nibh a felis rhoncus efficitur. Praesent malesuada suscipit sem eget fringilla. Mauris aliquam sit amet mi vitae fringilla."
+    },
+    {
+        "title": "Policy B Title",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras blandit risus quis dolor imperdiet, sed elementum enim ullamcorper. Donec at erat vestibulum, pharetra nibh porttitor, iaculis nisl. Mauris finibus tincidunt luctus. Donec consectetur eget massa pretium sagittis. Praesent nec semper ante. Ut feugiat suscipit pellentesque. In orci orci, ornare condimentum dui eget, rutrum tempor quam. Vivamus venenatis ante ut odio lacinia luctus. In eros lorem, mollis ut euismod sed, lobortis ac ligula. Pellentesque ut ex magna. Curabitur dictum tempor magna quis commodo. Etiam a efficitur urna. Donec feugiat nunc non porta mollis. Proin a elit placerat, euismod sem non, vehicula tortor."
+    }
+]

--- a/eventkit_cloud/jobs/forms.py
+++ b/eventkit_cloud/jobs/forms.py
@@ -33,17 +33,12 @@ class RegionalPolicyForm(forms.ModelForm):
 
         self.previous_justification_option_ids = []
         if self.instance.justification_options:
-            for previous_justification_option in self.instance.justification_options["justification_options"]:
+            for previous_justification_option in self.instance.justification_options:
                 previous_option_id = previous_justification_option.get("id")
                 self.previous_justification_option_ids.append(previous_option_id)
 
     def clean_policies(self):
-        # Both the field name and JSON object are named policies.
-        data = self.cleaned_data["policies"]
-        policies = data.get("policies")
-
-        if not policies:
-            raise ValidationError("Must include policies object, please see the example above.")
+        policies = self.cleaned_data["policies"]
 
         for policy in policies:
             title = policy.get("title")
@@ -54,16 +49,10 @@ class RegionalPolicyForm(forms.ModelForm):
             if not description:
                 raise ValidationError("Every policy must have a description.")
 
-        return data
+        return policies
 
     def clean_justification_options(self):
-        # Both the field name and JSON object are named justification_options.
-        data = self.cleaned_data["justification_options"]
-        justification_options = data.get("justification_options")
-
-        if not justification_options:
-            raise ValidationError("Must include justification_options object, please see the example above.")
-
+        justification_options = self.cleaned_data["justification_options"]
         justification_option_ids = []
 
         for justification_option in justification_options:
@@ -110,4 +99,4 @@ class RegionalPolicyForm(forms.ModelForm):
                     "Please do not remove options, set display to false instead."
                 )
 
-        return self.cleaned_data["justification_options"]
+        return justification_options

--- a/eventkit_cloud/jobs/tests/test_forms.py
+++ b/eventkit_cloud/jobs/tests/test_forms.py
@@ -4,77 +4,50 @@ from eventkit_cloud.jobs.forms import RegionalPolicyForm
 
 
 class TestRegionalPolicyForm(TestCase):
-    def test_no_policies(self):
-        form = RegionalPolicyForm(data={"policies": {"not_policies": "no_policy"}})
-
-        self.assertEqual(form.errors["policies"], ["Must include policies object, please see the example above."])
-
     def test_policy_no_title(self):
-        form = RegionalPolicyForm(data={"policies": {"policies": [{"description": "description"}]}})
+        form = RegionalPolicyForm(data={"policies": [{"description": "description"}]})
 
         self.assertEqual(form.errors["policies"], ["Every policy must have a title."])
 
     def test_policy_no_description(self):
-        form = RegionalPolicyForm(data={"policies": {"policies": [{"title": "title"}]}})
+        form = RegionalPolicyForm(data={"policies": [{"title": "title"}]})
 
         self.assertEqual(form.errors["policies"], ["Every policy must have a description."])
 
-    def test_no_justification_options(self):
-        form = RegionalPolicyForm(data={"justification_options": {"no_options": "no_options"}})
-
-        self.assertEqual(
-            form.errors["justification_options"],
-            ["Must include justification_options object, please see the example above."],
-        )
-
     def test_justification_options_missing_id(self):
-        form = RegionalPolicyForm(
-            data={"justification_options": {"justification_options": [{"name": "name", "display": True,}]}}
-        )
+        form = RegionalPolicyForm(data={"justification_options": [{"name": "name", "display": True,}]})
 
         self.assertEqual(form.errors["justification_options"], ["Every option must have an id."])
 
     def test_justification_options_invalid_id(self):
-        form = RegionalPolicyForm(
-            data={"justification_options": {"justification_options": [{"id": "id", "name": "name", "display": True,}]}}
-        )
+        form = RegionalPolicyForm(data={"justification_options": [{"id": "id", "name": "name", "display": True}]})
 
         self.assertEqual(form.errors["justification_options"], ["id value must be an integer."])
 
     def test_justification_options_missing_name(self):
-        form = RegionalPolicyForm(data={"justification_options": {"justification_options": [{"id": 1, "display": True,}]}})
+        form = RegionalPolicyForm(data={"justification_options": [{"id": 1, "display": True}]})
 
         self.assertEqual(form.errors["justification_options"], ["Every option must have a name."])
 
     def test_justification_options_invalid_name(self):
-        form = RegionalPolicyForm(
-            data={"justification_options": {"justification_options": [{"id": 1, "name": 1, "display": True,}]}}
-        )
+        form = RegionalPolicyForm(data={"justification_options": [{"id": 1, "name": 1, "display": True}]})
 
         self.assertEqual(form.errors["justification_options"], ["name value must be a string."])
 
     def test_justification_options_missing_display(self):
-        form = RegionalPolicyForm(data={"justification_options": {"justification_options": [{"id": 1, "name": "name",}]}})
+        form = RegionalPolicyForm(data={"justification_options": [{"id": 1, "name": "name",}]})
 
         self.assertEqual(form.errors["justification_options"], ["Every option must have a display boolean."])
 
     def test_justification_options_invalid_display(self):
-        form = RegionalPolicyForm(
-            data={
-                "justification_options": {"justification_options": [{"id": 1, "name": "name", "display": "display",}]}
-            }
-        )
+        form = RegionalPolicyForm(data={"justification_options": [{"id": 1, "name": "name", "display": "display",}]})
 
         self.assertEqual(form.errors["justification_options"], ["Display value must be a boolean."])
 
     def test_justification_options_suboption_invalid_type(self):
         form = RegionalPolicyForm(
             data={
-                "justification_options": {
-                    "justification_options": [
-                        {"id": 1, "name": "name", "display": False, "suboption": {"type": "invalid"}}
-                    ]
-                }
+                "justification_options": [{"id": 1, "name": "name", "display": False, "suboption": {"type": "invalid"}}]
             }
         )
 
@@ -85,11 +58,9 @@ class TestRegionalPolicyForm(TestCase):
     def test_justification_options_suboption_missing_options(self):
         form = RegionalPolicyForm(
             data={
-                "justification_options": {
-                    "justification_options": [
-                        {"id": 1, "name": "name", "display": False, "suboption": {"type": "dropdown"}}
-                    ]
-                }
+                "justification_options": [
+                    {"id": 1, "name": "name", "display": False, "suboption": {"type": "dropdown"}}
+                ]
             }
         )
 
@@ -100,13 +71,7 @@ class TestRegionalPolicyForm(TestCase):
 
     def test_justification_options_suboption_missing_label(self):
         form = RegionalPolicyForm(
-            data={
-                "justification_options": {
-                    "justification_options": [
-                        {"id": 1, "name": "name", "display": False, "suboption": {"type": "text"}}
-                    ]
-                }
-            }
+            data={"justification_options": [{"id": 1, "name": "name", "display": False, "suboption": {"type": "text"}}]}
         )
 
         self.assertEqual(


### PR DESCRIPTION
This PR cleans up the API response for regional policies.  It removes some unnecessary duplicate keys and refactors the tests to match.  