### PR TITLE
Fix Status Page crash after submitting jobs

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackOptions.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackOptions.tsx
@@ -195,7 +195,7 @@ export class DataPackOptions extends React.Component<Props, State> {
                 </BaseDialog>
                 <MatomoClickTracker
                     eventAction="Clone Export"
-                    eventName={`Clone ${this.props.job.name}`}
+                    eventName={`Clone ${this.props?.job?.name}`}
                     eventCategory="Status and Download"
                 >
                     <Button
@@ -219,7 +219,7 @@ export class DataPackOptions extends React.Component<Props, State> {
                 </BaseDialog>
                 <MatomoClickTracker
                     eventAction="Delete Export"
-                    eventName={`Delete ${this.props.job.name}`}
+                    eventName={`Delete ${this.props?.job?.name}`}
                     eventCategory="Status and Download"
                 >
                     <Button


### PR DESCRIPTION
Fixes a crash when landing on the Status and Download page directly after submitting a job. The crash occurred when the backend had not yet finished processing the job request to then send it to the frontend. The job didn't exist, so matomo tracking failed when trying to get the job name.

