### PR TITLE
Allow Custom Caches

### DIFF
--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -361,6 +361,7 @@ def create_mapproxy_app(slug: str):
                 ]
             },
         },
+        # Cache based on slug so that the caches don't overwrite each other.
         "caches": {slug: {"cache": {"type": "file"}, "sources": ["default"], "grids": ["default"]}},
         "layers": [{"name": slug, "title": slug, "sources": [slug]}],
         "globals": {"cache": {"base_dir": getattr(settings, "TILE_CACHE_DIR")}},
@@ -416,6 +417,8 @@ def get_conf_dict(slug: str) -> dict:
         # Load and "clean" mapproxy config for displaying a map.
     try:
         conf_dict = yaml.safe_load(provider.config)
+
+        # Pop layers out so that the default layer configuration above is used.
         conf_dict.pop("layers", "")
         ssl_verify = getattr(settings, "SSL_VERIFICATION", True)
         if isinstance(ssl_verify, bool):

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -382,8 +382,8 @@ def create_mapproxy_app(slug: str):
         ]
     try:
         mapproxy_config = load_default_config()
-        load_config(mapproxy_config, config_dict=conf_dict)
         load_config(mapproxy_config, config_dict=base_config)
+        load_config(mapproxy_config, config_dict=conf_dict)
         mapproxy_configuration = ProxyConfiguration(mapproxy_config)
     except ConfigurationError as e:
         logger.error(e)
@@ -416,7 +416,6 @@ def get_conf_dict(slug: str) -> dict:
         # Load and "clean" mapproxy config for displaying a map.
     try:
         conf_dict = yaml.safe_load(provider.config)
-        conf_dict.pop("caches", "")
         conf_dict.pop("layers", "")
         ssl_verify = getattr(settings, "SSL_VERIFICATION", True)
         if isinstance(ssl_verify, bool):


### PR DESCRIPTION
This PR updates our mapproxy_configuration to include custom caches in the provider config.  Previously all custom caches entries were being popped out of the config and ignored.  In order to test this PR, you'll need to create a custom config for a 3857 source that reprojects to 4326.  Example config available in Slack.



