### PR TITLE
Consolidate Conda Recipe & Requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ celerybeat-schedule
 
 # project specific files
 core/settings/secret.py
-
+conda/recipes/eventkit-cloud/conda-requirements.txt
 *.iml
 
 # temp and generated data

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -34,6 +34,9 @@ function create_index {
   echo "done."
 }
 
+echo "Converting the requirements.txt to a format compatible with conda."
+python /root/convert_requirements_to_conda.py
+
 echo "Building recipes"
 cd /root/recipes
 if [ -z "$1" ]; then
@@ -54,6 +57,9 @@ for RECIPE in $RECIPES; do
     break || s=$? && sleep 5;
   done; (exit $s)
 done
+
+echo "Cleaning up the conda-requirements.txt after the build."
+rm /root/recipes/eventkit-cloud/conda-requirements.txt
 
 pushd /root/repo/linux-64/
 python /root/download_packages.py

--- a/conda/convert_requirements_to_conda.py
+++ b/conda/convert_requirements_to_conda.py
@@ -1,0 +1,24 @@
+from os import path
+import re
+
+
+def convert_requirements_to_conda():
+    base_path = path.dirname(__file__)
+    requirements_file = path.abspath(path.join(base_path, "..", "eventkit-cloud", "requirements.txt"))
+    with open(requirements_file) as file:
+        requirements_list = file.read().splitlines()
+    conda_requirements = []
+    for requirement in requirements_list:
+        if "git+" in requirement:
+            # Match the repository name and version from the Github URL.
+            repository = "".join(requirement.split("/")[-1:]).split(".")[0]
+            version = re.search("(?:@v(.*?)#)", requirement).group(1)
+            conda_requirements.append(f"{repository}={version}".lower())
+        else:
+            conda_requirements.append(requirement.replace("==", "=").lower())
+    with open(path.join(base_path, "recipes", "eventkit-cloud", "conda-requirements.txt"), mode="wt", encoding="utf-8") as file:
+        file.write("\n".join(conda_requirements))
+
+
+if __name__ == "__main__":
+    convert_requirements_to_conda()

--- a/conda/docker-compose.yml
+++ b/conda/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./recipes:/root/recipes
       - ./build.sh:/root/build.sh
       - ./download_packages.py:/root/download_packages.py
+      - ./convert_requirements_to_conda.py:/root/convert_requirements_to_conda.py
       - ./recipes.txt:/root/recipes.txt
       - ../:/eventkit-cloud
     environment:

--- a/conda/recipes/eventkit-cloud/meta.yaml
+++ b/conda/recipes/eventkit-cloud/meta.yaml
@@ -1,5 +1,12 @@
 {% set name = "eventkit-cloud" %}
 {% set version = "1.9.0" %}
+
+{% set run_requirements = load_file_regex(
+    load_file="conda-requirements.txt",
+    regex_pattern=".+",
+    from_recipe_dir=True).string.strip().split("\n")
+%}
+
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
@@ -19,48 +26,14 @@ requirements:
     - memcached=1.6.6
     - qgis=3.14.16
   run:
+    {% for req in run_requirements -%}
+      - {{ req }}
+    {% endfor %}
     - python >=3.7,<3.8
-    - billiard=3.6.3.0
-    - boto3=1.14.15
-    - celery=4.4.6
-    - dj-database-url=0.5.0
-    - django=3.1.2
-    - django-audit-logging=0.2.1
-    - django-auth-ldap=2.2.0
-    - django-celery-beat=2.0.0
-    - django-extensions=3.0.9
-    - django-filter=2.4.0
-    - django-notifications-hq=1.6.0
-    - django-storages=1.9.1
-    - django-timezone-field=4.0
-    - djangorestframework=3.12.1
-    - djangorestframework-gis=0.15.0
-    - eventlet=0.28.0
-    - gdal=3.1.4
-    - gunicorn=20.0.4
     - libiconv=1.15
-    - mapproxy=1.12.0
     - mesa-libgl-cos7-x86_64
-    - numpy=1.19.2
     - osmctools=0.9.0
-    - pillow=8.0.1
     - proj=7.1.1
-    - psycopg2=2.8.4
-    - pyjwt=1.7.1
-    - pyparsing=2.4.7
-    - python-dateutil=2.8.1
-    - python-ldap=3.2.0
-    - python-magic=0.4.15
-    - python-memcached=1.59
-    - pytz=2020.1
-    - pyyaml=5.3.1
-    - requests=2.24.0
-    - shapely=1.7.1
-    - sqlparse=0.3.1
-    - swapper=1.1.2.post1
-    - uritemplate=3.0.1
-    - webtest=2.0.35
-    - whitenoise=4.1.4
     - zstd=1.4.5
 about:
   home: https://github.com/eventkit/eventkit-cloud

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-notifications-hq==1.6.0
 django-storages==1.9.1
 django-timezone-field==4.0
 djangorestframework==3.12.1
-djangorestframework-gis==0.15.0
+djangorestframework-gis==0.15
 eventlet==0.28.0
 GDAL==3.1.4
 gunicorn==20.0.4
@@ -28,10 +28,10 @@ python-magic==0.4.15
 python-memcached==1.59
 pytz==2020.1
 PyYAML==5.3.1
-qgis==3.14.16
 requests==2.24.0
 Shapely==1.7.1
 sqlparse==0.3.1
+swapper==1.1.2.post1
 uritemplate==3.0.1
 webtest==2.0.35
 whitenoise==4.1.4


### PR DESCRIPTION
Generate Python requirements for eventkit-cloud conda recipe from requirements.txt so that we don't have to keep changing dependencies in multiple places.  In order to test this code, you'll have to run a completely fresh build using make fresh.  