### PR TITLE
Update estimates when provider info changes

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/EstimateContainer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/EstimateContainer.tsx
@@ -228,7 +228,7 @@ function EstimateContainer(props: Props) {
         if (SERVE_ESTIMATES) {
             updateEstimate();
         }
-    }, props.exportInfo.providers);
+    }, props.exportInfo.providers, [props.exportInfo.providerInfo]);
 
     const [ aoiArea, setArea ] = useState(0);
     useEffect(() => {


### PR DESCRIPTION
Modifies the hook controlling estimate updates to run when exportInfo.providerInfo is updated. This was an oversight in the original implementation.