### PR TITLE
Pass slug as cred var to allow basic auth

### DIFF
--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -220,7 +220,12 @@ class ProviderCheck(object):
 
             cert_info = self.config.get("cert_info", None)
             response = auth_requests.get(
-                self.service_url, cert_info=cert_info, params=self.query, timeout=self.timeout, verify=self.verify
+                self.service_url,
+                cert_info=cert_info,
+                cred_var=self.slug,
+                params=self.query,
+                timeout=self.timeout,
+                verify=self.verify,
             )
 
             self.token_dict["status"] = response.status_code
@@ -308,7 +313,12 @@ class OverpassProviderCheck(ProviderCheck):
             cert_info = self.config.get("cert_info")
 
             response = auth_requests.post(
-                url=self.service_url, cert_info=cert_info, data="out meta;", timeout=self.timeout, verify=self.verify
+                url=self.service_url,
+                cert_info=cert_info,
+                cred_var=self.slug,
+                data="out meta;",
+                timeout=self.timeout,
+                verify=self.verify,
             )
 
             self.token_dict["status"] = response.status_code
@@ -731,6 +741,7 @@ class FileProviderCheck(ProviderCheck):
             response = auth_requests.head(
                 url=self.service_url,
                 cert_info=cert_info,
+                cred_var=self.slug,
                 timeout=self.timeout,
                 verify=getattr(settings, "SSL_VERIFICATION", True),
             )


### PR DESCRIPTION
Pass provider slug as credentials variable in accordance with auth_requests.handle_basic_auth in order to implement basic auth. 

Note: in dev environment you must add the provider credential variable to the docker-compose.yml or it will not be picked up. I'm not sure prod behaves compared to this. 

Here's the existing docs: 
![image](https://user-images.githubusercontent.com/14204943/118055167-d9e8e900-b344-11eb-8935-bc036ca1499a.png)
That actually seems relatively clear to me, if we want to change anything I'm not sure what to change.
