### PR TITLE
skips 'useless' conversions

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -816,14 +816,20 @@ def geopackage_export_task(
     gpkg_out_dataset = get_export_filepath(stage_dir, job_name, projection, provider_slug, "gpkg")
     selection = parse_result(result, "selection")
 
-    gpkg = gdalutils.convert(
-        driver="gpkg",
-        input_file=gpkg_in_dataset,
-        output_file=gpkg_out_dataset,
-        task_uid=task_uid,
-        boundary=selection,
-        projection=projection,
-    )
+    # This assumes that the source dataset has already been "clipped".  Since most things are tiles or selected
+    # based on area it doesn't make sense to run this again.  If that isn't true this may need to be updated.
+    if os.path.splitext(gpkg_in_dataset)[1] == ".gpkg":
+        os.rename(gpkg_in_dataset, gpkg_out_dataset)
+        gpkg = gpkg_out_dataset
+    else:
+        gpkg = gdalutils.convert(
+            driver="gpkg",
+            input_file=gpkg_in_dataset,
+            output_file=gpkg_out_dataset,
+            task_uid=task_uid,
+            boundary=selection,
+            projection=projection,
+        )
 
     result["driver"] = "gpkg"
     result["result"] = gpkg
@@ -1014,16 +1020,24 @@ def reprojection_task(
     if "tif" in os.path.splitext(in_dataset)[1]:
         in_dataset = f"GTIFF_RAW:{in_dataset}"
 
-    reprojection = gdalutils.convert(
-        driver=driver,
-        input_file=in_dataset,
-        output_file=out_dataset,
-        task_uid=task_uid,
-        projection=projection,
-        boundary=selection,
-        warp_params=warp_params,
-        translate_params=translate_params,
-    )
+    # This logic is only valid IFF this method only allows 4326 which is True as of 1.9.0.
+    # This needs to be updated to compare the input and output if over source projections are allowed.
+    if not projection or 4326 in str(projection):
+        logger.info(f"Skipping projection and renaming {in_dataset} to {out_dataset}")
+        os.rename(in_dataset, out_dataset)
+    else:
+        # If you are updating this see the note above about source projection.
+
+        reprojection = gdalutils.convert(
+            driver=driver,
+            input_file=in_dataset,
+            output_file=out_dataset,
+            task_uid=task_uid,
+            projection=projection,
+            boundary=selection,
+            warp_params=warp_params,
+            translate_params=translate_params,
+        )
 
     result["result"] = reprojection
 

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -494,9 +494,10 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result["result"])
         self.assertEqual(sample_input, result["source"])
 
-    @patch("eventkit_cloud.utils.gdalutils.convert")
+    @patch("eventkit_cloud.tasks.export_tasks.os.rename")
+    @patch("eventkit_cloud.tasks.export_tasks.gdalutils.convert")
     @patch("celery.app.task.Task.request")
-    def test_run_gpkg_export_task(self, mock_request, mock_convert):
+    def test_run_gpkg_export_task(self, mock_request, mock_convert, mock_rename):
         celery_uid = str(uuid.uuid4())
         type(mock_request).id = PropertyMock(return_value=celery_uid)
         job_name = self.job.name.lower()
@@ -507,8 +508,7 @@ class TestExportTasks(ExportTaskBase):
         expected_output_path = os.path.join(
             os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid)), expected_outfile
         )
-
-        mock_convert.return_value = expected_output_path
+        mock_rename.return_value = expected_output_path
         previous_task_result = {"source": expected_output_path}
         stage_dir = settings.EXPORT_STAGING_ROOT + str(self.run.uid) + "/"
         export_provider_task = DataProviderTaskRecord.objects.create(
@@ -517,10 +517,8 @@ class TestExportTasks(ExportTaskBase):
         saved_export_task = ExportTaskRecord.objects.create(
             export_provider_task=export_provider_task, status=TaskState.PENDING.value, name=geopackage_export_task.name
         )
-        geopackage_export_task.update_task_state(
-            task_status=TaskState.RUNNING.value, task_uid=str(saved_export_task.uid)
-        )
-        result = geopackage_export_task.run(
+
+        result = geopackage_export_task(
             run_uid=self.run.uid,
             result=previous_task_result,
             task_uid=str(saved_export_task.uid),
@@ -528,9 +526,27 @@ class TestExportTasks(ExportTaskBase):
             job_name=job_name,
             projection=projection,
         )
+        mock_rename.assert_called_once_with(expected_output_path, expected_output_path)
+        self.assertEqual(expected_output_path, result["result"])
+        self.assertEqual(expected_output_path, result["source"])
+
+        example_input_file = "test.tif"
+        previous_task_result = {"source": example_input_file}
+
+        mock_convert.return_value = expected_output_path
+
+        result = geopackage_export_task(
+            run_uid=self.run.uid,
+            result=previous_task_result,
+            task_uid=str(saved_export_task.uid),
+            stage_dir=stage_dir,
+            job_name=job_name,
+            projection=projection,
+        )
+
         mock_convert.assert_called_once_with(
             driver="gpkg",
-            input_file=expected_output_path,
+            input_file=example_input_file,
             output_file=expected_output_path,
             task_uid=str(saved_export_task.uid),
             projection=4326,
@@ -538,7 +554,7 @@ class TestExportTasks(ExportTaskBase):
         )
 
         self.assertEqual(expected_output_path, result["result"])
-        self.assertEqual(expected_output_path, result["source"])
+        self.assertEqual(example_input_file, result["source"])
 
     @patch("eventkit_cloud.tasks.export_tasks.get_creation_options")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_task_record")


### PR DESCRIPTION
This skips converting or reprojecting files that don't need to be converted or reprojected.   To test try exporting a raster geopackage.  The size of the initial task should be the same size as the reprojected task meaning the source geopackage wasn't passed into gdal.