### PR TITLE
fixed request for cgi endpoint

### DIFF
--- a/eventkit_cloud/utils/overpass.py
+++ b/eventkit_cloud/utils/overpass.py
@@ -103,8 +103,8 @@ class Overpass(object):
             user_details = {"username": "unknown-run_query"}
 
         req = None
-        q = self.get_query()
-        logger.debug(q)
+        query = self.get_query()
+        logger.debug(query)
         logger.debug(f"Query started at: {datetime.now()}")
         try:
             update_progress(
@@ -117,7 +117,12 @@ class Overpass(object):
             )
             conf: dict = yaml.safe_load(self.config) or dict()
             cert_var = conf.get("cert_var") or self.slug
-            req = auth_requests.post(self.url, cert_var=cert_var, data=q, stream=True, verify=self.verify_ssl)
+
+            req = auth_requests.post(self.url, cert_var=cert_var, data=query, stream=True, verify=self.verify_ssl)
+            if not req.ok:
+                # Workaround for https://bugs.python.org/issue27777
+                query = {"data": query}
+                req = auth_requests.post(self.url, cert_var=cert_var, data=query, stream=True, verify=self.verify_ssl)
             req.raise_for_status()
             try:
                 total_size = int(req.headers.get("content-length"))


### PR DESCRIPTION
Retries call if old style request doesn't work.  To test try a previously failing overpass endpoint and verify that exports succeed. 