### PR TITLE
Use Mapproxy to reproject geopackages

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -10,17 +10,17 @@ import time
 import traceback
 from typing import List, Union
 from urllib.parse import urlencode, urljoin
-
 from zipfile import ZipFile, ZIP_DEFLATED
 
+import yaml
+from audit_logging.celery_support import UserDetailsBase
 from billiard.einfo import ExceptionInfo
 from celery import signature
 from celery.result import AsyncResult
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from django.contrib.gis.geos import Polygon
 from django.contrib.auth.models import User
-
+from django.contrib.gis.geos import Polygon
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import EmailMultiAlternatives
 from django.db import DatabaseError, transaction
@@ -34,8 +34,10 @@ from eventkit_cloud.core.helpers import (
     NotificationVerb,
     NotificationLevel,
 )
-
 from eventkit_cloud.feature_selection.feature_selection import FeatureSelection
+from eventkit_cloud.jobs.enumerations import GeospatialDataType
+from eventkit_cloud.jobs.helpers import clean_config
+from eventkit_cloud.jobs.models import DataProviderTask
 from eventkit_cloud.tasks import set_cache_value
 from eventkit_cloud.tasks.enumerations import TaskState
 from eventkit_cloud.tasks.exceptions import CancelException, DeleteException
@@ -66,17 +68,7 @@ from eventkit_cloud.tasks.helpers import (
     download_data,
     download_concurrently,
 )
-from eventkit_cloud.jobs.enumerations import GeospatialDataType
-from eventkit_cloud.jobs.helpers import clean_config
 from eventkit_cloud.tasks.metadata import metadata_tasks
-from eventkit_cloud.tasks.task_process import update_progress
-from eventkit_cloud.utils import overpass, pbf, s3, mapproxy, wcs, geopackage, gdalutils, auth_requests
-from eventkit_cloud.utils.qgis_utils import convert_qgis_gpkg_to_kml
-from eventkit_cloud.utils.rocket_chat import RocketChat
-from eventkit_cloud.utils.stats.eta_estimator import ETA
-from eventkit_cloud.tasks.task_base import EventKitBaseTask
-from audit_logging.celery_support import UserDetailsBase
-
 from eventkit_cloud.tasks.models import (
     ExportTaskRecord,
     ExportTaskException,
@@ -85,8 +77,12 @@ from eventkit_cloud.tasks.models import (
     ExportRun,
     RunZipFile,
 )
-from eventkit_cloud.jobs.models import DataProviderTask
-import yaml
+from eventkit_cloud.tasks.task_base import EventKitBaseTask
+from eventkit_cloud.tasks.task_process import update_progress
+from eventkit_cloud.utils import overpass, pbf, s3, mapproxy, wcs, geopackage, gdalutils, auth_requests
+from eventkit_cloud.utils.qgis_utils import convert_qgis_gpkg_to_kml
+from eventkit_cloud.utils.rocket_chat import RocketChat
+from eventkit_cloud.utils.stats.eta_estimator import ETA
 
 BLACKLISTED_ZIP_EXTS = [".ini", ".om5", ".osm", ".lck", ".pyc"]
 
@@ -1037,29 +1033,52 @@ def reprojection_task(
         os.rename(in_dataset, out_dataset)
     else:
         # If you are updating this see the note above about source projection.
-        dptr = DataProviderTaskRecord.objects.get(tasks__uid__exact=task_uid)
+        dptr: DataProviderTaskRecord = DataProviderTaskRecord.objects.select_related("run__job").get(
+            tasks__uid__exact=task_uid
+        )
         metadata = get_metadata(data_provider_task_record_uids=[dptr.uid], source_only=True)
         data_type = metadata["data_sources"][provider_slug].get("type")
 
-        if "gpkg" in os.path.splitext(in_dataset)[1] and driver == "gpkg" and data_type == GeospatialDataType.RASTER.value:
+        if (
+            "gpkg" in os.path.splitext(in_dataset)[1]
+            and driver == "gpkg"
+            and data_type == GeospatialDataType.RASTER.value
+        ):
             # Use MapProxy instead of GDAL so all the pyramids/zoom levels of the source are preserved.
 
             level_from = metadata["data_sources"][provider_slug].get("level_from")
             level_to = metadata["data_sources"][provider_slug].get("level_to")
 
-            reprojection = mapproxy_reproject(
-                output_file=out_dataset,
-                input_file=in_dataset,
+            job_geom = dptr.run.job.the_geom
+            job_geom.transform(projection)
+            bbox = job_geom.extent
+            mp = mapproxy.MapproxyGeopackage(
+                gpkgfile=out_dataset,
+                service_url=out_dataset,
                 name=job_name,
+                config=config,
+                bbox=bbox,
                 level_from=level_from,
                 level_to=level_to,
-                projection=projection,
-                selection=selection,
                 task_uid=task_uid,
-                config=config,
+                selection=selection,
+                projection=projection,
+                input_gpkg=in_dataset,
             )
+            reprojection = mp.convert()
+            # reprojection = mapproxy_reproject(
+            #     output_file=out_dataset,
+            #     input_file=in_dataset,
+            #     name=job_name,
+            #     level_from=level_from,
+            #     level_to=level_to,
+            #     projection=projection,
+            #     selection=selection,
+            #     task_uid=task_uid,
+            #     config=config,
+            # )
 
-        else:    
+        else:
             reprojection = gdalutils.convert(
                 driver=driver,
                 input_file=in_dataset,
@@ -1075,9 +1094,8 @@ def reprojection_task(
 
     return result
 
-def mapproxy_reproject(
-    output_file, input_file, name, level_from, level_to, projection, selection, task_uid, config
-):
+
+def mapproxy_reproject(output_file, input_file, name, level_from, level_to, projection, selection, task_uid, config):
     # TODO: move this config block elsewhere after testing is done...
 
     config_2 = f"""
@@ -1150,9 +1168,9 @@ def mapproxy_reproject(
             level_from=level_from,
             level_to=level_to,
             task_uid=task_uid,
-            selection=selection, 
+            selection=selection,
             projection=projection,
-            output_file=output_file
+            input_gpkg=output_file,
         )
         gpkg = mp.convert()
 
@@ -1161,6 +1179,7 @@ def mapproxy_reproject(
     except Exception as e:
         logger.error(f"Raised exception in reprojection task, {e}")
         raise e
+
 
 @app.task(name="WFSExport", bind=True, base=ExportTask, abort_on_error=True)
 def wfs_export_task(

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -66,6 +66,7 @@ from eventkit_cloud.tasks.helpers import (
     download_data,
     download_concurrently,
 )
+from eventkit_cloud.jobs.enumerations import GeospatialDataType
 from eventkit_cloud.jobs.helpers import clean_config
 from eventkit_cloud.tasks.metadata import metadata_tasks
 from eventkit_cloud.tasks.task_process import update_progress
@@ -1031,27 +1032,135 @@ def reprojection_task(
 
     # This logic is only valid IFF this method only allows 4326 which is True as of 1.9.0.
     # This needs to be updated to compare the input and output if over source projections are allowed.
-    if not projection or 4326 in str(projection):
+    if not projection or "4326" in str(projection):
         logger.info(f"Skipping projection and renaming {in_dataset} to {out_dataset}")
         os.rename(in_dataset, out_dataset)
     else:
         # If you are updating this see the note above about source projection.
+        dptr = DataProviderTaskRecord.objects.get(tasks__uid__exact=task_uid)
+        metadata = get_metadata(data_provider_task_record_uids=[dptr.uid], source_only=True)
+        data_type = metadata["data_sources"][provider_slug].get("type")
 
-        reprojection = gdalutils.convert(
-            driver=driver,
-            input_file=in_dataset,
-            output_file=out_dataset,
-            task_uid=task_uid,
-            projection=projection,
-            boundary=selection,
-            warp_params=warp_params,
-            translate_params=translate_params,
-        )
+        if "gpkg" in os.path.splitext(in_dataset)[1] and driver == "gpkg" and data_type == GeospatialDataType.RASTER.value:
+            # Use MapProxy instead of GDAL so all the pyramids/zoom levels of the source are preserved.
+
+            level_from = metadata["data_sources"][provider_slug].get("level_from")
+            level_to = metadata["data_sources"][provider_slug].get("level_to")
+
+            reprojection = mapproxy_reproject(
+                output_file=out_dataset,
+                input_file=in_dataset,
+                name=job_name,
+                level_from=level_from,
+                level_to=level_to,
+                projection=projection,
+                selection=selection,
+                task_uid=task_uid,
+                config=config,
+            )
+
+        else:    
+            reprojection = gdalutils.convert(
+                driver=driver,
+                input_file=in_dataset,
+                output_file=out_dataset,
+                task_uid=task_uid,
+                projection=projection,
+                boundary=selection,
+                warp_params=warp_params,
+                translate_params=translate_params,
+            )
 
     result["result"] = reprojection
 
     return result
 
+def mapproxy_reproject(
+    output_file, input_file, name, level_from, level_to, projection, selection, task_uid, config
+):
+    # TODO: move this config block elsewhere after testing is done...
+
+    config_2 = f"""
+    caches:
+        default:
+            sources: [ ]
+            grids: [ default ]
+            cache:
+                type: geopackage
+                filename: {input_file}
+                table_name: default
+            meta_size: [4,4]
+            bulk_meta_tiles: true
+
+        repro_cache:
+            sources: [ default ]
+            grids: [ geom ]
+            cache:
+                type: geopackage
+                filename: {output_file}
+                table_name: default
+
+    grids:
+        default:
+            srs: EPSG:4326
+            tile_size: [ 256, 256 ]
+            origin: nw
+            res: [ 0.7031249999999999, 0.35156249999999994, 0.17578124999999997, 0.08789062499999999,
+                0.04394531249999999, 0.021972656249999997, 0.010986328124999998, 0.005493164062499999,
+                0.0027465820312499996, 0.0013732910156249998, 0.0006866455078124999, 0.00034332275390624995,
+                0.00017166137695312497, 8.583068847656249e-05, 4.291534423828124e-05, 2.145767211914062e-05,
+                1.072883605957031e-05, 5.364418029785155e-06, 2.6822090148925777e-06, 1.3411045074462889e-06,
+                6.705522537231444e-07 ]
+        webmercator:
+            srs: 'EPSG:3857'
+            tile_size: [ 256, 256 ]
+            origin: ul
+
+    coverages:
+        geom:
+            datasource: {selection}
+            srs: 'EPSG:4326'
+
+    seeds:
+        geom:
+            coverages: [ geom ]
+            caches: [ repro_cache ]
+            grids: [ webmercator ]
+            levels:
+                from: {level_from}
+                to: {level_to}
+    layers:
+        -   name: default
+            title: default
+            sources: [ default ]
+    """
+    config_3 = f"""
+    layers:
+        -   name: default
+            title: default
+            sources: [ default ]
+    """
+    print("_________________________________reprojecting...")
+    try:
+        mp = mapproxy.MapproxyGeopackage(
+            gpkgfile=input_file,
+            service_url=input_file,
+            name=name,
+            config=config,
+            level_from=level_from,
+            level_to=level_to,
+            task_uid=task_uid,
+            selection=selection, 
+            projection=projection,
+            output_file=output_file
+        )
+        gpkg = mp.convert()
+
+        return gpkg
+
+    except Exception as e:
+        logger.error(f"Raised exception in reprojection task, {e}")
+        raise e
 
 @app.task(name="WFSExport", bind=True, base=ExportTask, abort_on_error=True)
 def wfs_export_task(
@@ -1500,6 +1609,7 @@ def mapproxy_export_task(
     """
     Function defining geopackage export for external raster service.
     """
+    print("_________________________________ mapproxy_export_task")
     result = result or {}
     selection = parse_result(result, "selection")
 

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -524,6 +524,8 @@ def get_metadata(data_provider_task_record_uids: List[str], source_only=False):
             "metadata": get_metadata_url(data_provider.url, provider_type),
             "copyright": data_provider.service_copyright,
             "layers": data_provider.layers,
+            "level_from": data_provider.level_from,
+            "level_to": data_provider.level_to,
         }
         if (
             metadata["data_sources"][data_provider_task_record.provider.slug].get("type")

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -47,11 +47,8 @@ from eventkit_cloud.tasks.export_tasks import (
     wfs_export_task,
     vector_file_export_task,
     raster_file_export_task,
-<<<<<<< HEAD
     osm_data_collection_pipeline,
-=======
     reprojection_task,
->>>>>>> Clean up, and add/update tests
 )
 from eventkit_cloud.tasks.export_tasks import zip_files
 from eventkit_cloud.tasks.helpers import default_format_time

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -172,6 +172,8 @@ class TestHelpers(TestCase):
         mocked_data_provider.service_description = expected_data_provider_desc = "example_description"
         mocked_data_provider.layers = expected_layers
         mocked_data_provider.data_type = expected_type
+        mocked_data_provider.level_from = expected_level_from = 0
+        mocked_data_provider.level_to = expected_level_to = 12
 
         mocked_provider_task.provider = mocked_data_provider
 
@@ -233,6 +235,8 @@ class TestHelpers(TestCase):
                     "type": expected_type,
                     "uid": expected_provider_task_uid,
                     "layers": expected_layers,
+                    "level_from": expected_level_from,
+                    "level_to": expected_level_to,
                 }
             },
             "date": expected_date,

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -234,11 +234,6 @@ class MapproxyGeopackage(object):
 
         # Create a seed configuration object
         seed_configuration = SeedingConfiguration(seed_dict, mapproxy_conf=mapproxy_configuration)
-
-        logger.info("> Using Configuration:")
-        logger.info(conf_dict)
-        logger.info(" > Using Seed Configuration:")
-        logger.info(seed_dict)
         errors = validate_references(conf_dict)
         if errors:
             logger.error("MapProxy configuration failed.")

--- a/eventkit_cloud/utils/tests/test_mapproxy.py
+++ b/eventkit_cloud/utils/tests/test_mapproxy.py
@@ -118,10 +118,12 @@ class TestGeopackage(TransactionTestCase):
         load_config.assert_called_once_with(mapproxy_config, config_dict=json_config)
         remove_zoom_levels.assert_called_once_with(gpkgfile)
         mock_set_gpkg_contents_bounds.assert_called_once_with(gpkgfile, "imagery", bbox)
-        seed_template.assert_called_once_with(bbox=bbox, coverage_file=None, level_from=0, level_to=10)
+        seed_template.assert_called_once_with(bbox=bbox, coverage_file=None, level_from=0, level_to=10, projection=None)
         self.task_process.side_effect = Exception()
         with self.assertRaises(Exception):
             w2g.convert()
+
+        # test reproject
 
 
 class TestHelpers(TransactionTestCase):


### PR DESCRIPTION
This PR makes it so that geopackages are reprojected using Mapproxy instead of GDAL in order to preserve the overviews.