### PR TITLE
Restrict Tiles by Policy

### DIFF
--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.geos import GEOSGeometry
+from django.core.cache import cache
 from django.utils.translation import ugettext as _
 from audit_logging.models import AuditEvent
 from notifications.models import Notification
@@ -885,6 +886,9 @@ class RegionalJustificationSerializer(serializers.ModelSerializer):
             regional_policy=regional_policy,
             user=user,
         )
+
+        for provider in regional_policy.providers.all():
+            cache.delete(f"mapproxy-config-{user}-{provider.slug}")
 
         return regional_justification
 

--- a/eventkit_cloud/jobs/tests/test_helpers.py
+++ b/eventkit_cloud/jobs/tests/test_helpers.py
@@ -1,0 +1,102 @@
+import datetime
+import json
+import uuid
+
+from django.contrib.auth.models import Group, User
+from django.contrib.gis.geos import GEOSGeometry, Polygon
+from django.test import TestCase
+from django.utils import timezone
+
+from mock import MagicMock, patch
+
+from eventkit_cloud.jobs.admin import get_example_from_file
+from eventkit_cloud.jobs.helpers import get_valid_regional_justification
+from eventkit_cloud.jobs.models import DataProvider, Job, Region, RegionalPolicy, RegionalJustification
+from eventkit_cloud.tasks.enumerations import TaskStates
+from eventkit_cloud.tasks.models import DataProviderTaskRecord, ExportRun, ExportTaskRecord, FileProducingTaskResult, \
+    RunZipFile
+
+
+class TestRegionalJustificationHelpers(TestCase):
+
+    fixtures = ('osm_provider.json',)
+    @classmethod
+    def setUpTestData(cls):
+        group, created = Group.objects.get_or_create(name='TestDefaultExportExtentGroup')
+        with patch('eventkit_cloud.jobs.signals.Group') as mock_group:
+            mock_group.objects.get.return_value = group
+            user = User.objects.create_user(username='demo', email='demo@demo.com', password='demo', is_active=True)
+        # bbox that intersects with both Africa and Burma so that both regions are covered in tests.
+        bbox = Polygon.from_bbox((23.378906, -3.074695, 110.830078, 44.087585))
+        the_geom = GEOSGeometry(bbox, srid=4326)
+        Job.objects.create(name='TestRegionalJustificationHelpers', description='Test description', user=user, the_geom=the_geom)
+
+    def setUp(self):
+        self.job = Job.objects.get(name='TestRegionalJustificationHelpers')
+        self.provider = DataProvider.objects.first()
+        self.run = ExportRun.objects.create(job=self.job, user=self.job.user)
+
+        self.data_provider_task_record = DataProviderTaskRecord.objects.create(run=self.run,
+                                                                               name='Shapefile Export',
+                                                                               provider=self.provider,
+                                                                               status=TaskStates.PENDING.value)
+
+        self.task_uid = uuid.uuid4()
+        self.task = ExportTaskRecord.objects.create(export_provider_task=self.data_provider_task_record, uid=self.task_uid)
+
+    def test_get_valid_regional_justification(self):
+
+        self.job.user.last_login = timezone.now()
+        self.downloadable = FileProducingTaskResult.objects.create(
+             download_url='http://testserver/media/{0}/file.txt'.format(self.run.uid)
+        )
+        self.task.result = self.downloadable
+        self.task.save()
+
+        self.run_zip_file = RunZipFile.objects.create(run=self.run, downloadable_file=self.downloadable)
+        self.data_provider_task_records = [self.data_provider_task_record]
+        self.run_zip_file.data_provider_task_records.set(self.data_provider_task_records)
+
+        self.region = Region.objects.get(name="Africa")
+        policies_example = json.loads(get_example_from_file("examples/policies_example.json"))
+        justification_options_example = json.loads(get_example_from_file("examples/justification_options_example.json"))
+
+        self.regional_policy = RegionalPolicy.objects.create(
+            name="Test Policy",
+            region=self.region,
+            policies=policies_example,
+            justification_options=justification_options_example,
+            policy_title_text="Policy Title",
+            policy_cancel_button_text="Cancel Button"
+        )
+
+        self.regional_policy.providers.set([self.provider])
+
+        active_regional_justification = get_valid_regional_justification(self.regional_policy, self.job.user)
+        self.assertEqual(active_regional_justification, None)
+
+        regional_justification = RegionalJustification.objects.create(
+            justification_id=1,
+            justification_name="Test Option",
+            regional_policy=self.regional_policy,
+            user=self.job.user
+        )
+
+        active_regional_justification = get_valid_regional_justification(self.regional_policy, self.job.user)
+        self.assertEqual(active_regional_justification, regional_justification)
+
+        # Update the users last login, the previous regional justification should no longer be active.
+        self.job.user.last_login = timezone.now()
+        active_regional_justification = get_valid_regional_justification(self.regional_policy, self.job.user)
+        self.assertEqual(active_regional_justification, None)
+
+        with self.settings(REGIONAL_JUSTIFICATION_TIMEOUT_DAYS=1):
+            # Justification was created within the last day.
+            active_regional_justification = get_valid_regional_justification(self.regional_policy, self.job.user)
+            self.assertEqual(active_regional_justification, regional_justification)
+
+            # Subtract a day from the created_at date.
+            regional_justification.created_at = regional_justification.created_at - datetime.timedelta(days=1)
+            regional_justification.save()
+            active_regional_justification = get_valid_regional_justification(self.regional_policy, self.job.user)
+            self.assertEqual(active_regional_justification, None)

--- a/eventkit_cloud/tasks/models.py
+++ b/eventkit_cloud/tasks/models.py
@@ -38,7 +38,7 @@ from eventkit_cloud.tasks import (
 )
 from notifications.models import Notification
 
-from eventkit_cloud.utils.helpers import get_active_regional_justification
+from eventkit_cloud.jobs.helpers import get_valid_regional_justification
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +144,7 @@ class FileProducingTaskResult(UIDMixin, NotificationModelMixin):
         for policy in RegionalPolicy.objects.filter(
             region__the_geom__intersects=job.the_geom, providers__in=providers
         ).prefetch_related("justifications"):
-            if not get_active_regional_justification(policy, user):
+            if not get_valid_regional_justification(policy, user):
                 return False
 
         return True

--- a/eventkit_cloud/utils/helpers.py
+++ b/eventkit_cloud/utils/helpers.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 from django.conf import settings
-from django.utils import timezone
 
 logger = logging.getLogger()
 
@@ -27,29 +26,3 @@ def get_download_paths(relative_path):
     )
     download_url = os.path.join(settings.EXPORT_MEDIA_ROOT.rstrip(os.path.sep), relative_path.lstrip(os.path.sep),)
     return downloads_filepath, download_url
-
-
-def get_active_regional_justification(regional_policy, user):
-    """
-    Checks if a user has an active regional justification for a specific regional policy.
-    Returns the regional justification or None.
-    """
-    regional_justifications = regional_policy.justifications.filter(user=user)
-
-    if not regional_justifications:
-        return None
-
-    regional_justification = regional_justifications.latest("created_at")
-
-    # If a timeout was set, use that timeout.
-    if isinstance(settings.REGIONAL_JUSTIFICATION_TIMEOUT_DAYS, int):
-        timeout_seconds = settings.REGIONAL_JUSTIFICATION_TIMEOUT_DAYS * 3600 * 24
-        seconds_since_created = (timezone.now() - regional_justification.created_at).total_seconds()
-        if seconds_since_created > timeout_seconds:
-            return None
-    else:
-        # If there's no timeout set, use the last login instead.
-        if regional_justification.created_at < user.last_login:
-            return None
-
-    return regional_justification

--- a/eventkit_cloud/utils/helpers.py
+++ b/eventkit_cloud/utils/helpers.py
@@ -2,6 +2,9 @@ import logging
 import os
 
 from django.conf import settings
+from django.core.cache import cache
+
+from eventkit_cloud.utils.mapproxy import mapproxy_config_keys_index
 
 logger = logging.getLogger()
 
@@ -26,3 +29,8 @@ def get_download_paths(relative_path):
     )
     download_url = os.path.join(settings.EXPORT_MEDIA_ROOT.rstrip(os.path.sep), relative_path.lstrip(os.path.sep),)
     return downloads_filepath, download_url
+
+
+def clear_mapproxy_config_cache():
+    mapproxy_config_keys = cache.get_or_set(mapproxy_config_keys_index, set())
+    cache.delete_many(list(mapproxy_config_keys))

--- a/eventkit_cloud/utils/helpers.py
+++ b/eventkit_cloud/utils/helpers.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from django.conf import settings
+from django.utils import timezone
 
 logger = logging.getLogger()
 
@@ -26,3 +27,29 @@ def get_download_paths(relative_path):
     )
     download_url = os.path.join(settings.EXPORT_MEDIA_ROOT.rstrip(os.path.sep), relative_path.lstrip(os.path.sep),)
     return downloads_filepath, download_url
+
+
+def get_active_regional_justification(regional_policy, user):
+    """
+    Checks if a user has an active regional justification for a specific regional policy.
+    Returns the regional justification or None.
+    """
+    regional_justifications = regional_policy.justifications.filter(user=user)
+
+    if not regional_justifications:
+        return None
+
+    regional_justification = regional_justifications.latest("created_at")
+
+    # If a timeout was set, use that timeout.
+    if isinstance(settings.REGIONAL_JUSTIFICATION_TIMEOUT_DAYS, int):
+        timeout_seconds = settings.REGIONAL_JUSTIFICATION_TIMEOUT_DAYS * 3600 * 24
+        seconds_since_created = (timezone.now() - regional_justification.created_at).total_seconds()
+        if seconds_since_created > timeout_seconds:
+            return None
+    else:
+        # If there's no timeout set, use the last login instead.
+        if regional_justification.created_at < user.last_login:
+            return None
+
+    return regional_justification

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -6,6 +6,7 @@ import time
 import mapproxy
 import yaml
 from django.conf import settings
+from django.contrib.gis.geos import GEOSGeometry
 from django.core.cache import cache
 from django.db import connections
 from mapproxy.config.config import load_config, load_default_config
@@ -32,6 +33,7 @@ from eventkit_cloud.utils.geopackage import (
     get_zoom_levels_table,
     remove_empty_zoom_levels,
 )
+from eventkit_cloud.utils.helpers import get_active_regional_justification
 from eventkit_cloud.utils.stats.eta_estimator import ETA
 
 logger = logging.getLogger(__name__)
@@ -346,10 +348,11 @@ def get_concurrency(conf_dict):
     return int(concurrency)
 
 
-def create_mapproxy_app(slug: str):
+def create_mapproxy_app(user, slug: str):
     conf_dict = cache.get_or_set(f"base-config-{slug}", lambda: get_conf_dict(slug), 360)
-
+    # We need to hide the tiles within the region they have not agreed to.
     # TODO: place this somewhere else consolidate settings.
+    logger.info(f"PRINT CONF DICT: {conf_dict}")
     base_config = {
         "services": {
             "demo": None,
@@ -380,6 +383,9 @@ def create_mapproxy_app(slug: str):
                 "sources": [get_footprint_layer_name(slug)],
             }
         ]
+    # TODO: Cache the config with the restricted regions already added.
+    # TODO: Invalidate that cache when a regional justification is created or expired.
+    base_config, conf_dict = add_restricted_regions_to_config(base_config, conf_dict, user)
     try:
         mapproxy_config = load_default_config()
         load_config(mapproxy_config, config_dict=conf_dict)
@@ -424,7 +430,9 @@ def get_conf_dict(slug: str) -> dict:
                 conf_dict["globals"] = {"http": {"ssl_no_cert_checks": ssl_verify}}
         else:
             conf_dict["globals"] = {"http": {"ssl_ca_certs": ssl_verify}}
-        conf_dict.update({"globals": {"cache": {"lock_dir": "./locks", "tile_lock_dir": "./locks"}}})
+        conf_dict.update(
+            {"globals": {"cache": {"lock_dir": "./locks", "tile_lock_dir": "./locks"}, "tiles": {"expires_hours": 0}}}
+        )
     except Exception as e:
         logger.error(e)
         raise Exception(f"Unable to load a mapproxy configuration for slug {slug}")
@@ -445,3 +453,26 @@ def get_mapproxy_metadata_url(slug):
 def get_mapproxy_footprint_url(slug):
     footprint_url = f"{settings.SITE_URL.rstrip('/')}/map/{slug}/wmts/{get_footprint_layer_name(slug)}/default/{{z}}/{{x}}/{{y}}.png"  # NOQA
     return footprint_url
+
+
+def add_restricted_regions_to_config(base_config, config, user):
+    # Based on the user, get a list of regional policies that they have not agreed to.
+    from eventkit_cloud.jobs.models import RegionalPolicy
+
+    config["sources"]["default"]["coverage"] = {
+        "clip": True,
+        "difference": [{"bbox": [-180, -90, 180, 90], "srs": "EPSG:4326"}],
+    }
+
+    for policy in RegionalPolicy.objects.all().prefetch_related("justifications"):
+        logger.info(f"ACTIVE REGIONAL JUSTIFICATION: {get_active_regional_justification(policy, user)}")
+        if not get_active_regional_justification(policy, user):
+            config["sources"]["default"]["coverage"]["difference"].append(
+                {"bbox": GEOSGeometry(policy.region.the_geom).extent, "srs": "EPSG:4326"}
+            )
+            for current_cache in base_config.get("caches", {}):
+                base_config["caches"][current_cache]["disable_storage"] = True
+                logger.info(f"BASE_CONFIG CACHE: {base_config['caches'][current_cache]}")
+
+    logger.info(f"CONFIG: {config}")
+    return base_config, config

--- a/eventkit_cloud/utils/tests/test_helpers.py
+++ b/eventkit_cloud/utils/tests/test_helpers.py
@@ -1,0 +1,16 @@
+from mock import patch
+
+from django.test import TestCase
+
+from eventkit_cloud.utils.helpers import clear_mapproxy_config_cache
+from eventkit_cloud.utils.mapproxy import mapproxy_config_keys_index
+
+
+class TestHelpers(TestCase):
+
+    @patch("eventkit_cloud.utils.helpers.cache")
+    def test_clear_mapproxy_config_cache(self, cache_mock):
+        mapproxy_config_keys = cache_mock.get_or_set.return_value = {"key-a", "key-b"}
+        clear_mapproxy_config_cache()
+        cache_mock.get_or_set.assert_called_with(mapproxy_config_keys_index, set())
+        cache_mock.delete_many.assert_called_with(list(mapproxy_config_keys))

--- a/eventkit_cloud/utils/tests/test_mapproxy.py
+++ b/eventkit_cloud/utils/tests/test_mapproxy.py
@@ -136,7 +136,7 @@ class TestHelpers(TransactionTestCase):
         config_yaml: str = 'services: [stuff]'
         expected_config: dict = {'services': ['stuff'],
                                  'globals': {'cache': {'lock_dir': "./locks",
-                                                       'tile_lock_dir': "./locks"}}}
+                                                       'tile_lock_dir': "./locks"}, "tiles": {"expires_hours": 0}}}
         mock_data_provider = Mock(config=config_yaml)
         mock_data_provider.config = config_yaml
 

--- a/eventkit_cloud/utils/views.py
+++ b/eventkit_cloud/utils/views.py
@@ -20,7 +20,7 @@ def map(request: HttpRequest, slug: str, path: str) -> HttpResponse:
     :param path: The rest of the url context (i.e. path to the tile some_service/0/0/0.png).
     :return: The HttpResponse.
     """
-    mapproxy_app = create_mapproxy_app(slug)
+    mapproxy_app = create_mapproxy_app(request.user, slug)
     params = parse_qs(request.META["QUERY_STRING"])
     script_name = f"/map/{slug}"
     mp_response = mapproxy_app.get(


### PR DESCRIPTION
This PR restricts map tiles based on regional policies.  The tiles of any region with a policy that the user has not agree to will appear white until they do agree.  In order to test this PR, pull everything down and log in.  Ensure that you have a regional policy created locally.  You'll also have to clear all of your caches because old cached tiles will still show up, we've made some changes on how long tiles last before they expire but old tiles cached before this PR won't be effected by those changes.

Once you see the white tiles, you can create a regional justification for the region in question and refresh the page.  You'll then see the tiles loading again.  If you log out and log back in, you'll see white tiles again because the user's in a new session now.  As with the last PRs, regional justifications can be limited by session or timeout depending on whether or not you set the REGIONAL_JUSTIFICATION_TIMEOUT_DAYS environment variable.