### PR TITLE
Add feature chunking

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1337,12 +1337,14 @@ def arcgis_feature_service_export_task(
         tile_bboxes = get_chunked_bbox(bbox)
         chunks = []
         esrijson = get_export_filepath(stage_dir, job_name, projection, provider_slug, "json")
+        bbox = ["{0}", "{1}", "{2}", "{3}"]
+        url = get_arcgis_query_url(service_url, [])
         for _index, _tile_bbox in enumerate(tile_bboxes):
             url = get_arcgis_query_url(service_url, _tile_bbox)
             outfile = get_export_filepath(stage_dir, f"{job_name}_{_index}", projection, provider_slug, "json")
             download_data(task_uid, url, outfile, configuration.get("cert_var"))
             chunks.append(outfile)
-        merge_geojson(chunks[0:1], esrijson, "GeoJSON")
+        merge_geojson(chunks, esrijson, "GeoJSON")
 
         out = gdalutils.convert(
             driver="gpkg",
@@ -1362,7 +1364,7 @@ def arcgis_feature_service_export_task(
     return result
 
 
-def get_arcgis_query_url(service_url: str, bbox: list) -> str:
+def get_arcgis_query_url(service_url: str, bbox: list = None) -> str:
     """
     Function generates ArcGIS query URL
     """
@@ -1380,6 +1382,8 @@ def get_arcgis_query_url(service_url: str, bbox: list) -> str:
             "geometry": str(bbox).strip("[]"),
             "f": "json",
         }
+        if bbox is None:
+            query_params["geometry"] = "{0},{1},{2},{3}"
         query_str = urlencode(query_params, safe="=*")
         query_url = urljoin(f"{service_url}/", f"query?{query_str}")
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -66,7 +66,8 @@ from eventkit_cloud.tasks.helpers import (
     pickle_exception,
     progressive_kill,
     download_data,
-    download_concurrently, download_chunks,
+    download_concurrently,
+    download_chunks,
 )
 from eventkit_cloud.tasks.metadata import metadata_tasks
 from eventkit_cloud.tasks.models import (
@@ -1147,10 +1148,13 @@ def wfs_export_task(
             )
 
     else:
-        logger.info("Downloading WFS")
-        chunks = download_chunks(task_uid, bbox, stage_dir,
-                                 get_wfs_query_url(name, service_url, layer, projection),
-                                 configuration.get("cert_var"),)
+        chunks = download_chunks(
+            task_uid,
+            bbox,
+            stage_dir,
+            get_wfs_query_url(name, service_url, layer, projection),
+            configuration.get("cert_var"),
+        )
         merge_geojson(chunks, gpkg)
 
         out = gdalutils.convert(
@@ -1188,9 +1192,9 @@ def load_provider_config(config: str) -> dict:
     return configuration
 
 
-def get_wfs_query_url(name: str, service_url: str = None,
-                      layer: str = None, projection: int = None,
-                      bbox: list = None) -> str:
+def get_wfs_query_url(
+    name: str, service_url: str = None, layer: str = None, projection: int = None, bbox: list = None
+) -> str:
     """
     Function generates WFS query URL
     """
@@ -1346,9 +1350,9 @@ def arcgis_feature_service_export_task(
             )
 
     else:
-        chunks = download_chunks(task_uid, bbox, stage_dir,
-                                 get_arcgis_query_url(service_url),
-                                 configuration.get("cert_var"),)
+        chunks = download_chunks(
+            task_uid, bbox, stage_dir, get_arcgis_query_url(service_url), configuration.get("cert_var")
+        )
         esrijson = get_export_filepath(stage_dir, job_name, projection, provider_slug, "json")
         merge_geojson(chunks, esrijson)
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -67,7 +67,7 @@ from eventkit_cloud.tasks.helpers import (
     progressive_kill,
     download_data,
     download_concurrently,
-    download_chunks, merge_chunks,
+    merge_chunks,
 )
 from eventkit_cloud.tasks.metadata import metadata_tasks
 from eventkit_cloud.tasks.models import (
@@ -81,7 +81,6 @@ from eventkit_cloud.tasks.models import (
 from eventkit_cloud.tasks.task_base import EventKitBaseTask
 from eventkit_cloud.tasks.task_process import update_progress
 from eventkit_cloud.utils import overpass, pbf, s3, mapproxy, wcs, geopackage, gdalutils, auth_requests
-from eventkit_cloud.utils.gdalutils import merge_geojson
 from eventkit_cloud.utils.qgis_utils import convert_qgis_gpkg_to_kml
 from eventkit_cloud.utils.rocket_chat import RocketChat
 from eventkit_cloud.utils.stats.eta_estimator import ETA
@@ -1158,7 +1157,7 @@ def wfs_export_task(
             bbox,
             stage_dir,
             get_wfs_query_url(name, service_url, layer, projection),
-            configuration.get("cert_var")
+            configuration.get("cert_var"),
         )
 
     result["driver"] = "gpkg"
@@ -1326,7 +1325,7 @@ def arcgis_feature_service_export_task(
                 "base_path": os.path.join(stage_dir, f"{layer.get('name')}-{projection}"),
                 "bbox": bbox,
                 "cert_var": configuration.get("cert_var"),
-                "layer_name": layer.get('name'),
+                "layer_name": layer.get("name"),
                 "projection": projection,
             }
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1131,6 +1131,8 @@ def wfs_export_task(
                 "base_path": os.path.join(stage_dir, f"{layer.get('name')}-{projection}"),
                 "bbox": bbox,
                 "cert_var": configuration.get("cert_var"),
+                "layer_name": layer["name"],
+                "projection": projection,
             }
 
         download_concurrently(layers.values(), configuration.get("concurrency"))

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1316,7 +1316,6 @@ def arcgis_feature_service_export_task(
     vector_layer_data = configuration.get("vector_layers", [])
     if len(vector_layer_data):
         layers = {}
-
         for layer in vector_layer_data:
             path = get_export_filepath(stage_dir, job_name, f"{layer.get('name')}-{projection}", provider_slug, "json")
             url = get_arcgis_query_url(layer.get("url"))
@@ -1354,7 +1353,7 @@ def arcgis_feature_service_export_task(
             bbox,
             stage_dir,
             get_arcgis_query_url(service_url),
-            configuration.get("cert_var")
+            configuration.get("cert_var"),
         )
 
     result["driver"] = "gpkg"

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -32,7 +32,7 @@ from eventkit_cloud.tasks.exceptions import FailedException
 from eventkit_cloud.tasks.models import DataProviderTaskRecord, ExportRunFile, ExportTaskRecord
 from eventkit_cloud.tasks.task_process import update_progress
 from eventkit_cloud.utils import auth_requests, gdalutils
-from eventkit_cloud.utils.gdalutils import get_band_statistics, get_chunked_bbox, merge_geojson
+from eventkit_cloud.utils.gdalutils import get_band_statistics, get_chunked_bbox
 from eventkit_cloud.utils.generic import cd, get_file_paths  # NOQA
 
 logger = logging.getLogger()
@@ -837,15 +837,15 @@ def get_data_package_manifest(metadata: dict, ignore_files: list) -> str:
 
 
 def merge_chunks(
-        output_file,
-        layer_name,
-        projection,
-        task_uid: str,
-        bbox: list,
-        stage_dir: str,
-        base_url: str,
-        cert_var=None,
-        task_points=100
+    output_file,
+    layer_name,
+    projection,
+    task_uid: str,
+    bbox: list,
+    stage_dir: str,
+    base_url: str,
+    cert_var=None,
+    task_points=100,
 ):
     chunks = download_chunks(task_uid, bbox, stage_dir, base_url, cert_var, task_points)
     out = gdalutils.convert(

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -844,10 +844,10 @@ def merge_chunks(
     bbox: list,
     stage_dir: str,
     base_url: str,
-    cert_var=None,
+    cert_info=None,
     task_points=100,
 ):
-    chunks = download_chunks(task_uid, bbox, stage_dir, base_url, cert_var, task_points)
+    chunks = download_chunks(task_uid, bbox, stage_dir, base_url, cert_info, task_points)
     out = gdalutils.convert(
         driver="gpkg",
         input_file=chunks,
@@ -877,7 +877,7 @@ def download_concurrently(layers: ValuesView, concurrency=None):
             bbox=layer.get("bbox"),
             stage_dir=base_path,
             base_url=layer.get("url"),
-            cert_var=layer.get("cert_var"),
+            cert_info=layer.get("cert_info"),
             task_points=task_points,
         )
 
@@ -905,7 +905,7 @@ def download_chunks(task_uid: str, bbox: list, stage_dir: str, base_url: str, ce
         # Replace bbox placeholder here, allowing for the bbox as either a list or tuple
         url = base_url.replace("BBOX_PLACEHOLDER", urllib.parse.quote(str([*_tile_bbox]).strip("[]")))
         outfile = os.path.join(stage_dir, f"chunk{_index}.json")
-        download_data(task_uid, url, outfile, cert_var, task_points=task_points)
+        download_data(task_uid, url, outfile, cert_info, task_points=task_points)
         chunks.append(outfile)
     return chunks
 

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -300,8 +300,8 @@ class TestExportTasks(ExportTaskBase):
         layer = "foo"
         service_url = "https://abc.gov/WFSserver/"
         expected_input_path = (
-             'https://abc.gov/WFSserver/?SERVICE=WFS&VERSION=1.0.0&REQUEST='
-             'GetFeature&TYPENAME=foo&SRSNAME=EPSG:4326&BBOX=2.0%2C%202.0%2C%203.0%2C%203.0'
+            "https://abc.gov/WFSserver/?SERVICE=WFS&VERSION=1.0.0&REQUEST="
+            "GetFeature&TYPENAME=foo&SRSNAME=EPSG:4326&BBOX=2.0%2C%202.0%2C%203.0%2C%203.0"
         )
         mock_merge.return_value = expected_output_path
 
@@ -327,7 +327,7 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
             service_url=service_url,
             layer=layer,
-            bbox=[1, 2, 3, 4]
+            bbox=[1, 2, 3, 4],
         )
         mock_convert.assert_called_once_with(
             driver="gpkg",
@@ -457,10 +457,11 @@ class TestExportTasks(ExportTaskBase):
             service_url=service_url,
             layer=layer,
             config='cert_var: "test2"',
-            bbox=[1, 2, 3, 4]
+            bbox=[1, 2, 3, 4],
         )
-        mock_download_data.assert_called_with(str(saved_export_task.uid),
-                                              expected_input_path, ANY, "test2", task_points=100)
+        mock_download_data.assert_called_with(
+            str(saved_export_task.uid), expected_input_path, ANY, "test2", task_points=100
+        )
 
     @patch("eventkit_cloud.utils.gdalutils.convert")
     @patch("celery.app.task.Task.request")
@@ -828,8 +829,10 @@ class TestExportTasks(ExportTaskBase):
         service_url = "https://abc.gov/arcgis/services/x"
         bbox = [1, 2, 3, 4]
         query_string = "query?where=objectid=objectid&outfields=*&geometry=1%2C+2%2C+3%2C+4&f=json"
-        expected_input_url = ("https://abc.gov/arcgis/services/x/query?where=objectid=objectid&"
-                              "outfields=*&f=json&geometry=2.0%2C%202.0%2C%203.0%2C%203.0")
+        expected_input_url = (
+            "https://abc.gov/arcgis/services/x/query?where=objectid=objectid&"
+            "outfields=*&f=json&geometry=2.0%2C%202.0%2C%203.0%2C%203.0"
+        )
         mock_convert.return_value = expected_esrijson
         mock_merge.return_value = expected_output_path
         mock_download_data.return_value = expected_esrijson

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -274,14 +274,13 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result["result"])
         self.assertEqual(expected_output_path, result["source"])
 
-    @patch("eventkit_cloud.tasks.export_tasks.merge_geojson")
     @patch("eventkit_cloud.tasks.export_tasks.download_concurrently")
     @patch("eventkit_cloud.tasks.helpers.download_data")
     @patch("eventkit_cloud.tasks.export_tasks.gdalutils.convert")
     @patch("eventkit_cloud.tasks.export_tasks.geopackage")
     @patch("celery.app.task.Task.request")
     def test_run_wfs_export_task(
-        self, mock_request, mock_gpkg, mock_convert, mock_download_data, mock_download_concurrently, mock_merge
+        self, mock_request, mock_gpkg, mock_convert, mock_download_data, mock_download_concurrently
     ):
         celery_uid = str(uuid.uuid4())
         type(mock_request).id = PropertyMock(return_value=celery_uid)
@@ -300,12 +299,11 @@ class TestExportTasks(ExportTaskBase):
         layer = "foo"
         service_url = "https://abc.gov/WFSserver/"
         expected_input_path = [
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk0.json'),
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk1.json'),
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk2.json'),
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk3.json'),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk0.json"),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk1.json"),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk2.json"),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk3.json"),
         ]
-        mock_merge.return_value = expected_output_path
 
         mock_convert.return_value = expected_output_path
         mock_download_data.return_value = expected_input_path
@@ -808,13 +806,12 @@ class TestExportTasks(ExportTaskBase):
         )
         self.assertEqual(returned_result, expected_result)
 
-    @patch("eventkit_cloud.tasks.export_tasks.merge_geojson")
     @patch("eventkit_cloud.tasks.export_tasks.download_concurrently")
     @patch("eventkit_cloud.tasks.helpers.download_data")
     @patch("eventkit_cloud.tasks.export_tasks.gdalutils.convert")
     @patch("celery.app.task.Task.request")
     def test_run_arcgis_feature_service_export_task(
-        self, mock_request, mock_convert, mock_download_data, mock_download_concurrently, mock_merge
+        self, mock_request, mock_convert, mock_download_data, mock_download_concurrently,
     ):
         celery_uid = str(uuid.uuid4())
         type(mock_request).id = PropertyMock(return_value=celery_uid)
@@ -831,10 +828,10 @@ class TestExportTasks(ExportTaskBase):
             os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid)), f"{outpath}.gpkg"
         )
         expected_esrijson = [
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk0.json'),
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk1.json'),
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk2.json'),
-            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), 'chunk3.json'),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk0.json"),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk1.json"),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk2.json"),
+            os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid), "chunk3.json"),
         ]
         service_url = "https://abc.gov/arcgis/services/x"
         bbox = [1, 2, 3, 4]
@@ -844,7 +841,6 @@ class TestExportTasks(ExportTaskBase):
             "outfields=*&f=json&geometry=2.0%2C%202.0%2C%203.0%2C%203.0"
         )
         mock_convert.return_value = expected_output_path
-        mock_merge.return_value = expected_output_path
         mock_download_data.return_value = expected_esrijson
 
         previous_task_result = {"source": expected_input_url}

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -828,12 +828,12 @@ class TestExportTasks(ExportTaskBase):
         )
         service_url = "https://abc.gov/arcgis/services/x"
         bbox = [1, 2, 3, 4]
-        query_string = "query?where=objectid=objectid&outfields=*&geometry=1%2C+2%2C+3%2C+4&f=json"
+        query_string = "query?where=objectid=objectid&outfields=*&f=json&geometry=BBOX_PLACEHOLDER"
         expected_input_url = (
             "https://abc.gov/arcgis/services/x/query?where=objectid=objectid&"
             "outfields=*&f=json&geometry=2.0%2C%202.0%2C%203.0%2C%203.0"
         )
-        mock_convert.return_value = expected_esrijson
+        mock_convert.return_value = expected_output_path
         mock_merge.return_value = expected_output_path
         mock_download_data.return_value = expected_esrijson
 
@@ -919,12 +919,16 @@ class TestExportTasks(ExportTaskBase):
                 "task_uid": str(saved_export_task.uid),
                 "url": expected_url_1,
                 "path": expected_path_1,
+                "base_path": f"{stage_dir}{layer_name_1}-{projection}",
+                "bbox": [1, 2, 3, 4],
                 "cert_var": None,
             },
             layer_name_2: {
                 "task_uid": str(saved_export_task.uid),
                 "url": expected_url_2,
                 "path": expected_path_2,
+                "base_path": f"{stage_dir}{layer_name_2}-{projection}",
+                "bbox": [1, 2, 3, 4],
                 "cert_var": None,
             },
         }
@@ -990,7 +994,13 @@ class TestExportTasks(ExportTaskBase):
             bbox=bbox,
             config='cert_var: "test1"',
         )
-        mock_download_data.assert_called_once_with(str(saved_export_task.uid), expected_input_url, ANY, "test1")
+        mock_download_data.assert_called_with(
+            str(saved_export_task.uid),
+            expected_input_url,
+            'dir/chunk3.json',
+            'test1',
+            task_points=100
+        )
 
     @patch("celery.app.task.Task.request")
     @patch("eventkit_cloud.utils.mapproxy.MapproxyGeopackage")

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -995,11 +995,7 @@ class TestExportTasks(ExportTaskBase):
             config='cert_var: "test1"',
         )
         mock_download_data.assert_called_with(
-            str(saved_export_task.uid),
-            expected_input_url,
-            'dir/chunk3.json',
-            'test1',
-            task_points=100
+            str(saved_export_task.uid), expected_input_url, "dir/chunk3.json", "test1", task_points=100
         )
 
     @patch("celery.app.task.Task.request")

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -467,16 +467,10 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
             service_url=service_url,
             layer=layer,
-            config="""
-            cert_info:
-                - cert_path: '/path/to/cert'
-                  cert_pass_var: 'fake_pass'
-
-            """,
             bbox=[1, 2, 3, 4],
         )
         mock_download_data.assert_called_with(
-            str(saved_export_task.uid), ANY, expected_input_path[3], "test2", task_points=100
+            str(saved_export_task.uid), ANY, expected_input_path[3], None, task_points=100
         )
 
     @patch("eventkit_cloud.utils.gdalutils.convert")
@@ -1027,10 +1021,9 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
             service_url=url_1,
             bbox=bbox,
-            config='cert_var: "test1"',
         )
         mock_download_data.assert_called_with(
-            str(saved_export_task.uid), expected_input_url, "dir/chunk3.json", "test1", task_points=100
+            str(saved_export_task.uid), expected_input_url, "dir/chunk3.json", None, task_points=100
         )
 
     @patch("celery.app.task.Task.request")
@@ -1628,7 +1621,11 @@ class TestExportTasks(ExportTaskBase):
             os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid)), expected_outfile
         )
         layer = "foo"
-        config = 'cert_var: "test_var"'
+        config = """
+                 cert_info:
+                     - cert_path: '/path/to/cert'
+                       cert_pass_var: 'fake_pass'
+                 """
         service_url = "https://abc.gov/file.geojson"
 
         mock_convert.return_value = expected_output_path
@@ -1671,7 +1668,7 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result["source"])
         self.assertEqual(expected_output_path, result["gpkg"])
 
-        mock_download_data.assert_called_once_with(service_url, ANY, None)
+        mock_download_data.assert_called_once_with(service_url, ANY, ANY)
 
     @patch("eventkit_cloud.tasks.export_tasks.parse_result")
     @patch("eventkit_cloud.tasks.export_tasks.os")
@@ -1706,7 +1703,12 @@ class TestExportTasks(ExportTaskBase):
             export_provider_task=export_provider_task, status=TaskState.PENDING.value, name=reprojection_task.name
         )
         task_uid = str(saved_export_task.uid)
-        config = 'cert_var: "test_var"'
+        config = """
+        cert_info:
+            - cert_path: '/path/to/cert'
+              cert_pass_var: 'fake_pass'
+
+        """
         selection = "selection.geojson"
         metadata = {"data_sources": {expected_provider_slug: {"type": "something"}}}
         mock_get_metadata.return_value = metadata

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import json
 import logging
 from typing import List, Tuple

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -196,9 +196,6 @@ def get_gdal_metadata(ds_path, is_raster, multiprocess_queue):
             logger.debug("Could not identify dataset {0}".format(ds_path))
 
         multiprocess_queue.put(ret)
-    except:
-        import traceback
-        traceback.print_exc()
     finally:
         cleanup_dataset(dataset)
 

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -331,7 +331,7 @@ def convert(
     meta_list = []
     for _index, _file in enumerate(input_file):
         input_file[_index], output_file = get_dataset_names(_file, output_file)
-        meta_list.append(get_meta(_file, is_raster))
+        meta_list.append(get_meta(input_file[_index], is_raster))
 
     src_src = f"EPSG:{src_srs}"
     dst_src = f"EPSG:{projection}"
@@ -387,7 +387,6 @@ def convert(
             config_options=config_options,
         )
     else:
-        logger.info(f"vector translate: {input_file}")
         cmd = get_task_command(
             convert_vector,
             input_file,

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -119,7 +119,7 @@ def open_dataset(file_path, is_raster):
             return ogr_dataset or gdal_dataset
     except RuntimeError as ex:
         if ("not recognized as a supported file format" not in str(ex)) or (
-                "Error browsing database for PostGIS Raster tables" in str(ex)
+            "Error browsing database for PostGIS Raster tables" in str(ex)
         ):
             raise ex
     finally:

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -758,7 +758,7 @@ def merge_geotiffs(in_files, out_file, task_uid=None):
     return out_file
 
 
-def merge_geojson(in_files, out_file, driver, task_uid=None):
+def merge_geojson(in_files, out_file):
     """
     :param in_files: A list of geojson files.
     :param out_file: A location for the result of the merge.

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -196,7 +196,9 @@ def get_gdal_metadata(ds_path, is_raster, multiprocess_queue):
             logger.debug("Could not identify dataset {0}".format(ds_path))
 
         multiprocess_queue.put(ret)
-
+    except:
+        import traceback
+        traceback.print_exc()
     finally:
         cleanup_dataset(dataset)
 
@@ -326,12 +328,18 @@ def convert(
     :return: Filename of clipped dataset
     """
 
-    input_file, output_file = get_dataset_names(input_file, output_file)
-    meta = get_meta(input_file, is_raster)
+    if isinstance(input_file, str) and not use_translate:
+        input_file = [input_file]
+
+    meta_list = []
+    for _index, _file in enumerate(input_file):
+        input_file[_index], output_file = get_dataset_names(_file, output_file)
+        meta_list.append(get_meta(_file, is_raster))
 
     src_src = f"EPSG:{src_srs}"
     dst_src = f"EPSG:{projection}"
-
+    # Currently, when there are more than 1 files, they much each be the same driver, making the meta the same.
+    meta = meta_list[0]
     if not driver:
         driver = meta["driver"] or "gpkg"
 
@@ -382,6 +390,7 @@ def convert(
             config_options=config_options,
         )
     else:
+        logger.info(f"vector translate: {input_file}")
         cmd = get_task_command(
             convert_vector,
             input_file,
@@ -490,7 +499,11 @@ def convert_raster(
     if isinstance(input_files, str) and not use_translate:
         input_files = [input_files]
     elif isinstance(input_files, list) and use_translate:
-        raise Exception("Cannot use_translate with a list of files.")
+        # If a single file is provided in an array, we can simply pull it out
+        if len(input_files) == 1:
+            input_files = input_files[0]
+        else:
+            raise Exception("Cannot use_translate with a list of files.")
     gdal.UseExceptions()
     subtask_percentage = 50 if driver.lower() == "gtiff" else 100
     options = clean_options(
@@ -577,6 +590,15 @@ def convert_vector(
     :param config_options: A list of gdal configuration options as a tuple (option, value).
     :return: The output file.
     """
+    if isinstance(input_file, str) and access_mode == "append":
+        input_file = [input_file]
+    elif isinstance(input_file, list) and access_mode == "overwrite":
+        # If a single file is provided in an array, we can simply pull it out
+        if len(input_file) == 1:
+            input_file = input_file[0]
+        else:
+            raise Exception("Cannot overwrite with a list of files.")
+
     gdal.UseExceptions()
     options = clean_options(
         {
@@ -601,8 +623,10 @@ def convert_vector(
     if config_options:
         for config_option in config_options:
             gdal.SetConfigOption(*config_option)
-    logger.info(f"calling gdal.VectorTranslate('{output_file}', '{input_file}', {stringify_params(options)})")
-    gdal.VectorTranslate(output_file, input_file, **options)
+    if access_mode == "append":
+        for _input_file in input_file:
+            logger.info(f"calling gdal.VectorTranslate('{output_file}', '{_input_file}', {stringify_params(options)})")
+            gdal.VectorTranslate(output_file, _input_file, **options)
     return output_file
 
 

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -627,6 +627,8 @@ def convert_vector(
         for _input_file in input_file:
             logger.info(f"calling gdal.VectorTranslate('{output_file}', '{_input_file}', {stringify_params(options)})")
             gdal.VectorTranslate(output_file, _input_file, **options)
+    else:
+        gdal.VectorTranslate(output_file, input_file, **options)
     return output_file
 
 

--- a/eventkit_cloud/utils/tests/test_gdalutils.py
+++ b/eventkit_cloud/utils/tests/test_gdalutils.py
@@ -137,7 +137,7 @@ class TestGdalUtils(TestCase):
         )
         get_task_command_mock.assert_called_once_with(
             convert_raster,
-            in_dataset,
+            [in_dataset],
             out_dataset,
             driver=driver,
             config_options=None,
@@ -167,7 +167,7 @@ class TestGdalUtils(TestCase):
         )
         get_task_command_mock.assert_called_once_with(
             convert_raster,
-            in_dataset,
+            [in_dataset],
             out_dataset,
             driver=driver,
             config_options=None,
@@ -194,7 +194,7 @@ class TestGdalUtils(TestCase):
         )
         get_task_command_mock.assert_called_once_with(
             convert_raster,
-            in_dataset,
+            [in_dataset],
             out_dataset,
             driver=driver,
             config_options=None,
@@ -221,7 +221,7 @@ class TestGdalUtils(TestCase):
         )
         get_task_command_mock.assert_called_once_with(
             convert_vector,
-            in_dataset,
+            [in_dataset],
             out_dataset,
             driver=driver,
             config_options=None,
@@ -258,7 +258,7 @@ class TestGdalUtils(TestCase):
         )
         get_task_command_mock.assert_called_once_with(
             convert_raster,
-            in_dataset,
+            [in_dataset],
             out_dataset,
             driver=driver,
             config_options=None,
@@ -287,7 +287,7 @@ class TestGdalUtils(TestCase):
         convert(driver=driver, input_file=in_dataset, output_file=out_dataset, task_uid=self.task_uid, projection=3857)
         get_task_command_mock.assert_called_once_with(
             convert_raster,
-            in_dataset,
+            [in_dataset],
             out_dataset,
             driver=driver,
             config_options=None,


### PR DESCRIPTION
A follow on to the WCS chunking branches. Adds similar capabilities to feature type providers (eg WFS).

Requests will be split into chunks then joined at the end into one output file to spread the load over multiple requests.