### PR TITLE
Change job validator to use data size OR aoi size

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -229,7 +229,9 @@ function StepValidator(props: Props) {
                 if (arrayHasValue(noMaxDataSize, provider.slug)) {
                     return false;
                 }
-                return !arrayHasValue(exceedingSize, provider.slug);
+                // The AOI is exceeded, and data size can be used.
+                // Estimates can't be currently loading, and the provider must not be exceeding its data size
+                return !areEstimatesLoading && !arrayHasValue(exceedingSize, provider.slug);
             }
             return true;
         });


### PR DESCRIPTION
This changes the validator on step 2 of the create page to allow a job to continue if the data size OR aoi is not exceeded.
