### PR TITLE
remove channels

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,7 +1,4 @@
 name: eventkit-cloud
-channels:
-  - file:///var/lib/eventkit/conda/repo
-  - nodefaults
 dependencies:
   - eventkit-cloud=1.9.0
   - memcached=1.6.6

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,4 @@
 name: eventkit-cloud
-channels:
-  - file:///var/lib/eventkit/conda/repo
-  - nodefaults
 dependencies:
   - eventkit-cloud=1.9.0
   - memcached=1.6.6


### PR DESCRIPTION
This removes channels from the conda environment files.  Users will likely have their own .condarc files they want to use, and since the conda configuration is built into the docker file there is no need to include that here as well. 