### PR TITLE
Make Region Dialog respect intersections

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapZoomLimiter.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapZoomLimiter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {RegionJustification} from '../StatusDownloadPage/RegionJustification';
 
 interface Props {
@@ -24,10 +24,8 @@ export function MapZoomLimiter(props: Props) {
 
     const [displayDialog, setDisplayDialog] = useState(false);
     useEffect(() => {
-        if (!displayDialog) {
-            if ((!!zoomLevel || zoomLevel === 0) && olZoom > zoomLevel) {
-                setDisplayDialog(true);
-            }
+        if ((!!zoomLevel || zoomLevel === 0) && olZoom > zoomLevel) {
+            setDisplayDialog(true);
         }
     }, [olZoom]);
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapZoomLimiter.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapZoomLimiter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {RegionJustification} from '../StatusDownloadPage/RegionJustification';
 
 interface Props {
@@ -24,8 +24,10 @@ export function MapZoomLimiter(props: Props) {
 
     const [displayDialog, setDisplayDialog] = useState(false);
     useEffect(() => {
-        if ((!!zoomLevel || zoomLevel === 0) && olZoom > zoomLevel) {
-            setDisplayDialog(true);
+        if (!displayDialog) {
+            if ((!!zoomLevel || zoomLevel === 0) && olZoom > zoomLevel) {
+                setDisplayDialog(true);
+            }
         }
     }, [olZoom]);
 

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/RegionJustification.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/RegionJustification.tsx
@@ -91,9 +91,21 @@ export function RegionJustification(props: React.PropsWithChildren<Props>) {
         if (policyProviders && policyIntersections) {
             // Finds any policy where the region intersects with one of the specified extents
             // AND it has an affected provider AND no justification is submitted for that policy
-            const foundPolicyPair = policyProviders.find(([_policyA,]) =>
-                arrayHasValue(policyIntersections.map(([_policyB,]) => _policyB), _policyA) &&
-                !justificationSubmitted[_policyA]
+            const foundPolicyPair = policyProviders.find(([_policyA,]) => {
+                    if (justificationSubmitted[_policyA]) {
+                        return false;
+                    }
+                    let policyFound = false;
+                    let policyB, hasIntersection;
+                    for (let _index = 0; _index < policyIntersections.length; _index = _index + 1) {
+                        [policyB, hasIntersection] = policyIntersections[_index];
+                        if (policyB === _policyA && hasIntersection) {
+                            policyFound = true;
+                            break;
+                        }
+                    }
+                    return policyFound;
+                }
             );
             if (foundPolicyPair) {
                 // Policy not being found at this point should be considered a serious error


### PR DESCRIPTION
Intersections between policy regions and AOI/Screen extents were being computed but not checked. This PR ensures that the intersection is found before displaying a dialog.