### PR TITLE
Update layer selection tools to display data type

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -182,6 +182,7 @@ export interface BaseMapSource {
     name: string;
     type: string;
     thumbnail_url: string;
+    data_type: string;
 }
 
 export interface Props {
@@ -277,6 +278,7 @@ export function MapDrawer(props: Props) {
                     } as MapLayer,
                     name: provider.name,
                     type: provider.type,
+                    data_type: provider.data_type,
                     thumbnail_url: provider.thumbnail_url,
                 } as BaseMapSource;
             })
@@ -373,7 +375,7 @@ export function MapDrawer(props: Props) {
                                                         />
                                                     </div>
                                                     <div className={classes.buttonLabelSecondary}>
-                                                        {source.type.toUpperCase()}
+                                                        {source.data_type && source.data_type[0].toUpperCase() + source.data_type.substring(1)}
                                                     </div>
                                                 </div>
                                             </ListItem>

--- a/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
+++ b/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
@@ -166,6 +166,7 @@ declare namespace Eventkit {
         supported_formats: Format[];
         thumbnail_url: string;
         hidden: boolean;
+        data_type: string;
     }
 
     interface Format {


### PR DESCRIPTION
This PR updates the basemap selection to display the sources' data type instead of provider type. 

If the data_type field is not set on a provider, nothing will be displayed.

From:
![Screen Shot 2020-12-09 at 12 23 36 PM](https://user-images.githubusercontent.com/12192559/101667417-50dc2780-3a1d-11eb-9d6e-cce98694b594.png)

To:
![Screen Shot 2020-12-09 at 12 21 49 PM](https://user-images.githubusercontent.com/12192559/101667428-546fae80-3a1d-11eb-9e9d-bb155ec5c9c0.png)
