### PR TITLE
Fix vector formats

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -458,7 +458,7 @@ def osm_data_collection_pipeline(
         input_file=in_dataset,
         output_file=gpkg_filepath,
         layers=["land_polygons"],
-        fmt="gpkg",
+        driver="gpkg",
         is_raster=False,
     )
 
@@ -580,7 +580,7 @@ def shp_export_task(
     selection = parse_result(result, "selection")
 
     shp = gdalutils.convert(
-        fmt="shp",
+        driver="ESRI Shapefile",
         input_file=shp_in_dataset,
         output_file=shp_out_dataset,
         task_uid=task_uid,
@@ -588,9 +588,8 @@ def shp_export_task(
         projection=projection,
     )
 
-    result["file_format"] = "shp"
+    result["driver"] = "ESRI Shapefile"
     result["result"] = shp
-    result["source"] = shp
     return result
 
 
@@ -619,7 +618,7 @@ def kml_export_task(
     selection = parse_result(result, "selection")
 
     kml = gdalutils.convert(
-        fmt="kml",
+        driver="libkml",
         input_file=kml_in_dataset,
         output_file=kml_out_dataset,
         task_uid=task_uid,
@@ -627,9 +626,9 @@ def kml_export_task(
         projection=projection,
     )
 
-    result["file_format"] = "kml"
+    result["driver"] = "libkml"
+    result["file_extension"] = "kml"
     result["result"] = kml
-    result["source"] = kml
     return result
 
 
@@ -661,12 +660,12 @@ def gpx_export_task(
         out = gdalutils.convert(
             input_file=pbf,
             output_file=gpx_file,
-            fmt="GPX",
+            driver="GPX",
             dataset_creation_options=["GPX_USE_EXTENSIONS=YES"],
             boundary=selection,
         )
         result["file_extension"] = "gpx"
-        result["file_format"] = "GPX"
+        result["driver"] = "GPX"
         result["result"] = out
         result["gpx"] = out
         return result
@@ -699,7 +698,7 @@ def pbf_export_task(
     logger.error(pbf_file)
     try:
         result["file_extension"] = "pbf"
-        result["file_format"] = "OSM"
+        result["driver"] = "OSM"
         result["result"] = pbf_file
         logger.error(f"Returning PBF RESULT: {result}")
         return result
@@ -733,7 +732,7 @@ def sqlite_export_task(
     selection = parse_result(result, "selection")
 
     sqlite = gdalutils.convert(
-        fmt="sqlite",
+        driver="SQLite",
         input_file=sqlite_in_dataset,
         output_file=sqlite_out_dataset,
         task_uid=task_uid,
@@ -741,9 +740,8 @@ def sqlite_export_task(
         projection=projection,
     )
 
-    result["file_format"] = "SQLite"
+    result["driver"] = "SQLite"
     result["result"] = sqlite
-    result["source"] = sqlite
     return result
 
 
@@ -804,7 +802,7 @@ def geopackage_export_task(
     selection = parse_result(result, "selection")
 
     gpkg = gdalutils.convert(
-        fmt="gpkg",
+        driver="gpkg",
         input_file=gpkg_in_dataset,
         output_file=gpkg_out_dataset,
         task_uid=task_uid,
@@ -812,7 +810,7 @@ def geopackage_export_task(
         projection=projection,
     )
 
-    result["file_format"] = "gpkg"
+    result["driver"] = "gpkg"
     result["result"] = gpkg
     result["gpkg"] = gpkg
     return result
@@ -847,7 +845,7 @@ def mbtiles_export_task(
     logger.error(f"Converting {source_dataset} to {mbtiles_out_dataset}")
 
     mbtiles = gdalutils.convert(
-        fmt="MBTiles",
+        driver="MBTiles",
         src_srs=4326,
         input_file=source_dataset,
         output_file=mbtiles_out_dataset,
@@ -857,7 +855,7 @@ def mbtiles_export_task(
         use_translate=True,
     )
 
-    result["file_format"] = "MBTiles"
+    result["driver"] = "MBTiles"
     result["result"] = mbtiles
     return result
 
@@ -882,7 +880,7 @@ def geotiff_export_task(
         gtiff_in_dataset = f"GTIFF_RAW:{gtiff_in_dataset}"
 
     gtiff_out_dataset = gdalutils.convert(
-        fmt="gtiff",
+        driver="gtiff",
         input_file=gtiff_in_dataset,
         output_file=gtiff_out_dataset,
         task_uid=task_uid,
@@ -892,7 +890,7 @@ def geotiff_export_task(
     )
 
     result["file_extension"] = "tif"
-    result["file_format"] = "gtiff"
+    result["driver"] = "gtiff"
     result["result"] = gtiff_out_dataset
     result["gtiff"] = gtiff_out_dataset
 
@@ -923,14 +921,14 @@ def nitf_export_task(
 
     creation_options = ["ICORDS=G"]
     nitf = gdalutils.convert(
-        fmt="nitf",
+        driver="nitf",
         input_file=nitf_in_dataset,
         output_file=nitf_out_dataset,
         task_uid=task_uid,
         creation_options=creation_options,
     )
 
-    result["file_format"] = "nitf"
+    result["driver"] = "nitf"
     result["result"] = nitf
     result["nitf"] = nitf
     return result
@@ -957,10 +955,10 @@ def hfa_export_task(
     hfa_in_dataset = parse_result(result, "source")
     provider_slug = get_provider_slug(task_uid)
     hfa_out_dataset = get_export_filename(stage_dir, job_name, projection, provider_slug, "img")
-    hfa = gdalutils.convert(fmt="hfa", input_file=hfa_in_dataset, output_file=hfa_out_dataset, task_uid=task_uid,)
+    hfa = gdalutils.convert(driver="hfa", input_file=hfa_in_dataset, output_file=hfa_out_dataset, task_uid=task_uid,)
 
     result["file_extension"] = "img"
-    result["file_format"] = "hfa"
+    result["driver"] = "hfa"
     result["result"] = hfa
     result["hfa"] = hfa
     return result
@@ -984,7 +982,7 @@ def reprojection_task(
     Function defining a task that will reproject all file formats to the chosen projections.
     """
     result = result or {}
-    file_format = parse_result(result, "file_format")
+    file_format = parse_result(result, "driver")
     selection = parse_result(result, "selection")
 
     if parse_result(result, "file_extension"):
@@ -1002,7 +1000,7 @@ def reprojection_task(
         in_dataset = f"GTIFF_RAW:{in_dataset}"
 
     reprojection = gdalutils.convert(
-        fmt=file_format,
+        driver=file_format,
         input_file=in_dataset,
         output_file=out_dataset,
         task_uid=task_uid,
@@ -1071,10 +1069,10 @@ def wfs_export_task(
             url = re.sub(r"(?<=://)", "%s:%s@" % (user, pw), url)
 
     out = gdalutils.convert(
-        fmt="gpkg", input_file=url, output_file=gpkg, task_uid=task_uid, projection=projection, boundary=bbox,
+        driver="gpkg", input_file=url, output_file=gpkg, task_uid=task_uid, projection=projection, boundary=bbox,
     )
 
-    result["file_format"] = "gpkg"
+    result["driver"] = "gpkg"
     result["result"] = out
     result["source"] = out
 
@@ -1183,10 +1181,15 @@ def arcgis_feature_service_export_task(
         service_url = urljoin(f"{service_url}/", f"query?{query_str}")
 
     out = gdalutils.convert(
-        fmt="gpkg", input_file=service_url, output_file=gpkg, task_uid=task_uid, boundary=bbox, projection=projection,
+        driver="gpkg",
+        input_file=service_url,
+        output_file=gpkg,
+        task_uid=task_uid,
+        boundary=bbox,
+        projection=projection,
     )
 
-    result["file_format"] = "gpkg"
+    result["driver"] = "gpkg"
     result["result"] = out
     result["source"] = out
     return result
@@ -1265,7 +1268,7 @@ def mapproxy_export_task(
             selection=selection,
         )
         gpkg = w2g.convert()
-        result["file_format"] = "gpkg"
+        result["driver"] = "gpkg"
         result["result"] = gpkg
         result["source"] = gpkg
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -982,25 +982,25 @@ def reprojection_task(
     Function defining a task that will reproject all file formats to the chosen projections.
     """
     result = result or {}
-    file_format = parse_result(result, "driver")
+    driver = parse_result(result, "driver")
     selection = parse_result(result, "selection")
 
     if parse_result(result, "file_extension"):
         file_extension = parse_result(result, "file_extension")
     else:
-        file_extension = file_format
+        file_extension = driver
 
     in_dataset = parse_result(result, "source")
     provider_slug = get_provider_slug(task_uid)
     out_dataset = get_export_filename(stage_dir, job_name, projection, provider_slug, file_extension)
 
-    warp_params, translate_params = get_creation_options(config, file_format)
+    warp_params, translate_params = get_creation_options(config, driver)
 
     if "tif" in os.path.splitext(in_dataset)[1]:
         in_dataset = f"GTIFF_RAW:{in_dataset}"
 
     reprojection = gdalutils.convert(
-        driver=file_format,
+        driver=driver,
         input_file=in_dataset,
         output_file=out_dataset,
         task_uid=task_uid,
@@ -1924,16 +1924,16 @@ def get_function(function):
     return function_object
 
 
-def get_creation_options(config: str, file_format: str) -> Union[list, None]:
+def get_creation_options(config: str, driver: str) -> Union[list, None]:
     """
     Gets a list of options for a specific format or returns None.
     :param config: The configuration for a datasource.
-    :param file_format: The file format to look for specific creation options.
+    :param driver: The file format to look for specific creation options.
     :return: A list of creation options of None
     """
     if config:
         conf = yaml.safe_load(config) or dict()
-        params = conf.get("formats", {}).get(file_format, {})
+        params = conf.get("formats", {}).get(driver, {})
         return params.get("warp_params"), params.get("translate_params")
     return None, None
 

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -159,7 +159,7 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
         )
         mock_convert.assert_called_once_with(
-            fmt="shp",
+            driver="ESRI Shapefile",
             input_file=expected_output_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
@@ -204,7 +204,7 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
         )
         mock_convert.assert_called_once_with(
-            fmt="kml",
+            driver="libkml",
             input_file=expected_output_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
@@ -249,7 +249,7 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
         )
         mock_convert.assert_called_once_with(
-            fmt="sqlite",
+            driver="SQLite",
             input_file=expected_output_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
@@ -303,7 +303,7 @@ class TestExportTasks(ExportTaskBase):
             layer=layer,
         )
         mock_convert.assert_called_once_with(
-            fmt="gpkg",
+            driver="gpkg",
             input_file=expected_input_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
@@ -336,7 +336,7 @@ class TestExportTasks(ExportTaskBase):
         job_name = self.job.name.lower()
         input_projection = 4326
         output_projection = 3857
-        fmt = "MBTiles"
+        driver = "MBTiles"
         ext = "mbtiles"
         expected_provider_slug = "osm-generic"
         date = default_format_time(timezone.now())
@@ -365,7 +365,7 @@ class TestExportTasks(ExportTaskBase):
             projection=output_projection,
         )
         mock_convert.assert_called_once_with(
-            fmt=fmt,
+            driver=driver,
             input_file=sample_input,
             output_file=expected_output_path,
             src_srs=input_projection,
@@ -413,7 +413,7 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
         )
         mock_convert.assert_called_once_with(
-            fmt="gpkg",
+            driver="gpkg",
             input_file=expected_output_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
@@ -443,7 +443,7 @@ class TestExportTasks(ExportTaskBase):
         mock_gdalutils.convert.return_value = expected_outfile
         mock_gdalutils.convert.assert_called_once_with(
             boundary=None,
-            fmt="gtiff",
+            driver="gtiff",
             input_file=f"GTIFF_RAW:{example_geotiff}",
             output_file=expected_outfile,
             task_uid=task_uid,
@@ -454,7 +454,7 @@ class TestExportTasks(ExportTaskBase):
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir="stage", job_name="job")
         mock_gdalutils.convert.assert_called_once_with(
             boundary=None,
-            fmt="gtiff",
+            driver="gtiff",
             input_file=f"GTIFF_RAW:{example_geotiff}",
             output_file=expected_outfile,
             task_uid=task_uid,
@@ -467,7 +467,7 @@ class TestExportTasks(ExportTaskBase):
         geotiff_export_task(result=example_result, task_uid=task_uid, stage_dir="stage", job_name="job")
         mock_gdalutils.convert.assert_called_once_with(
             boundary="selection",
-            fmt="gtiff",
+            driver="gtiff",
             input_file=f"GTIFF_RAW:{example_geotiff}",
             output_file=expected_outfile,
             task_uid=task_uid,
@@ -489,7 +489,7 @@ class TestExportTasks(ExportTaskBase):
         mock_gdalutils.convert.return_value = expected_outfile
         mock_gdalutils.convert.assert_called_once_with(
             creation_options=["ICORDS=G"],
-            fmt="nitf",
+            driver="nitf",
             input_file=example_nitf,
             output_file=expected_outfile,
             task_uid=task_uid,
@@ -498,7 +498,7 @@ class TestExportTasks(ExportTaskBase):
         nitf_export_task(result=example_result, task_uid=task_uid, stage_dir="stage", job_name="job")
         mock_gdalutils.convert.assert_called_once_with(
             creation_options=["ICORDS=G"],
-            fmt="nitf",
+            driver="nitf",
             input_file=example_nitf,
             output_file=expected_outfile,
             task_uid=task_uid,
@@ -509,7 +509,7 @@ class TestExportTasks(ExportTaskBase):
         ExportTask.__call__ = lambda *args, **kwargs: celery.Task.__call__(*args, **kwargs)
         example_pbf = "example.pbf"
         example_result = {"pbf": example_pbf}
-        expected_result = {"file_extension": "pbf", "file_format": "OSM", "pbf": example_pbf, "result": example_pbf}
+        expected_result = {"file_extension": "pbf", "driver": "OSM", "pbf": example_pbf, "result": example_pbf}
         returned_result = pbf_export_task(example_result)
         self.assertEquals(expected_result, returned_result)
 
@@ -549,7 +549,7 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
         )
         mock_convert.assert_called_once_with(
-            fmt="sqlite",
+            driver="SQLite",
             input_file=expected_output_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
@@ -577,7 +577,7 @@ class TestExportTasks(ExportTaskBase):
         expected_result = {
             "pbf": example_source,
             "file_extension": "gpx",
-            "file_format": "GPX",
+            "driver": "GPX",
             "result": expected_outfile,
             "gpx": expected_outfile,
             "selection": example_geojson,
@@ -586,7 +586,7 @@ class TestExportTasks(ExportTaskBase):
         mock_gdalutils.convert.assert_called_once_with(
             input_file=example_source,
             output_file=expected_outfile,
-            fmt="GPX",
+            driver="GPX",
             dataset_creation_options=["GPX_USE_EXTENSIONS=YES"],
             boundary=example_geojson,
         )
@@ -640,7 +640,7 @@ class TestExportTasks(ExportTaskBase):
         )
 
         mock_convert.assert_called_once_with(
-            fmt="gpkg",
+            driver="gpkg",
             input_file=expected_input_path,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),

--- a/eventkit_cloud/ui/helpers.py
+++ b/eventkit_cloud/ui/helpers.py
@@ -59,7 +59,7 @@ def file_to_geojson(in_memory_file):
         if not meta["driver"] or meta["is_raster"]:
             out_path = polygonize(in_path, out_path)
         else:
-            out_path = convert_vector(in_path, out_path, fmt="geojson")
+            out_path = convert_vector(in_path, out_path, driver="geojson")
 
         if os.path.exists(out_path):
             geojson = read_json_file(out_path)

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
@@ -60,7 +60,6 @@ import {useEffect} from "react";
 import {useEffectOnMount} from "../../utils/hooks/hooks";
 import MapDrawer from "./MapDrawer";
 import EventkitJoyride from "../common/JoyrideWrapper";
-import {RegionJustification} from "../StatusDownloadPage/RegionJustification";
 import {MapZoomLimiter} from "./MapZoomLimiter";
 
 export const WGS84 = 'EPSG:4326';

--- a/eventkit_cloud/ui/static/ui/app/joyride.config.js
+++ b/eventkit_cloud/ui/static/ui/app/joyride.config.js
@@ -137,7 +137,7 @@ export const joyride = {
             title: 'Welcome to the Create DataPack Page',
             content: `Creating DataPacks is the core function of EventKit.
                 The process begins with defining an Area of Interest (AOI), then selecting Data Sources and output formats.`,
-            target: '.qa-BreadcrumbStepper-div-content',
+            target: '.qa-BreadcrumbStepper-div-stepLabel',
             placement: 'bottom',
             style: JoyRideStyles.welcomeTooltipStyle,
         },

--- a/eventkit_cloud/ui/tests/test_helpers.py
+++ b/eventkit_cloud/ui/tests/test_helpers.py
@@ -70,7 +70,7 @@ class TestHelpers(TestCase):
             mock_makedir.assert_called_once_with(dir)
             mock_write.assert_called_once_with(file, expected_in_path)
             mock_meta.assert_called_once_with(expected_in_path, is_raster=False)
-            mock_convert_vector.assert_called_once_with(expected_in_path, expected_out_path, fmt="geojson")
+            mock_convert_vector.assert_called_once_with(expected_in_path, expected_out_path, driver="geojson")
             mock_rm.assert_called_once_with(dir)
             mock_convert_vector.reset_mock()
             mock_meta.reset_mock()
@@ -89,7 +89,7 @@ class TestHelpers(TestCase):
             mock_unzip.assert_called_once_with(expected_in_path, dir)
             mock_listdirs.assert_called_with(dir)
             mock_meta.convert_vector(updated_in_path, is_raster=False)
-            mock_convert_vector.assert_called_once_with(updated_in_path, expected_out_path, fmt="geojson")
+            mock_convert_vector.assert_called_once_with(updated_in_path, expected_out_path, driver="geojson")
 
             # It should raise an exception if there is no file extension
             file.name = "something"

--- a/eventkit_cloud/utils/geopackage.py
+++ b/eventkit_cloud/utils/geopackage.py
@@ -469,7 +469,11 @@ def add_geojson_to_geopackage(geojson=None, gpkg=None, layer_name=None, task_uid
         open_file.write(geojson)
 
     gpkg = gdalutils.convert(
-        fmt="gpkg", input_file=gpkg, output_file=geojson_file, task_uid=task_uid, creation_options=f"-nln {layer_name}",
+        driver="gpkg",
+        input_file=gpkg,
+        output_file=geojson_file,
+        task_uid=task_uid,
+        creation_options=f"-nln {layer_name}",
     )
 
     return gpkg

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -474,7 +474,13 @@ class TestGdalUtils(TestCase):
         dst_srs = "EPSG:3857"
 
         convert_vector(
-            input_file, output_file, driver=driver, boundary=boundary, src_srs=src_srs, dst_srs=dst_srs, task_uid=task_uid
+            input_file,
+            output_file,
+            driver=driver,
+            boundary=boundary,
+            src_srs=src_srs,
+            dst_srs=dst_srs,
+            task_uid=task_uid,
         )
         mock_gdal.VectorTranslate.assert_called_once_with(
             output_file,

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -120,7 +120,7 @@ class TestGdalUtils(TestCase):
         geojson_file = "/path/to/geojson"
         out_dataset = "/path/to/dataset"
         in_dataset = "/path/to/old_dataset"
-        fmt = "gpkg"
+        driver = "gpkg"
         band_type = gdal.GDT_Byte
         dstalpha = True
         lambda_mock = Mock()
@@ -131,7 +131,7 @@ class TestGdalUtils(TestCase):
             boundary=geojson_file,
             input_file=in_dataset,
             output_file=out_dataset,
-            fmt=fmt,
+            driver=driver,
             task_uid=self.task_uid,
             projection=3857,
         )
@@ -139,7 +139,7 @@ class TestGdalUtils(TestCase):
             convert_raster,
             in_dataset,
             out_dataset,
-            fmt=fmt,
+            driver=driver,
             creation_options=None,
             band_type=band_type,
             dst_alpha=dstalpha,
@@ -156,17 +156,19 @@ class TestGdalUtils(TestCase):
         self.task_process.reset_mock()
 
         # Geotiff
-        fmt = "gtiff"
+        driver = "gtiff"
         band_type = None
         dstalpha = None
         get_meta_mock.return_value = {"driver": "gtiff", "is_raster": True, "nodata": None}
         is_envelope_mock.return_value = True  # So, no need for -dstalpha
-        convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid)
+        convert(
+            boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, driver=driver, task_uid=self.task_uid
+        )
         get_task_command_mock.assert_called_once_with(
             convert_raster,
             in_dataset,
             out_dataset,
-            fmt=fmt,
+            driver=driver,
             creation_options=None,
             band_type=band_type,
             dst_alpha=dstalpha,
@@ -185,12 +187,14 @@ class TestGdalUtils(TestCase):
         # Geotiff with non-envelope polygon cutline
         is_envelope_mock.return_value = False
         dstalpha = True
-        convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid)
+        convert(
+            boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, driver=driver, task_uid=self.task_uid
+        )
         get_task_command_mock.assert_called_once_with(
             convert_raster,
             in_dataset,
             out_dataset,
-            fmt=fmt,
+            driver=driver,
             creation_options=None,
             band_type=band_type,
             dst_alpha=dstalpha,
@@ -207,14 +211,16 @@ class TestGdalUtils(TestCase):
         self.task_process.reset_mock()
 
         # Vector
-        fmt = "gpkg"
+        driver = "gpkg"
         get_meta_mock.return_value = {"driver": "gpkg", "is_raster": False}
-        convert(boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, fmt=fmt, task_uid=self.task_uid)
+        convert(
+            boundary=geojson_file, input_file=in_dataset, output_file=out_dataset, driver=driver, task_uid=self.task_uid
+        )
         get_task_command_mock.assert_called_once_with(
             convert_vector,
             in_dataset,
             out_dataset,
-            fmt=fmt,
+            driver=driver,
             dataset_creation_options=None,
             layer_creation_options=None,
             src_srs=in_projection,
@@ -229,7 +235,7 @@ class TestGdalUtils(TestCase):
         self.task_process.reset_mock()
 
         # Test that extra_parameters are added when converting to NITF.
-        fmt = "nitf"
+        driver = "nitf"
         extra_parameters = "-co ICORDS=G"
         in_projection = "EPSG:4326"
         out_projection = "EPSG:3857"
@@ -237,7 +243,7 @@ class TestGdalUtils(TestCase):
         dstalpha = True
         get_meta_mock.return_value = {"driver": "gpkg", "is_raster": True}
         convert(
-            fmt=fmt,
+            driver=driver,
             input_file=in_dataset,
             creation_options=extra_parameters,
             output_file=out_dataset,
@@ -248,7 +254,7 @@ class TestGdalUtils(TestCase):
             convert_raster,
             in_dataset,
             out_dataset,
-            fmt=fmt,
+            driver=driver,
             creation_options=extra_parameters,
             band_type=band_type,
             dst_alpha=dstalpha,
@@ -265,18 +271,18 @@ class TestGdalUtils(TestCase):
         self.task_process.reset_mock()
 
         # Test converting to a new projection
-        fmt = "gpkg"
+        driver = "gpkg"
         in_projection = "EPSG:4326"
         out_projection = "EPSG:3857"
         band_type = gdal.GDT_Byte
         dstalpha = True
         get_meta_mock.return_value = {"driver": "gpkg", "is_raster": True}
-        convert(fmt=fmt, input_file=in_dataset, output_file=out_dataset, task_uid=self.task_uid, projection=3857)
+        convert(driver=driver, input_file=in_dataset, output_file=out_dataset, task_uid=self.task_uid, projection=3857)
         get_task_command_mock.assert_called_once_with(
             convert_raster,
             in_dataset,
             out_dataset,
-            fmt=fmt,
+            driver=driver,
             creation_options=None,
             band_type=band_type,
             dst_alpha=dstalpha,
@@ -398,11 +404,13 @@ class TestGdalUtils(TestCase):
         input_file = "/test/test.gpkg"
         output_file = "/test/test.tif"
         boundary = "/test/test.json"
-        fmt = "gtiff"
+        driver = "gtiff"
         srs = "EPSG:4326"
 
         mock_get_dataset_names.return_value = (input_file, output_file)
-        convert_raster(input_file, output_file, fmt=fmt, boundary=boundary, src_srs=srs, dst_srs=srs, task_uid=task_uid)
+        convert_raster(
+            input_file, output_file, driver=driver, boundary=boundary, src_srs=srs, dst_srs=srs, task_uid=task_uid
+        )
         mock_gdal.Warp.assert_called_once_with(
             output_file,
             [input_file],
@@ -411,14 +419,14 @@ class TestGdalUtils(TestCase):
             cropToCutline=True,
             cutlineDSName=boundary,
             dstSRS=srs,
-            format=fmt,
+            format=driver,
             srcSRS=srs,
         )
         mock_gdal.Translate.assert_called_once_with(
             output_file,
             input_file,
             callback=progress_callback,
-            format=fmt,
+            format=driver,
             callback_data={"task_uid": task_uid, "subtask_percentage": 50},
             creationOptions=["COMPRESS=LZW", "TILED=YES", "BIGTIFF=YES"],
         )
@@ -428,7 +436,7 @@ class TestGdalUtils(TestCase):
         convert_raster(
             input_file,
             output_file,
-            fmt=fmt,
+            driver=driver,
             boundary=boundary,
             src_srs=srs,
             dst_srs=srs,
@@ -443,14 +451,14 @@ class TestGdalUtils(TestCase):
             callback_data={"task_uid": task_uid, "subtask_percentage": 50},
             cropToCutline=True,
             cutlineDSName=boundary,
-            format=fmt,
+            format=driver,
             warp="params",
         )
         mock_gdal.Translate.assert_called_once_with(
             output_file,
             input_file,
             callback=progress_callback,
-            format=fmt,
+            format=driver,
             callback_data={"task_uid": task_uid, "subtask_percentage": 50},
             translate="params",
         )
@@ -461,12 +469,12 @@ class TestGdalUtils(TestCase):
         input_file = "/test/test.gpkg"
         output_file = "/test/test.kml"
         boundary = "/test/test.json"
-        fmt = "kml"
+        driver = "kml"
         src_srs = "EPSG:4326"
         dst_srs = "EPSG:3857"
 
         convert_vector(
-            input_file, output_file, fmt=fmt, boundary=boundary, src_srs=src_srs, dst_srs=dst_srs, task_uid=task_uid
+            input_file, output_file, driver=driver, boundary=boundary, src_srs=src_srs, dst_srs=dst_srs, task_uid=task_uid
         )
         mock_gdal.VectorTranslate.assert_called_once_with(
             output_file,
@@ -475,7 +483,7 @@ class TestGdalUtils(TestCase):
             callback=progress_callback,
             callback_data={"task_uid": task_uid},
             dstSRS=dst_srs,
-            format=fmt,
+            format=driver,
             options=["-clipSrc", boundary],
             reproject=True,
             skipFailures=True,

--- a/eventkit_cloud/utils/tests/test_geopackage.py
+++ b/eventkit_cloud/utils/tests/test_geopackage.py
@@ -236,7 +236,7 @@ class TestGeopackage(TransactionTestCase):
         )
         gdal_mock = mock_convert.return_value
         gdal_mock.convert.called_once_with(
-            fmt="gpkg", input_file=geojson, output_file=gpkg, creation_options="-nln {0}".format(layer_name)
+            driver="gpkg", input_file=geojson, output_file=gpkg, creation_options="-nln {0}".format(layer_name)
         )
 
     @patch("eventkit_cloud.utils.geopackage.sqlite3")


### PR DESCRIPTION
Fixes regression in vector format pipeline and clarifies that the value passed into convert is used for the gdal driver not to be confused with the file format extension. 