### PR TITLE
Fix status message on in progress exports

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
@@ -320,14 +320,19 @@ export function CreateDataPackButton(props: Props) {
                 </p>
             )
         }
+        if (!isRunCompleted() && !isRunCanceled()) {
+            return (<p>
+                This DataPack is being processed  We will let you know in the notifications panel when it is ready.
+            </p>)
+        }
         if (isRequestZipFileStatusBad()) {
             return (<p>
                 Unable to create your zipfile at this time, please try again or contact an administrator
-            </p>)
+            </p>);
         }
         return (<p>
             We are creating your zip file. We will let you know in the notifications panel when it is ready.
-        </p>)
+        </p>);
     }
 
     // Builds the icon that is displayed to the left of the button text.

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/CreateDataPackButton.tsx
@@ -322,7 +322,7 @@ export function CreateDataPackButton(props: Props) {
         }
         if (!isRunCompleted() && !isRunCanceled()) {
             return (<p>
-                This DataPack is being processed  We will let you know in the notifications panel when it is ready.
+                This DataPack is being processed. We will let you know in the notifications panel when it is ready.
             </p>)
         }
         if (isRequestZipFileStatusBad()) {


### PR DESCRIPTION
Clicking on the "Job Processing" button on in progress jobs produced a misleading popup message. This PR addresses this by adding in a new message properly indicating the state of the datapack as in progress