### PR TITLE
Replace mock dependency

### DIFF
--- a/eventkit_cloud/api/tests/test_filters.py
+++ b/eventkit_cloud/api/tests/test_filters.py
@@ -3,7 +3,7 @@ import logging
 
 from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import GEOSGeometry, Polygon
-from mock import patch
+from unittest.mock import patch
 from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase

--- a/eventkit_cloud/api/tests/test_validators.py
+++ b/eventkit_cloud/api/tests/test_validators.py
@@ -4,7 +4,7 @@ import logging
 from django.contrib.auth.models import User, Group
 from django.contrib.gis.geos import GEOSGeometry, GeometryCollection, Point, LineString, Polygon
 from django.test import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from rest_framework.serializers import ValidationError
 
 from eventkit_cloud.api.validators import (

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -11,7 +11,7 @@ from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import GEOSGeometry, GeometryCollection, Polygon, Point, LineString
 from django.core import serializers
 from django.utils import timezone
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse

--- a/eventkit_cloud/auth/tests/test_auth.py
+++ b/eventkit_cloud/auth/tests/test_auth.py
@@ -9,7 +9,7 @@ import requests_mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
-from mock import patch
+from unittest.mock import patch
 
 from eventkit_cloud.auth.auth import (
     get_user,

--- a/eventkit_cloud/auth/tests/test_views.py
+++ b/eventkit_cloud/auth/tests/test_views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User, Group
 from django.urls import reverse
 from django.test import Client, override_settings
 from django.test import TestCase
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 from eventkit_cloud.auth.models import OAuth
 from eventkit_cloud.auth.views import callback, oauth

--- a/eventkit_cloud/core/tests/test_helpers.py
+++ b/eventkit_cloud/core/tests/test_helpers.py
@@ -2,10 +2,9 @@
 
 
 import logging
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 
 from django.test import TestCase
-from mock import Mock
 
 from eventkit_cloud.core.helpers import get_id, get_cached_model, get_model_by_params
 

--- a/eventkit_cloud/jobs/tests/test_helpers.py
+++ b/eventkit_cloud/jobs/tests/test_helpers.py
@@ -7,7 +7,7 @@ from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.test import TestCase
 from django.utils import timezone
 
-from mock import patch
+from unittest.mock import patch
 
 from eventkit_cloud.jobs.admin import get_example_from_file
 from eventkit_cloud.jobs.helpers import get_valid_regional_justification

--- a/eventkit_cloud/jobs/tests/test_models.py
+++ b/eventkit_cloud/jobs/tests/test_models.py
@@ -9,7 +9,7 @@ from django.contrib.gis.db.models.functions import Intersection
 from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import GEOSGeometry, Polygon, MultiPolygon
 from django.test import TestCase
-from mock import call, patch
+from unittest.mock import call, patch
 
 from eventkit_cloud.jobs.models import (
     ExportFormat,

--- a/eventkit_cloud/tasks/tests/test_arcgis.py
+++ b/eventkit_cloud/tasks/tests/test_arcgis.py
@@ -2,7 +2,7 @@
 import logging
 
 from django.test import TestCase
-from mock import MagicMock, Mock, patch, ANY
+from unittest.mock import MagicMock, Mock, patch, ANY
 
 logger = logging.getLogger(__name__)
 

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -14,7 +14,7 @@ from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.test import TestCase
 from django.utils import timezone
-from mock import Mock, PropertyMock, patch, MagicMock
+from unittest.mock import Mock, PropertyMock, patch, MagicMock
 
 from eventkit_cloud.celery import TaskPriority, app
 from eventkit_cloud.jobs.models import DatamodelPreset, DataProvider, Job

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -8,7 +8,7 @@ import signal
 from django.test import TestCase
 from django.conf import settings
 from django.utils import timezone
-from mock import patch, call, Mock, MagicMock
+from unittest.mock import patch, call, Mock, MagicMock
 import os
 from eventkit_cloud.tasks.helpers import (
     get_style_files,

--- a/eventkit_cloud/tasks/tests/test_models.py
+++ b/eventkit_cloud/tasks/tests/test_models.py
@@ -10,7 +10,7 @@ from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.core.files import File
 from django.test import TestCase
 from django.utils import timezone
-from mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from eventkit_cloud.jobs.admin import get_example_from_file
 from eventkit_cloud.jobs.models import (

--- a/eventkit_cloud/tasks/tests/test_scheduled_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_scheduled_tasks.py
@@ -25,7 +25,7 @@ from eventkit_cloud.utils.provider_check import CheckResults
 
 import json
 import logging
-from mock import patch, call
+from unittest.mock import patch, call
 
 from notifications.models import Notification
 

--- a/eventkit_cloud/tasks/tests/test_styles.py
+++ b/eventkit_cloud/tasks/tests/test_styles.py
@@ -4,7 +4,7 @@ import os
 
 from django.conf import settings
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from eventkit_cloud.tasks.helpers import generate_qgs_style
 

--- a/eventkit_cloud/tasks/tests/test_task_builders.py
+++ b/eventkit_cloud/tasks/tests/test_task_builders.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-from mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock
 
 from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import GEOSGeometry, Polygon

--- a/eventkit_cloud/tasks/tests/test_task_factory.py
+++ b/eventkit_cloud/tasks/tests/test_task_factory.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.db import DatabaseError
 from django.test import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from eventkit_cloud.jobs.models import Job, Region, DataProviderTask, DataProvider, License, UserLicense
 from eventkit_cloud.tasks.models import ExportRun

--- a/eventkit_cloud/tasks/tests/test_task_process.py
+++ b/eventkit_cloud/tasks/tests/test_task_process.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase
 from django.utils import timezone
-from mock import patch, call
+from unittest.mock import patch, call
 from eventkit_cloud.tasks.task_process import update_progress
 
 

--- a/eventkit_cloud/tasks/tests/test_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_tasks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from eventkit_cloud.tasks.models import ExportTaskRecord
 from eventkit_cloud.tasks import get_cache_value, get_cache_key, set_cache_value

--- a/eventkit_cloud/ui/tests/test_helpers.py
+++ b/eventkit_cloud/ui/tests/test_helpers.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 import os
 
-from mock import Mock, patch, mock_open
+from unittest.mock import Mock, patch, mock_open
 from eventkit_cloud.ui.helpers import (
     file_to_geojson,
     read_json_file,

--- a/eventkit_cloud/ui/tests/test_views.py
+++ b/eventkit_cloud/ui/tests/test_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User, Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
 from django.test import TestCase, override_settings
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 logger = logging.getLogger(__name__)
 

--- a/eventkit_cloud/utils/gpkg/tests/test_sqlite_utils.py
+++ b/eventkit_cloud/utils/gpkg/tests/test_sqlite_utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from django.test import TransactionTestCase
 

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -2,7 +2,7 @@
 import http.client
 import logging
 import urllib
-from mock import patch, MagicMock, ANY
+from unittest.mock import patch, MagicMock, ANY
 
 import requests
 from mapproxy.client.http import _URLOpenerCache, VerifiedHTTPSConnection

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -4,7 +4,7 @@ import os
 from uuid import uuid4
 
 from django.test import TestCase
-from mock import Mock, patch, call, MagicMock, ANY
+from unittest.mock import Mock, patch, call, MagicMock, ANY
 from osgeo import gdal, ogr
 
 from eventkit_cloud.utils.gdalutils import (

--- a/eventkit_cloud/utils/tests/test_geocode_auth.py
+++ b/eventkit_cloud/utils/tests/test_geocode_auth.py
@@ -2,7 +2,7 @@ import logging
 import requests
 from django.conf import settings
 from django.test import TestCase, override_settings
-from mock import patch
+from unittest.mock import patch
 from eventkit_cloud.utils.geocoding.geocode_auth import (
     get_auth_headers,
     CACHE_COOKIE_KEY,

--- a/eventkit_cloud/utils/tests/test_geocode_auth_response.py
+++ b/eventkit_cloud/utils/tests/test_geocode_auth_response.py
@@ -1,5 +1,5 @@
 import logging
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 from django.test import TestCase
 

--- a/eventkit_cloud/utils/tests/test_geopackage.py
+++ b/eventkit_cloud/utils/tests/test_geopackage.py
@@ -4,7 +4,7 @@ import os
 from uuid import uuid4
 
 from django.test import TransactionTestCase
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 
 from eventkit_cloud.utils.geopackage import (
     add_geojson_to_geopackage,

--- a/eventkit_cloud/utils/tests/test_helpers.py
+++ b/eventkit_cloud/utils/tests/test_helpers.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from django.test import TestCase
 

--- a/eventkit_cloud/utils/tests/test_image_snapshot.py
+++ b/eventkit_cloud/utils/tests/test_image_snapshot.py
@@ -1,6 +1,6 @@
 import logging
 
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 from django.test import TestCase
 from eventkit_cloud.utils.image_snapshot import (
     get_tile,

--- a/eventkit_cloud/utils/tests/test_map_query.py
+++ b/eventkit_cloud/utils/tests/test_map_query.py
@@ -2,7 +2,7 @@
 import logging
 
 from eventkit_cloud.utils.map_query import ArcGISQuery
-from mock import Mock
+from unittest.mock import Mock
 from django.test import TestCase
 import json
 

--- a/eventkit_cloud/utils/tests/test_mapproxy.py
+++ b/eventkit_cloud/utils/tests/test_mapproxy.py
@@ -6,7 +6,7 @@ import yaml as real_yaml
 from django.conf import settings
 from django.test import TransactionTestCase
 from mapproxy.config.config import load_default_config
-from mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock
 
 from eventkit_cloud.jobs.models import DataProvider
 from eventkit_cloud.tasks.enumerations import TaskStates

--- a/eventkit_cloud/utils/tests/test_overpass.py
+++ b/eventkit_cloud/utils/tests/test_overpass.py
@@ -2,12 +2,11 @@
 import logging
 import os
 
-import mock
 from django.conf import settings
 from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.test import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import yaml
 
 from eventkit_cloud.jobs.models import ExportFormat, Job, DatamodelPreset
@@ -89,7 +88,7 @@ class TestOverpass(TestCase):
         )
         overpass_query = op.get_query()
         out = self.path + "/files/query.osm"
-        mock_response = mock.Mock()
+        mock_response = Mock()
         sample_data = ["<osm>some data</osm>".encode()]
         expected = sample_data[0].decode()
         mock_response.headers = {"content-length": 20}

--- a/eventkit_cloud/utils/tests/test_pbf.py
+++ b/eventkit_cloud/utils/tests/test_pbf.py
@@ -3,7 +3,7 @@ import logging
 from uuid import uuid4
 
 from django.test import TransactionTestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from eventkit_cloud.utils.pbf import OSMToPBF
 

--- a/eventkit_cloud/utils/tests/test_pcf.py
+++ b/eventkit_cloud/utils/tests/test_pcf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-from mock import patch
+from unittest.mock import patch
 import os
 
 import requests_mock

--- a/eventkit_cloud/utils/tests/test_provider_check.py
+++ b/eventkit_cloud/utils/tests/test_provider_check.py
@@ -5,7 +5,7 @@ import logging
 import requests
 from django.conf import settings
 from django.test import TransactionTestCase
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from eventkit_cloud.utils.provider_check import (
     WCSProviderCheck,

--- a/eventkit_cloud/utils/tests/test_s3.py
+++ b/eventkit_cloud/utils/tests/test_s3.py
@@ -3,7 +3,7 @@ import os
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from mock import patch, mock_open, Mock, MagicMock
+from unittest.mock import patch, mock_open, Mock, MagicMock
 
 from eventkit_cloud.utils.s3 import delete_from_s3, upload_to_s3, get_presigned_url
 

--- a/eventkit_cloud/utils/tests/test_wcs.py
+++ b/eventkit_cloud/utils/tests/test_wcs.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.test import TransactionTestCase
-from mock import Mock, patch, ANY
+from unittest.mock import Mock, patch, ANY
 
 from eventkit_cloud.utils.wcs import WCSConverter
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 coverage==5.1
 coveralls==2.0
-mock==4.0.2
 flake8==3.8.3
 autopep8==1.5.3
 flower==0.9.5


### PR DESCRIPTION
This PR replaces the mock dependency with Python's built-in (`unittest.mock`).