### PR TITLE
clean up near black pixels

### DIFF
--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -229,6 +229,7 @@ class TestGdalUtils(TestCase):
         mock_gdal.Open.return_value = mock_dataset
         polygonize(example_input, example_output)
         expected_band = 4
+        mock_gdal.Nearblack.assert_called_once_with(ANY, example_input)
         mock_dataset.GetRasterBand.assert_called_once_with(expected_band)
         mock_dataset.GetRasterBand.reset_mock()
 


### PR DESCRIPTION
Cleans up the boundary of files use black pixels to ensure they are actually black and don't cause a "noisy" boundary. 

To test upload a raster image with a black border, and ensure that the boundary is relatively, "smooth" or free of random single pixel clusters on the border. 