### PR TITLE
Fix blank space crash on step 2

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportValidation.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportValidation.tsx
@@ -38,10 +38,11 @@ export function hasRequiredFields(exportInfo: Eventkit.Store.ExportInfo) {
             && exportOptions[provider.slug].formats.length > 0;
     });
 
+    const getIsStringValid = (value: string) => !!value && value.trim() !== "";
     return !!(
-        exportInfo.exportName
-        && exportInfo.datapackDescription
-        && exportInfo.projectName
+        getIsStringValid(exportInfo.exportName)
+        && getIsStringValid(exportInfo.datapackDescription)
+        && getIsStringValid(exportInfo.projectName)
         && exportInfo.providers.length > 0
         && exportInfo.projections.length > 0
         && formatsAreSelected.every(selected => selected)


### PR DESCRIPTION
Validates the text field on step 2 of the create workflow to prevent blank spaces from being submitted.