### PR TITLE
Add bbox chunking for WCS requests

### DIFF
--- a/eventkit_cloud/jobs/helpers.py
+++ b/eventkit_cloud/jobs/helpers.py
@@ -79,7 +79,9 @@ def clean_config(config: str, return_dict: bool = False) -> Union[str, dict]:
     :param return_dict: True if wishing to return config as dictionary.
     :return: A yaml as a str.
     """
-    service_keys = ["cert_var", "cert_cred", "concurrency", "max_repeat", "overpass_query", "max_data_size", "pbf_file"]
+    service_keys = ["cert_var", "cert_cred", "concurrency",
+                    "max_repeat", "overpass_query", "max_data_size",
+                    "pbf_file", "tile_size"]
 
     conf = yaml.safe_load(config) or dict()
 

--- a/eventkit_cloud/jobs/helpers.py
+++ b/eventkit_cloud/jobs/helpers.py
@@ -79,9 +79,16 @@ def clean_config(config: str, return_dict: bool = False) -> Union[str, dict]:
     :param return_dict: True if wishing to return config as dictionary.
     :return: A yaml as a str.
     """
-    service_keys = ["cert_var", "cert_cred", "concurrency",
-                    "max_repeat", "overpass_query", "max_data_size",
-                    "pbf_file", "tile_size"]
+    service_keys = [
+        "cert_var",
+        "cert_cred",
+        "concurrency",
+        "max_repeat",
+        "overpass_query",
+        "max_data_size",
+        "pbf_file",
+        "tile_size",
+    ]
 
     conf = yaml.safe_load(config) or dict()
 

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -830,6 +830,6 @@ def get_chunked_bbox(bbox, size: tuple = None):
     # bbox is the bounding box of all tiles affected at the given level, unused here
     # size is the x, y dimensions of the grid
     # tiles at level is a generator that returns the tiles in order
-    _unused, sizes, tiles_at_level = mapproxy_grid.get_affected_level_tiles(bbox, 0)
+    tiles_at_level = mapproxy_grid.get_affected_level_tiles(bbox, 0)[2]
     # convert the tiles to bboxes representing the tiles on the map
-    return sizes, [mapproxy_grid.tile_bbox(_tile) for _tile in tiles_at_level]
+    return [mapproxy_grid.tile_bbox(_tile) for _tile in tiles_at_level]

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import json
 import logging
 from typing import List, Tuple
@@ -119,7 +118,7 @@ def open_dataset(file_path, is_raster):
             return ogr_dataset or gdal_dataset
     except RuntimeError as ex:
         if ("not recognized as a supported file format" not in str(ex)) or (
-                "Error browsing database for PostGIS Raster tables" in str(ex)
+            "Error browsing database for PostGIS Raster tables" in str(ex)
         ):
             raise ex
     finally:

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -523,7 +523,6 @@ class TestGdalUtils(TestCase):
     @patch("eventkit_cloud.utils.gdalutils.gdal")
     def test_get_chunked_tiles(self, mock_gdal):
         bbox = [-77.26290092220698, 38.58181863431442, -76.86362334675664, 38.94635628150632]
-        tile_dims, bboxes = get_chunked_bbox(bbox)
-        self.assertEqual(tile_dims, (3, 2))
+        bboxes = get_chunked_bbox(bbox)
         self.assertEqual(len(bboxes), 6)
         self.assertEqual(bboxes[0], (-77.26290092220698, 38.76408745791032, -77.08063209861098, 38.94635628150632))

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -19,6 +19,7 @@ from eventkit_cloud.utils.gdalutils import (
     convert_vector,
     progress_callback,
     polygonize,
+    get_chunked_bbox,
 )
 
 logger = logging.getLogger(__name__)
@@ -503,3 +504,11 @@ class TestGdalUtils(TestCase):
             skipFailures=True,
             srcSRS=src_srs,
         )
+
+    @patch("eventkit_cloud.utils.gdalutils.gdal")
+    def test_get_chunked_tiles(self, mock_gdal):
+        bbox = [-77.26290092220698, 38.58181863431442, -76.86362334675664, 38.94635628150632]
+        tile_dims, bboxes = get_chunked_bbox(bbox)
+        self.assertEqual(tile_dims, (3, 2))
+        self.assertEqual(len(bboxes), 6)
+        self.assertEqual(bboxes[0], (-77.26290092220698, 38.76408745791032, -77.08063209861098, 38.94635628150632))

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -179,10 +179,14 @@ class WCSConverter(object):
 
                     # Setting this to arbitrarily high values improves the computed
                     # resolution but makes the requests slow down.
-                    # It could be set from a configuration value
-                    tile_x, tile_y = get_dimensions(_tile_bbox, scale)
-                    params["width"] = tile_x
-                    params["height"] = tile_y
+                    # If it is set in the config, use that value, otherwise compute approximate res based on scale
+                    if self.config.get("tile_size", None) is None:
+                        tile_x, tile_y = get_dimensions(_tile_bbox, scale)
+                        params["width"] = tile_x
+                        params["height"] = tile_y
+                    else:
+                        params["width"] = self.config.get("tile_size")
+                        params["height"] = self.config.get("tile_size")
 
                     params["bbox"] = ",".join(map(str, _tile_bbox))
                     req = auth_requests.get(

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -165,6 +165,7 @@ class WCSConverter(object):
         tile_bboxes = get_chunked_bbox(self.bbox, (width, height))
 
         geotiffs = []
+        auth_session = auth_requests.AuthSession()
         for idx, coverage in enumerate(coverages):
             params["COVERAGE"] = coverage
             file_path, ext = os.path.splitext(self.out)
@@ -189,7 +190,7 @@ class WCSConverter(object):
                         params["height"] = self.config.get("tile_size")
 
                     params["bbox"] = ",".join(map(str, _tile_bbox))
-                    req = auth_requests.get(
+                    req = auth_session.get(
                         self.service_url,
                         params=params,
                         cert_var=cert_var,

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -10,7 +10,7 @@ from django.conf import settings
 
 from eventkit_cloud.tasks.task_process import TaskProcess
 from eventkit_cloud.utils import auth_requests
-from eventkit_cloud.utils.gdalutils import get_dimensions, merge_geotiffs, retry
+from eventkit_cloud.utils.gdalutils import get_dimensions, merge_geotiffs, retry, get_chunked_bbox_at_scale
 
 logger = logging.getLogger(__name__)
 
@@ -158,51 +158,58 @@ class WCSConverter(object):
                 # NOQA
             )
             raise Exception("Data source incorrectly configured.")
-        logger.info("Getting Dimensions...")
-        width, height = get_dimensions(self.bbox, float(service.get("scale")))
 
-        logger.info("{}, {}".format(width, height))
-        params["width"] = str(width)
-        params["height"] = str(height)
+        scale = float(service.get("scale"))
         params["service"] = "WCS"
         params["bbox"] = ",".join(map(str, self.bbox))
+        width, height = get_dimensions(self.bbox, scale)
+        bbox, sizes, tile_bboxes = get_chunked_bbox_at_scale(self.bbox, width, height)
+
+        logger.info(f"width: {width} -- height: {height}")
+        tile_size = get_dimensions(bbox, scale)[0] / sizes[0]
         geotiffs = []
         for idx, coverage in enumerate(coverages):
             params["COVERAGE"] = coverage
             file_path, ext = os.path.splitext(self.out)
-            outfile = "{0}-{1}{2}".format(file_path, idx, ext)
-            try:
-                os.remove(outfile)
-            except OSError:
-                pass
             try:
                 cert_var = self.config.get("cert_var", self.slug)
-                req = auth_requests.get(
-                    self.service_url,
-                    params=params,
-                    cert_var=cert_var,
-                    stream=True,
-                    verify=getattr(settings, "SSL_VERIFICATION", True),
-                )
-                logger.info("Getting the coverage: {0}".format(req.url))
-                try:
-                    size = int(req.headers.get("content-length"))
-                except (ValueError, TypeError):
-                    if req.content:
-                        size = len(req.content)
-                    else:
-                        raise Exception("Overpass Query failed to return any data")
-                if not req:
-                    logger.error(req.content)
-                    raise Exception("WCS request for {0} failed.".format(self.name))
-                CHUNK = 1024 * 1024 * 2  # 2MB chunks
-                from audit_logging.file_logging import logging_open
+                for _bbox_idx, _tile_bbox, in enumerate(tile_bboxes):
+                    outfile = "{0}-{1}-{2}{3}".format(file_path, idx, _bbox_idx, ext)
+                    try:
+                        os.remove(outfile)
+                    except OSError:
+                        pass
 
-                with logging_open(outfile, "wb", user_details=self.user_details) as fd:
-                    for chunk in req.iter_content(CHUNK):
-                        fd.write(chunk)
-                        size += CHUNK
-                geotiffs += [outfile]
+                    params["bbox"] = ",".join(map(str, _tile_bbox))
+                    params["width"] = tile_size
+                    params["height"] = tile_size
+                    req = auth_requests.get(
+                        self.service_url,
+                        params=params,
+                        cert_var=cert_var,
+                        stream=True,
+                        verify=getattr(settings, "SSL_VERIFICATION", True),
+                    )
+                    logger.info(params)
+                    logger.info("Getting the coverage: {0}".format(req.url))
+                    try:
+                        size = int(req.headers.get("content-length"))
+                    except (ValueError, TypeError):
+                        if req.content:
+                            size = len(req.content)
+                        else:
+                            raise Exception("Overpass Query failed to return any data")
+                    if not req:
+                        logger.error(req.content)
+                        raise Exception("WCS request for {0} failed.".format(self.name))
+                    CHUNK = 1024 * 1024 * 2  # 2MB chunks
+                    from audit_logging.file_logging import logging_open
+
+                    with logging_open(outfile, "wb", user_details=self.user_details) as fd:
+                        for chunk in req.iter_content(CHUNK):
+                            fd.write(chunk)
+                            size += CHUNK
+                    geotiffs += [outfile]
             except Exception as e:
                 logger.error(e)
                 raise Exception("There was an error writing the file to disk.")


### PR DESCRIPTION
Adds a function to chunk WCS requests into smaller portions to ease request loads. The requested bbox will be broken into multiple smaller bboxes calculated using mapproxy grids.