### PR TITLE
Remove testing code from core code

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
@@ -84,8 +84,6 @@ const jss = (theme: Eventkit.Theme & Theme) => ({
 });
 
 export async function downloadRequest(url: string, displaySetter: (value: boolean) => void) {
-    displaySetter(true);
-
     return await axios({
         url,
         headers: {'X-CSRFToken': getCookie('csrftoken')},

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/CreateDataPackButton.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/CreateDataPackButton.spec.tsx
@@ -5,7 +5,6 @@ import {useRunContext} from "../../components/StatusDownloadPage/context/RunFile
 import '@testing-library/jest-dom/extend-expect';
 import {rest} from 'msw';
 import {setupServer} from 'msw/node';
-import axios from 'axios';
 
 jest.mock('../../components/StatusDownloadPage/context/RunFile', () => {
     return {
@@ -118,15 +117,24 @@ describe('CreateDataPackButton component', () => {
                     "status": "FAILED"
                 }]))
             })
-        )
+        );
         setup();
         await waitFor(() => screen.getByText('Zip Error'))
         expect(screen.getByText(/Zip Error/)).toBeInTheDocument();
     });
 
-    it('should call the setter appropriately', () => {
+    it('should call the setter appropriately', async () => {
+        server.use(
+            // override the initial "GET /greeting" request handler
+            // to return a 500 Server Error
+            rest.get('url/urlpath.zip', (req, res, ctx) => {
+                return res(
+                    ctx.status(500)
+                )
+            })
+        );
         const setterFunction = jest.fn();
-        downloadRequest('url/urlpath.zip', setterFunction);
+        await downloadRequest('url/urlpath.zip', setterFunction);
         expect(setterFunction).toHaveBeenCalledWith(true);
     });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/CreateDataPackButton.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/CreateDataPackButton.spec.tsx
@@ -125,8 +125,6 @@ describe('CreateDataPackButton component', () => {
 
     it('should call the setter appropriately', async () => {
         server.use(
-            // override the initial "GET /greeting" request handler
-            // to return a 500 Server Error
             rest.get('url/urlpath.zip', (req, res, ctx) => {
                 return res(
                     ctx.status(500)


### PR DESCRIPTION
Removes a line of code that was accidentally committed. The code was being used to work through tests, but accidentally made the test appear to pass. The test has been corrected and the erroneous code removed.