### PR TITLE
Disable JS compression to resolve iOS bug.

### DIFF
--- a/config/ui/webpack.config.js
+++ b/config/ui/webpack.config.js
@@ -8,7 +8,7 @@ var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
-var BASE_DIR = path.resolve('eventkit_cloud', 'ui', 'static', 'ui')
+var BASE_DIR = path.resolve('eventkit_cloud', 'ui', 'static', 'ui');
 var BUILD_DIR = path.resolve(BASE_DIR, 'build');
 var APP_DIR = path.resolve(BASE_DIR, 'app');
 
@@ -22,7 +22,7 @@ var plugins = [
     new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),
     new webpack.HashedModuleIdsPlugin(),
     new CompressionPlugin({
-        test: /(\.js$|\.css$)/
+        exclude: /(\.js$)/
     }),
     new ExtractTextPlugin({ filename: '[name].css' })
 ];


### PR DESCRIPTION
Disables compression of JavaScript files to resolve a bug where the site failed to load on iOS due to invalid characters caused by the compression-webpack-plugin.  In order to test this PR, you'll need to use either an iOS device or the XCode iPhone Simulator.  Make sure to bring your containers down and back up after checking out the branch and let webpack recompile.  After webpack recompiles, you should be able to hit the site and see the login page, whereas previously the page would not load.