### PR TITLE
Use temporary key during Docker image builds.

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -L https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.3-Linux-x86_
     conda config --set channel_priority strict && \
     conda env create --file environment-dev.yml python=3.7 && \
     conda clean --yes --all && \
-    /home/eventkit/miniconda3/envs/eventkit-cloud/bin/python \
+    SECRET_KEY=temp_secret_key /home/eventkit/miniconda3/envs/eventkit-cloud/bin/python \
     /home/eventkit/miniconda3/envs/eventkit-cloud/bin/manage.py collectstatic && \
     rm -rf /var/lib/eventkit/conda && \
     # Remove the directory because of stale files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,7 @@ services:
       - MAX_EXPORTRUN_EXPIRATION_DAYS
       - CONTAINER_CODE_PATH
       - DEV_MACHINE_CODE_PATH
+      - SECRET_KEY
     extra_hosts:
       - "${SITE_NAME}:${SITE_IP}"
     command: /home/eventkit/miniconda3/envs/eventkit-cloud/lib/python3.7/site-packages/scripts/run-celery-beat.sh

--- a/eventkit_cloud/settings/utils.py
+++ b/eventkit_cloud/settings/utils.py
@@ -9,20 +9,3 @@ DJANGO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__
 
 def ABS_PATH(*args):
     return os.path.join(DJANGO_ROOT, *args)
-
-
-def ensure_secret_key_file():
-    """Checks that secret.py exists in settings dir. If not, creates one
-with a random generated SECRET_KEY setting."""
-    secret_path = ABS_PATH("eventkit_cloud", "settings", "secret.py")
-    if not os.path.exists(secret_path):
-        from django.utils.crypto import get_random_string
-
-        secret_key = get_random_string(50, "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)")
-        with open(secret_path, "w") as f:
-            f.write("import os\n")
-            f.write("SECRET_KEY = os.environ.get('SECRET_KEY', " + repr(secret_key) + "\n")
-
-
-# Import the secret key
-ensure_secret_key_file()


### PR DESCRIPTION
Resolves an issue with the Django SECRET_KEY during builds.  In order to test, pull down this branch and rebuild the eventkit docker image using `docker-compose build --no-cache` or `make build`.