### PR TITLE
Remove unused variable, update ArcGIS scripts

### DIFF
--- a/eventkit_cloud/tasks/arcgis/create_aprx.py
+++ b/eventkit_cloud/tasks/arcgis/create_aprx.py
@@ -100,16 +100,16 @@ def add_layers_to_group(
                 )
                 continue
             file_path = os.path.abspath(os.path.join(BASE_DIR, file_info["file_path"]))
-            # If possible calculate the statistics now so that they are correct when opening arcmap.
+            # If possible calculate the statistics now so that they are correct when opening ArcPro.
             try:
                 logger.warning((f"Calculating statistics for the file {file_path}..."))
                 arcpy.management.CalculateStatistics(file_path)
             except Exception as e:
                 logger.warning(e)
-            layer_file = get_layer_file(layer_info["type"], version, projection=file_info["projection"])
+            layer_file = get_layer_file(layer_info["type"], version)
             if not (layer_file or layer_info["type"].lower() == "vector"):
                 logger.warning(
-                    f"Skipping layer {vector_layer_name} because the file type is not supported for ArcMap {version}"
+                    f"Skipping layer {vector_layer_name} because the file type is not supported for ArcPro {version}"
                 )
                 continue
             vector_layer_name = (
@@ -235,7 +235,7 @@ def add_layer_to_map(
     layer_name: str, layer_path: str, mapx: arcpy._mp.Map, group_layer: arcpy.mp.LayerFile = None
 ) -> arcpy._mp.Layer:
     """
-    :param layer_name: The name of the layer as it will appear in arcmap.
+    :param layer_name: The name of the layer as it will appear in ArcPro.
     :param layer_file: The .lyr which will be used for the layer template.
     :param data_frame:  The dataframe from the map document where the layer should be loaded.
     :return: Layer, raises exception.
@@ -264,7 +264,7 @@ def get_aprx_template():
     return template_file
 
 
-def get_layer_file(type, version=CURRENT_VERSION, projection="4326"):
+def get_layer_file(type, version=CURRENT_VERSION):
     """
 
     :param type: Type of templace (i.e. raster, osm...)

--- a/eventkit_cloud/tasks/arcgis/create_aprx.py
+++ b/eventkit_cloud/tasks/arcgis/create_aprx.py
@@ -29,7 +29,7 @@ try:
 except Exception as e:
     logger.warning(e)
     input(
-        "Could not import ArcPY.  ArcGIS greater than 10.4 is required to run this script. "
+        "Could not import ArcPY.  ArcGIS Pro is required to run this script. "
         "Please ensure that it is installed and activated. "
         "If multiple versions of python are installed ensure that you are using python that came bundled with ArcGIS. "
         "Press any key to exit."
@@ -105,7 +105,7 @@ def add_layers_to_group(
                 logger.warning((f"Calculating statistics for the file {file_path}..."))
                 arcpy.management.CalculateStatistics(file_path)
             except Exception as e:
-                logger.warning(e)
+                logger.info(e)
             layer_file = get_layer_file(layer_info["type"], version)
             if not (layer_file or layer_info["type"].lower() == "vector"):
                 logger.warning(
@@ -304,7 +304,7 @@ def update_layer(layer: arcpy._mp.Layer, file_path: str, type: str, projection: 
                     logger.debug(f"Updating layers from {lyr.dataSource} to {file_path}")
                     # https://pro.arcgis.com/en/pro-app/latest/arcpy/mapping/updatingandfixingdatasources.htm
                     connection_properties = lyr.connectionProperties
-
+                    logger.debug(f"Updating connection_properties: {connection_properties}")
                     if type == "raster" and os.path.splitext(file_path)[1] != ".gpkg":
                         logger.debug("Replacing Datasource")
                         connection_properties["connection_info"]["database"] = os.path.dirname(file_path)
@@ -325,12 +325,11 @@ def update_layer(layer: arcpy._mp.Layer, file_path: str, type: str, projection: 
                     if lyr.isFeatureLayer:
                         try:
                             logger.debug(arcpy.management.RecalculateFeatureClassExtent(lyr).getMessages())
-                        except Exception as e:
-                            print(e)
-                            raise
+                        except Exception:
+                            logger.warning(f"Could not update the extent for {lyr.name}")
                 except Exception as e:
                     logger.error(e)
-                    # raise
+                    raise
         finally:
             del lyr
 

--- a/eventkit_cloud/tasks/arcgis/create_mxd.py
+++ b/eventkit_cloud/tasks/arcgis/create_mxd.py
@@ -124,7 +124,7 @@ def add_layers_to_group(data_sources, group_layer, mxd, verify=False, version=CU
                 arcpy.CalculateStatistics_management(file_path)
             except Exception as e:
                 logger.warning(e)
-            layer_file = get_layer_file(layer_info["type"], version, projection=file_info["projection"])
+            layer_file = get_layer_file(layer_info["type"], version)
             if not (layer_file or layer_info["type"].lower() == "vector"):
                 logger.warning(
                     (
@@ -248,7 +248,7 @@ def get_mxd_template(version=CURRENT_VERSION):
     return template_file
 
 
-def get_layer_file(type, version=CURRENT_VERSION, projection="4326"):
+def get_layer_file(type, version=CURRENT_VERSION):
     """
 
     :param type: Type of templace (i.e. raster, osm...)
@@ -258,10 +258,7 @@ def get_layer_file(type, version=CURRENT_VERSION, projection="4326"):
     # Use 10.6 templates for versions greater than 10.6.
     if int(version.split(".")[1]) >= 6:
         version = "10.6"
-    if type in ["osm", "nome"]:
-        layer_basename = "{0}-{1}-{2}.lyr".format(type, version.replace(".", "-"), projection)
-    else:
-        layer_basename = "{0}-{1}.lyr".format(type, version.replace(".", "-"))
+    layer_basename = "{0}-{1}.lyr".format(type, version.replace(".", "-"))
     layer_file = os.path.abspath(os.path.join(BASE_DIR, "arcgis", "templates", layer_basename))
     if os.path.isfile(layer_file):
         logger.warning(("Fetching layer template: {0}".format(layer_file)))


### PR DESCRIPTION
This PR resolves an error that was being caused by an unused variable in the ArcGIS scripts.  It also updates some of the debug statements to provide more descriptive warnings.  In order to test, you'll need to run both the MXD and APRX scripts with the correct versions of ArcMap (for MXD) and ArcPro (for APRX).  The scripts should generate mxd and aprx scripts which can then be opened in ArcMap and ArcPro respectively and you should see your datasets.