### PR TITLE
Cancel the OSM provider task if the geopackage contains no data

### DIFF
--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -560,7 +560,6 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(example_input_file, result["source"])
 
     @patch("eventkit_cloud.tasks.export_tasks.cancel_export_provider_task.run")
-    @patch("eventkit_cloud.tasks.export_tasks.check_content_exists")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_filepath")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_task_record")
     @patch("eventkit_cloud.tasks.export_tasks.os")
@@ -581,7 +580,6 @@ class TestExportTasks(ExportTaskBase):
         mock_os,
         mock_get_export_task_record,
         mock_get_export_filepath,
-        mock_check_content_exists,
         mock_cancel_provider_task,
     ):
         provider_slug = "osm"
@@ -605,7 +603,7 @@ class TestExportTasks(ExportTaskBase):
         mock_cancel_provider_task.assert_not_called()
 
         # Test canceling the provider task on an empty geopackage.
-        mock_check_content_exists.return_value = False
+        mock_geopackage.Geopackage().run.return_value = None
         osm_data_collection_pipeline(
             example_export_task_record_uid, stage_dir, bbox=example_bbox, config=yaml.dump(example_config)
         )
@@ -614,6 +612,7 @@ class TestExportTasks(ExportTaskBase):
         mock_overpass.reset_mock()
         mock_pbf.reset_mock()
         mock_feature_selection.reset_mock()
+        mock_geopackage.reset_mock()
 
         # Test with using pbf_file
         example_pbf_file = "test.pbf"

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -559,6 +559,8 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result["result"])
         self.assertEqual(example_input_file, result["source"])
 
+    @patch("eventkit_cloud.tasks.export_tasks.cancel_export_provider_task.run")
+    @patch("eventkit_cloud.tasks.export_tasks.check_content_exists")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_filepath")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_task_record")
     @patch("eventkit_cloud.tasks.export_tasks.os")
@@ -579,7 +581,11 @@ class TestExportTasks(ExportTaskBase):
         mock_os,
         mock_get_export_task_record,
         mock_get_export_filepath,
+        mock_check_content_exists,
+        mock_cancel_provider_task,
     ):
+        provider_slug = "osm"
+        mock_get_export_task_record.return_value = Mock(export_provider_task=Mock(provider=Mock(slug=provider_slug)))
         example_export_task_record_uid = "1234"
         stage_dir = settings.EXPORT_STAGING_ROOT
         example_bbox = [-1, -1, 1, 1]
@@ -596,6 +602,14 @@ class TestExportTasks(ExportTaskBase):
         mock_overpass.Overpass.assert_called_once()
         mock_pbf.OSMToPBF.assert_called_once()
         mock_feature_selection.example.assert_called_once()
+        mock_cancel_provider_task.assert_not_called()
+
+        # Test canceling the provider task on an empty geopackage.
+        mock_check_content_exists.return_value = False
+        osm_data_collection_pipeline(
+            example_export_task_record_uid, stage_dir, bbox=example_bbox, config=yaml.dump(example_config)
+        )
+        mock_cancel_provider_task.assert_called_once()
 
         mock_overpass.reset_mock()
         mock_pbf.reset_mock()

--- a/eventkit_cloud/utils/geopackage.py
+++ b/eventkit_cloud/utils/geopackage.py
@@ -371,6 +371,8 @@ class Geopackage(object):
         cur.execute("DROP TABLE lines")
         cur.execute("DROP TABLE multipolygons")
 
+        cur.execute("VACUUM;")
+
         conn.commit()
         conn.close()
 
@@ -389,10 +391,10 @@ class Geopackage(object):
                 for geom_type in self.feature_selection.geom_types(theme):
                     for stmt in self.feature_selection.create_sql(theme, geom_type):
                         cur.executescript(stmt)
+                cur.execute("VACUUM;")
                 conn.commit()
                 conn.close()
 
-        cur.execute("VACUUM;")
         update_progress(self.export_task_record_uid, 100, subtask_percentage, subtask_start, eta=eta)
         return self.output_gpkg
 


### PR DESCRIPTION
This PR resolves an issue where the OSM pipeline would continue on even if the Geopackage it created was empty.  Instead of continuing on, we will now cancel the data provider task associated with the failing export.  It also adds a test case to the osm pipeline test cases to account for this change.