### PR TITLE
Refactor auth

### DIFF
--- a/eventkit_cloud/auth/auth.py
+++ b/eventkit_cloud/auth/auth.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from django.shortcuts import redirect
 
 from eventkit_cloud.auth.models import OAuth
+from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.ui.helpers import set_session_user_last_active_at
 
 logger = logging.getLogger(__name__)
@@ -60,9 +61,8 @@ def fetch_user_from_token(access_token):
 
     logger.debug('Sending request: access_token="{0}"'.format(access_token))
     try:
-        response = requests.get(
-            "{0}".format(settings.OAUTH_PROFILE_URL), headers={"Authorization": "Bearer {0}".format(access_token)},
-        )
+        session = get_or_update_session(headers={"Authorization": "Bearer {0}".format(access_token)})
+        response = session.get(settings.OAUTH_PROFILE_URL)
         logger.debug("Received response: {0}".format(response.text))
         response.raise_for_status()
     except requests.ConnectionError as err:
@@ -204,7 +204,8 @@ def request_access_token(auth_code):
 
     logger.debug('Requesting: code="{0}"'.format(auth_code))
     try:
-        response = requests.post(
+        session = get_or_update_session()
+        response = session.post(
             settings.OAUTH_TOKEN_URL,
             auth=(settings.OAUTH_CLIENT_ID, settings.OAUTH_CLIENT_SECRET),
             data={"grant_type": "authorization_code", "code": auth_code, "redirect_uri": settings.OAUTH_REDIRECT_URI},

--- a/eventkit_cloud/auth/tests/test_auth.py
+++ b/eventkit_cloud/auth/tests/test_auth.py
@@ -3,13 +3,13 @@
 
 import json
 import logging
-from unittest.mock import patch
 
 import requests
 import requests_mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
+from unittest.mock import patch
 
 from eventkit_cloud.auth.auth import (
     get_user,
@@ -107,7 +107,7 @@ class TestAuth(TestCase):
         self.assertEqual(example_access_token, returned_token)
 
         # Test connection issues
-        with patch("eventkit_cloud.auth.auth.requests.post") as mock_post:
+        with patch("requests.Session.post") as mock_post:
             mock_post.side_effect = requests.ConnectionError()
             with self.assertRaises(OAuthServerUnreachable):
                 request_access_token(OAuthServerUnreachable)
@@ -197,7 +197,7 @@ class TestAuth(TestCase):
 
         # Test connection issues
         self.mock_requests.get(settings.OAUTH_PROFILE_URL, text=json.dumps(user_data), status_code=200)
-        with patch("eventkit_cloud.auth.auth.requests.get") as mock_post:
-            mock_post.side_effect = requests.ConnectionError()
+        with patch("requests.Session.get") as mock_get:
+            mock_get.side_effect = requests.ConnectionError()
             with self.assertRaises(OAuthServerUnreachable):
                 fetch_user_from_token(OAuthServerUnreachable)

--- a/eventkit_cloud/core/helpers.py
+++ b/eventkit_cloud/core/helpers.py
@@ -166,7 +166,7 @@ def get_or_update_session(session=None, max_retries=3, headers=None, **auth_info
         session = requests.Session()
 
     if username and password:
-        logger.error(f"setting {username} and {password} for session")
+        logger.debug(f"setting {username} and {password} for session")
         session.auth = (username, password)
         adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
         session.mount("http://", adapter)

--- a/eventkit_cloud/core/helpers.py
+++ b/eventkit_cloud/core/helpers.py
@@ -162,14 +162,6 @@ def get_or_update_session(session=None, max_retries=3, headers=None, **auth_info
     cert_pass = auth_info.get("cert_pass")
     ssl_verify = getattr(settings, "SSL_VERIFICATION", True)
 
-    # TODO: remove
-    logger.error("************************************")
-    logger.error("username: {}".format(username))
-    logger.error("password: {}".format(password))
-    logger.error("cert_path: {}".format(cert_path))
-    logger.error("cert_pass: {}".format(cert_pass))
-    logger.error("************************************")
-
     if not session:
         session = requests.Session()
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1555,7 +1555,7 @@ def vector_file_export_task(
 
     configuration = load_provider_config(config)
 
-    download_data(task_uid, service_url, gpkg, cert_info=configuration.get("cert_info"))
+    download_data(task_uid, service_url, gpkg, cert_info=configuration.get("cert_info"), provider_slug=provider_slug)
 
     out = gdalutils.convert(
         driver="gpkg",
@@ -1606,7 +1606,7 @@ def raster_file_export_task(
 
     configuration = load_provider_config(config)
 
-    download_data(task_uid, service_url, gpkg, cert_info=configuration.get("cert_info"))
+    download_data(task_uid, service_url, gpkg, cert_info=configuration.get("cert_info"), provider_slug=provider_slug)
 
     out = gdalutils.convert(
         driver="gpkg",
@@ -2461,6 +2461,7 @@ def get_ogcapi_data(
         session=session,
         cert_info=cert_info,
         cookie=cookie,
+        provider_slug=provider_slug,
     )
     extract_metadata_files(download_path, stage_dir)
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -2461,7 +2461,6 @@ def get_ogcapi_data(
         session=session,
         cert_info=cert_info,
         cookie=cookie,
-        provider_slug=provider_slug,
     )
     extract_metadata_files(download_path, stage_dir)
 

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -10,7 +10,6 @@ import urllib.parse
 import uuid
 import xml.etree.ElementTree as ET
 from concurrent import futures
-from enum import Enum
 from functools import reduce
 from operator import itemgetter
 from pathlib import Path
@@ -28,16 +27,15 @@ from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 from enum import Enum
-from functools import reduce, wraps
 from numpy import linspace
 
-from eventkit_cloud.core.helpers import get_cached_model, get_or_update_session
+from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.jobs.enumerations import GeospatialDataType
 from eventkit_cloud.jobs.models import ExportFormat, get_data_provider_label, get_data_type_from_provider, DataProvider
 from eventkit_cloud.tasks import DEFAULT_CACHE_EXPIRATION, set_cache_value
 from eventkit_cloud.tasks.exceptions import FailedException
 from eventkit_cloud.tasks.models import DataProviderTaskRecord, ExportRunFile, ExportTaskRecord
-from eventkit_cloud.utils import auth_requests, gdalutils
+from eventkit_cloud.utils import gdalutils
 from eventkit_cloud.utils.gdalutils import get_band_statistics, get_chunked_bbox
 from eventkit_cloud.utils.generic import cd, get_file_paths  # NOQA
 
@@ -939,13 +937,13 @@ def download_data(
     session=None,
     task_points=100,
     cookie=None,
-    provider_slug: str=None,
+    provider_slug: str = None,
 ):
     """
     Function for downloading data, optionally using a certificate.
     """
 
-    response=None
+    response = None
     try:
         session = get_or_update_session(session=session, cert_info=cert_info, provider_slug=provider_slug)
         response = session.get(input_url, stream=True)

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -945,6 +945,7 @@ def download_data(
     Function for downloading data, optionally using a certificate.
     """
 
+    response=None
     try:
         session = get_or_update_session(session=session, cert_info=cert_info, provider_slug=provider_slug)
         response = session.get(input_url, stream=True)

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -27,8 +27,11 @@ from django.db import connection
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
+from enum import Enum
+from functools import reduce, wraps
 from numpy import linspace
 
+from eventkit_cloud.core.helpers import get_cached_model, get_or_update_session
 from eventkit_cloud.jobs.enumerations import GeospatialDataType
 from eventkit_cloud.jobs.models import ExportFormat, get_data_provider_label, get_data_type_from_provider, DataProvider
 from eventkit_cloud.tasks import DEFAULT_CACHE_EXPIRATION, set_cache_value
@@ -350,14 +353,14 @@ def get_metadata_url(url, type):
 
 def get_osm_last_update(url, cert_info=None):
     """
-
     :param url: A path to the overpass api.
     :param cert_info: Optionally cert info if needed
     :return: The default timestamp as a string (2018-06-18T13:09:59Z)
     """
     try:
         timestamp_url = "{0}timestamp".format(url.rstrip("/").rstrip("interpreter"))
-        response = auth_requests.get(timestamp_url, cert_info=cert_info)
+        session = get_or_update_session(cert_info=cert_info)
+        response = session.get(timestamp_url)
         if response:
             return response.content.decode()
         raise Exception("Get OSM last update failed with {0}: {1}".format(response.status_code, response.content))
@@ -937,16 +940,16 @@ def download_data(
     session=None,
     task_points=100,
     cookie=None,
+    provider_slug: str=None,
 ):
     """
     Function for downloading data, optionally using a certificate.
     """
-    response = None
+    from eventkit_cloud.core.helpers import get_or_update_session
+
     try:
-        auth_session = get_or_update_session(
-            session=session, username=username, password=password, cert_info=cert_info, cookie=cookie
-        )
-        response = auth_session.get(input_url, stream=True)
+        session = get_or_update_session(session=session, cert_info=cert_info, provider_slug=provider_slug)
+        response = session.get(input_url, stream=True)
         response.raise_for_status()
 
     except requests.exceptions.RequestException as e:

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -38,7 +38,6 @@ from eventkit_cloud.tasks import DEFAULT_CACHE_EXPIRATION, set_cache_value
 from eventkit_cloud.tasks.exceptions import FailedException
 from eventkit_cloud.tasks.models import DataProviderTaskRecord, ExportRunFile, ExportTaskRecord
 from eventkit_cloud.utils import auth_requests, gdalutils
-from eventkit_cloud.utils.auth_requests import get_or_update_session
 from eventkit_cloud.utils.gdalutils import get_band_statistics, get_chunked_bbox
 from eventkit_cloud.utils.generic import cd, get_file_paths  # NOQA
 
@@ -945,7 +944,6 @@ def download_data(
     """
     Function for downloading data, optionally using a certificate.
     """
-    from eventkit_cloud.core.helpers import get_or_update_session
 
     try:
         session = get_or_update_session(session=session, cert_info=cert_info, provider_slug=provider_slug)

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -1945,10 +1945,6 @@ class TestExportTasks(ExportTaskBase):
             session_token=session_token,
         )
 
-        mock_download_data.assert_called_once_with(
-            task_uid, download_url, expected_outzip_path, cert_info=None, provider_slug=expected_provider_slug
-        )
-
         expected_result = {
             "driver": "gpkg",
             "file_extension": ".gpkg",

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -71,6 +71,8 @@ test_cert_info = """
         cert_pass_var: 'fakepass'
 """
 
+expected_cert_info = {"cert_path": "/path/to/fake/cert", "cert_pass_var": "fakepass"}
+
 
 class TestLockingTask(TestCase):
     def test_locking_task(self):
@@ -1616,8 +1618,9 @@ class TestExportTasks(ExportTaskBase):
         mock_download_data.assert_called_once_with(
             str(saved_export_task.uid),
             service_url,
-            ANY,
-            cert_info={"cert_path": "/path/to/fake/cert", "cert_pass_var": "fakepass"},
+            expected_output_path,
+            cert_info=expected_cert_info,
+            provider_slug=expected_provider_slug,
         )
 
     @patch("eventkit_cloud.tasks.export_tasks.download_data")
@@ -1639,11 +1642,7 @@ class TestExportTasks(ExportTaskBase):
             os.path.join(settings.EXPORT_STAGING_ROOT.rstrip("\/"), str(self.run.uid)), expected_outfile
         )
         layer = "foo"
-        config = """
-                 cert_info:
-                     cert_path: '/path/to/cert'
-                     cert_pass_var: 'fake_pass'
-                 """
+        config = test_cert_info
         service_url = "https://abc.gov/file.geojson"
 
         mock_convert.return_value = expected_output_path
@@ -1689,8 +1688,9 @@ class TestExportTasks(ExportTaskBase):
         mock_download_data.assert_called_once_with(
             str(saved_export_task.uid),
             service_url,
-            ANY,
-            cert_info={"cert_path": "/path/to/cert", "cert_pass_var": "fake_pass"},
+            expected_output_path,
+            cert_info=expected_cert_info,
+            provider_slug=expected_provider_slug,
         )
 
     @patch("eventkit_cloud.tasks.export_tasks.parse_result")
@@ -1943,6 +1943,10 @@ class TestExportTasks(ExportTaskBase):
             config=config,
             bbox=bbox,
             session_token=session_token,
+        )
+
+        mock_download_data.assert_called_once_with(
+            task_uid, download_url, expected_outzip_path, cert_info=None, provider_slug=expected_provider_slug
         )
 
         expected_result = {

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-import os
+import requests_mock
 import signal
 from unittest.mock import patch, call, Mock, MagicMock
 

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -2,17 +2,15 @@
 
 import json
 import logging
-import requests_mock
 import signal
-from unittest.mock import patch, call, Mock, MagicMock
-
 import requests_mock
+import requests
+
 from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 
 from eventkit_cloud.tasks.enumerations import TaskState
-from requests import Session
 from unittest.mock import patch, call, Mock, MagicMock
 import os
 from eventkit_cloud.tasks.helpers import (
@@ -83,7 +81,7 @@ class TestHelpers(TestCase):
         get_last_update(test_url, test_type)
         mock_get_osm_last_update.assert_called_once_with(test_url, cert_info=None)
 
-    @patch.object(Session, "get")
+    @patch.object(requests.Session, "get")
     def test_get_osm_last_update(self, mock_get):
         test_url = "https://test/interpreter"
         expected_url = "https://test/timestamp"

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -12,6 +12,9 @@ from django.test import TestCase
 from django.utils import timezone
 
 from eventkit_cloud.tasks.enumerations import TaskState
+from requests import Session
+from unittest.mock import patch, call, Mock, MagicMock
+import os
 from eventkit_cloud.tasks.helpers import (
     get_style_files,
     get_file_paths,
@@ -80,18 +83,18 @@ class TestHelpers(TestCase):
         get_last_update(test_url, test_type)
         mock_get_osm_last_update.assert_called_once_with(test_url, cert_info=None)
 
-    @patch("eventkit_cloud.tasks.helpers.auth_requests")
-    def test_get_osm_last_update(self, mock_auth_requests):
+    @patch.object(Session, "get")
+    def test_get_osm_last_update(self, mock_get):
         test_url = "https://test/interpreter"
         expected_url = "https://test/timestamp"
         expected_time = "2017-12-29T13:09:59Z"
 
-        mock_auth_requests.get.return_value.content.decode.return_value = expected_time
+        mock_get.return_value.content.decode.return_value = expected_time
         returned_time = get_osm_last_update(test_url)
-        mock_auth_requests.get.assert_called_once_with(expected_url, cert_info=None)
+        mock_get.assert_called_once_with(expected_url)
         self.assertEqual(expected_time, returned_time)
 
-        mock_auth_requests.get.side_effect = Exception("FAIL")
+        mock_get.side_effect = Exception("FAIL")
         returned_time = get_osm_last_update(test_url)
         self.assertIsNone(returned_time)
 

--- a/eventkit_cloud/utils/auth_requests.py
+++ b/eventkit_cloud/utils/auth_requests.py
@@ -109,7 +109,6 @@ def get_cred(cred_var=None, url=None, params=None):
 _ORIG_HTTPSCONNECTION_INIT = http.client.HTTPSConnection.__init__
 _ORIG_URLOPENERCACHE_CALL = mapproxy_http._URLOpenerCache.__call__
 
-
 def patch_https(cert_info: dict = None):
     """
     Given cert info for a provider, establishes a SSSLContext object using requests_pkcs12 for HTTPSConnection.

--- a/eventkit_cloud/utils/auth_requests.py
+++ b/eventkit_cloud/utils/auth_requests.py
@@ -109,6 +109,7 @@ def get_cred(cred_var=None, url=None, params=None):
 _ORIG_HTTPSCONNECTION_INIT = http.client.HTTPSConnection.__init__
 _ORIG_URLOPENERCACHE_CALL = mapproxy_http._URLOpenerCache.__call__
 
+
 def patch_https(cert_info: dict = None):
     """
     Given cert info for a provider, establishes a SSSLContext object using requests_pkcs12 for HTTPSConnection.

--- a/eventkit_cloud/utils/geocoding/geocode.py
+++ b/eventkit_cloud/utils/geocoding/geocode.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 
 from django.conf import settings
 
-from eventkit_cloud.utils import auth_requests
+from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.utils.geocoding.geocode_auth import get_geocode_cert_info
 from eventkit_cloud.utils.geocoding.geocode_auth_response import GeocodeAuthResponse
 
@@ -298,9 +298,8 @@ class Pelias(GeocodeAdapter):
                 break
 
         if search_id:
-            response = auth_requests.get(
-                update_url, params={"ids": search_id}, cert_info=get_geocode_cert_info()
-            ).json()
+            session = get_or_update_session(cert_info=get_geocode_cert_info())
+            response = session.get(update_url, params={"ids": search_id}).json()
             features = response.get("features", [])
             if len(features):
                 feature = features[0]

--- a/eventkit_cloud/utils/geocoding/geocode_auth.py
+++ b/eventkit_cloud/utils/geocoding/geocode_auth.py
@@ -4,8 +4,7 @@ import os
 import requests
 from django.conf import settings
 from django.core.cache import cache
-
-from eventkit_cloud.utils import auth_requests
+from eventkit_cloud.core.helpers import get_or_update_session
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +44,8 @@ def authenticate():
         url = getattr(settings, "GEOCODING_AUTH_URL")
         if url:
             logger.info("Receiving new authentication token for geocoder.")
-            auth_response = auth_requests.get(
-                getattr(settings, "GEOCODING_AUTH_URL"),
-                verify=getattr(settings, "SSL_VERIFICATION", True),
-                cert_info=get_geocode_cert_info(),
-            ).json()
+            session = get_or_update_session(cert_info=get_geocode_cert_info())
+            auth_response = session.get(getattr(settings, "GEOCODING_AUTH_URL")).json()
 
             token = auth_response.get("token")
             # if not token set the token key as something so we know not to check this everytime.

--- a/eventkit_cloud/utils/geocoding/geocode_auth_response.py
+++ b/eventkit_cloud/utils/geocoding/geocode_auth_response.py
@@ -45,11 +45,7 @@ def get_auth_response(url, payload):
     session = get_or_update_session(cert_info=get_geocode_cert_info())
     response = session.get(url, params=payload)
     if response.ok and check_data(response):
-<<<<<<< HEAD
-        update_session_cookies(session.session.cookies)
-=======
         update_session_cookies(session.cookies)
->>>>>>> pass slug as cred var to allow basic auth
         return response
 
 

--- a/eventkit_cloud/utils/geocoding/geocode_auth_response.py
+++ b/eventkit_cloud/utils/geocoding/geocode_auth_response.py
@@ -1,14 +1,12 @@
 import logging
 import os
-
-from eventkit_cloud.utils import auth_requests
-from eventkit_cloud.utils.auth_requests import get_or_update_session
 from eventkit_cloud.utils.geocoding.geocode_auth import (
     get_session_cookies,
     get_auth_headers,
     update_session_cookies,
     get_geocode_cert_info,
 )
+from eventkit_cloud.core.helpers import get_or_update_session
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +25,8 @@ class GeocodeAuthResponse(object):
             else:
                 raise Exception(error_message)
         else:
-            response = auth_requests.get(self.url, params=payload)
+            session = get_or_update_session()
+            response = session.get(self.url, params=payload)
             if not response.ok:
                 raise Exception(error_message)
             return response
@@ -36,7 +35,8 @@ class GeocodeAuthResponse(object):
 def get_cached_response(url, payload):
     cookies = get_session_cookies()
     headers = get_auth_headers()
-    response = auth_requests.get(url, params=payload, cookies=cookies, headers=headers)
+    session = get_or_update_session(headers=headers)
+    response = session.get(url, params=payload, cookies=cookies)
     if response.ok and check_data(response):
         return response
 
@@ -45,7 +45,11 @@ def get_auth_response(url, payload):
     session = get_or_update_session(cert_info=get_geocode_cert_info())
     response = session.get(url, params=payload)
     if response.ok and check_data(response):
+<<<<<<< HEAD
         update_session_cookies(session.session.cookies)
+=======
+        update_session_cookies(session.cookies)
+>>>>>>> pass slug as cred var to allow basic auth
         return response
 
 

--- a/eventkit_cloud/utils/ogcapi_process.py
+++ b/eventkit_cloud/utils/ogcapi_process.py
@@ -15,7 +15,7 @@ from eventkit_cloud.jobs.models import clean_config
 from eventkit_cloud.jobs.models import load_provider_config
 from eventkit_cloud.tasks.enumerations import OGC_Status
 from eventkit_cloud.core.helpers import get_or_update_session
-from eventkit_cloud.tasks.task_process import update_progress
+from eventkit_cloud.tasks.helpers import update_progress
 from django.conf import settings
 from urllib.parse import urljoin
 

--- a/eventkit_cloud/utils/ogcapi_process.py
+++ b/eventkit_cloud/utils/ogcapi_process.py
@@ -2,12 +2,11 @@ import copy
 import json
 import logging
 import time
-from urllib.parse import urljoin
-
 import requests
-from django.conf import settings
+
 from django.contrib.gis.geos import WKTWriter
 from django.core.cache import cache
+from urllib.parse import urljoin
 
 from eventkit_cloud.utils import gdalutils
 from eventkit_cloud.auth.views import has_valid_access_token
@@ -16,8 +15,11 @@ from eventkit_cloud.jobs.models import load_provider_config
 from eventkit_cloud.tasks.enumerations import OGC_Status
 from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.tasks.helpers import update_progress
-from django.conf import settings
-from urllib.parse import urljoin
+
+logger = logging.getLogger(__name__)
+
+
+PROCESS_CACHE_TIMEOUT = 600
 
 
 class OgcApiProcess:

--- a/eventkit_cloud/utils/overpass.py
+++ b/eventkit_cloud/utils/overpass.py
@@ -8,8 +8,8 @@ from string import Template
 import yaml
 from django.conf import settings
 from requests import exceptions
-
-from eventkit_cloud.utils import auth_requests
+from eventkit_cloud.core.helpers import get_or_update_session
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,6 @@ class Overpass(object):
         self.job_name = job_name
         self.debug = debug
         self.task_uid = task_uid
-        self.verify_ssl = getattr(settings, "SSL_VERIFICATION", True)
         self.config = config
         if bbox:
             # Overpass expects a bounding box string of the form "<lat0>,<long0>,<lat1>,<long1>"
@@ -119,11 +118,12 @@ class Overpass(object):
             conf: dict = yaml.safe_load(self.config) or dict()
             cert_info = conf.get("cert_info")
 
-            req = auth_requests.post(self.url, cert_info=cert_info, data=query, stream=True, verify=self.verify_ssl)
+            session = get_or_update_session(cert_info=cert_info, slug=self.slug)
+            req = session.post(self.url, data=query, stream=True)
             if not req.ok:
                 # Workaround for https://bugs.python.org/issue27777
                 query = {"data": query}
-                req = auth_requests.post(self.url, cert_info=cert_info, data=query, stream=True, verify=self.verify_ssl)
+                req = session.post(self.url, data=query, stream=True)
             req.raise_for_status()
             try:
                 total_size = int(req.headers.get("content-length"))

--- a/eventkit_cloud/utils/overpass.py
+++ b/eventkit_cloud/utils/overpass.py
@@ -5,7 +5,6 @@ import os
 from datetime import datetime
 from string import Template
 
-import yaml
 from django.conf import settings
 from requests import exceptions
 from eventkit_cloud.core.helpers import get_or_update_session

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -8,7 +8,6 @@ import xml.etree.ElementTree as ET
 from enum import Enum
 from io import StringIO
 from typing import Type
-from urllib.parse import urljoin
 
 import requests
 import yaml
@@ -727,8 +726,6 @@ class FileProviderCheck(ProviderCheck):
                 self.result = CheckResults.NO_URL
                 return
 
-            cert_info = self.config.get("cert_info")
-
             response = self.session.head(url=self.service_url, timeout=self.timeout)
 
             self.token_dict["status"] = response.status_code
@@ -783,7 +780,6 @@ class OGCProviderCheck(ProviderCheck):
                 self.result = CheckResults.NO_URL
                 return
 
-            cert_info = self.config.get("cert_info")
             service_url = self.service_url.rstrip("/\\")
             processes_endpoint = urljoin(service_url, "processes/")
 

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -310,22 +310,7 @@ class OverpassProviderCheck(ProviderCheck):
                 self.result = CheckResults.NO_URL
                 return
 
-<<<<<<< HEAD
-            cert_info = self.config.get("cert_info")
-
-            query = "out meta;"
-            response = auth_requests.post(
-                url=self.service_url, cert_info=cert_info, data=query, timeout=self.timeout, verify=self.verify
-            )
-            if not response.ok:
-                # Workaround for https://bugs.python.org/issue27777
-                query = {"data": query}
-                response = auth_requests.post(
-                    self.service_url, cert_info=cert_info, data=query, timeout=self.timeout, verify=self.verify
-                )
-=======
             response = self.session.post(url=self.service_url, data="out meta;", timeout=self.timeout)
->>>>>>> pass slug as cred var to allow basic auth
 
             self.token_dict["status"] = response.status_code
 

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -42,21 +42,6 @@ class TestAuthResult(TransactionTestCase):
         self.assertEqual("test", result.content)
 
     @patch.dict(os.environ, {"fakepassvar": "FAKEPASS"})
-    @patch("eventkit_cloud.utils.auth_requests.requests_pkcs12.get")
-    def test_get(self, get_patch):
-        self.do_tests(auth_requests.get, get_patch)
-
-    @patch.dict(os.environ, {"fakepassvar": "FAKEPASS"})
-    @patch("eventkit_cloud.utils.auth_requests.requests_pkcs12.head")
-    def test_head(self, get_patch):
-        self.do_tests(auth_requests.head, get_patch)
-
-    @patch.dict(os.environ, {"fakepassvar": "FAKEPASS"})
-    @patch("eventkit_cloud.utils.auth_requests.requests_pkcs12.post")
-    def test_post(self, post_patch):
-        self.do_tests(auth_requests.post, post_patch)
-
-    @patch.dict(os.environ, {"fakepassvar": "FAKEPASS"})
     @patch("eventkit_cloud.utils.auth_requests.create_ssl_context")
     @patch("eventkit_cloud.utils.auth_requests.os.getenv")
     def test_patch_https(self, getenv, create_ssl_sslcontext):

--- a/eventkit_cloud/utils/tests/test_geocode.py
+++ b/eventkit_cloud/utils/tests/test_geocode.py
@@ -14,12 +14,14 @@ logger = logging.getLogger(__name__)
 @override_settings(GEOCODING_AUTH_URL=None)
 class TestGeoCode(TestCase):
     def setUp(self):
-        self.mock_requests = requests_mock.Mocker()
-        self.mock_requests.start()
-        self.addCleanup(self.mock_requests.stop)
+        self.adapter = requests_mock.Adapter()
+        self.session = requests.Session()
+        self.session.mount("mock://", self.adapter)
 
-    def geocode_test(self, api_response):
-        self.mock_requests.get(settings.GEOCODING_API_URL, text=json.dumps(api_response), status_code=200)
+    @patch("eventkit_cloud.utils.geocoding.geocode_auth_response.get_or_update_session")
+    def geocode_test(self, api_response, mock_get_session):
+        mock_get_session.return_value = self.session
+        self.adapter.register_uri("GET", settings.GEOCODING_API_URL, text=json.dumps(api_response), status_code=200)
         geocode = Geocode()
         result = geocode.search("test")
         self.assertIsNotNone(result.get("features"))
@@ -35,7 +37,7 @@ class TestGeoCode(TestCase):
             for property in GeocodeAdapter._properties:
                 self.assertTrue(property in properties)
 
-    @override_settings(GEOCODING_API_URL="http://geonames.url/", GEOCODING_API_TYPE="geonames")
+    @override_settings(GEOCODING_API_URL="mock://geonames.url/", GEOCODING_API_TYPE="geonames")
     def test_geonames_success(self):
         geonames_response = {
             "totalResultsCount": 2786,
@@ -80,9 +82,9 @@ class TestGeoCode(TestCase):
         self.geocode_test(geonames_response)
 
     @override_settings(
-        GEOCODING_API_URL="http://geonames.url/",
+        GEOCODING_API_URL="mock://geonames.url/",
         GEOCODING_API_TYPE="geonames",
-        GEOCODING_UPDATE_URL="http://geonames.url/fake-update",
+        GEOCODING_UPDATE_URL="mock://geonames.url/fake-update",
     )
     def test_geonames_add_bbox(self):
         in_result = {
@@ -113,7 +115,7 @@ class TestGeoCode(TestCase):
         result = geocode.add_bbox(in_result)
         self.assertEqual(result, in_result)
 
-    @override_settings(GEOCODING_API_URL="http://pelias.url/", GEOCODING_API_TYPE="pelias")
+    @override_settings(GEOCODING_API_URL="mock://pelias.url/", GEOCODING_API_TYPE="pelias")
     def test_pelias_success(self):
         pelias_response = {
             "geocoding": {
@@ -191,13 +193,15 @@ class TestGeoCode(TestCase):
 
         self.geocode_test(pelias_response)
 
+    @patch("eventkit_cloud.utils.geocoding.geocode.get_or_update_session")
     @patch("eventkit_cloud.utils.geocoding.geocode.get_geocode_cert_info")
     @override_settings(
-        GEOCODING_API_URL="http://pelias.url/",
+        GEOCODING_API_URL="mock://pelias.url/",
         GEOCODING_API_TYPE="pelias",
-        GEOCODING_UPDATE_URL="http://pelias.url/place",
+        GEOCODING_UPDATE_URL="mock://pelias.url/place",
     )
-    def test_pelias_add_bbox(self, get_cert_info):
+    def test_pelias_add_bbox(self, get_cert_info, mock_get_session):
+        mock_get_session.return_value = self.session
         get_cert_info.return_value = None
         in_result = {
             "type": "Feature",
@@ -263,7 +267,7 @@ class TestGeoCode(TestCase):
             ],
             "bbox": [102.020749821, 17.6291659858, 102.33623593, 17.8795015544],
         }
-        self.mock_requests.get(settings.GEOCODING_UPDATE_URL, text=json.dumps(api_response), status_code=200)
+        self.adapter.register_uri("GET", settings.GEOCODING_UPDATE_URL, text=json.dumps(api_response), status_code=200)
         expected_bbox = api_response.get("bbox")
         geocode = Geocode()
         result = geocode.add_bbox(in_result)
@@ -271,7 +275,7 @@ class TestGeoCode(TestCase):
         self.assertEqual(result.get("bbox"), expected_bbox)
         self.assertEqual(result.get("properties").get("bbox"), expected_bbox)
 
-    @override_settings(GEOCODING_API_URL="http://pelias.url/", GEOCODING_API_TYPE="pelias", GEOCODING_UPDATE_URL="")
+    @override_settings(GEOCODING_API_URL="mock://pelias.url/", GEOCODING_API_TYPE="pelias", GEOCODING_UPDATE_URL="")
     def test_geocode_no_update_url(self):
         in_result = {
             "type": "Feature",
@@ -349,18 +353,20 @@ class TestGeoCode(TestCase):
         self.assertFalse(is_valid_bbox(bbox))
 
     @override_settings(
-        GEOCODING_API_URL="http://pelias.url/",
+        GEOCODING_API_URL="mock://pelias.url/",
         GEOCODING_API_TYPE="pelias",
-        GEOCODING_UPDATE_URL="http://pelias.url/place",
+        GEOCODING_UPDATE_URL="mock://pelias.url/place",
     )
-    def test_pelias_point_geometry(self):
+    @patch("eventkit_cloud.utils.geocoding.geocode_auth_response.get_or_update_session")
+    def test_pelias_point_geometry(self, mock_get_session):
         bbox = [-71.1912490997, 42.227911131, -70.9227798807, 42.3969775021]
         api_response = {
             "features": [
                 {"type": "Feature", "geometry": {"type": "Point", "coordinates": []}, "properties": {}, "bbox": bbox}
             ]
         }
-        self.mock_requests.get(settings.GEOCODING_API_URL, text=json.dumps(api_response), status_code=200)
+        mock_get_session.return_value = self.session
+        self.adapter.register_uri("GET", settings.GEOCODING_API_URL, text=json.dumps(api_response), status_code=200)
         geocode = Geocode()
         result = geocode.search("test")
         self.assertEqual(
@@ -377,11 +383,13 @@ class TestGeoCode(TestCase):
         )
 
     @override_settings(
-        GEOCODING_API_URL="http://pelias.url/",
+        GEOCODING_API_URL="mock://pelias.url/",
         GEOCODING_API_TYPE="pelias",
-        GEOCODING_UPDATE_URL="http://pelias.url/place",
+        GEOCODING_UPDATE_URL="mock://pelias.url/place",
     )
-    def test_pelias_polygon_geometry(self):
+    @patch("eventkit_cloud.utils.geocoding.geocode_auth_response.get_or_update_session")
+    def test_pelias_polygon_geometry(self, mock_get_session):
+        mock_get_session.return_value = self.session
         polygonCoordinates = [[[0, 1], [1, 0], [0, 3]]]
         bbox = [-71.1912490997, 42.227911131, -70.9227798807, 42.3969775021]
         api_response = {
@@ -394,12 +402,12 @@ class TestGeoCode(TestCase):
                 }
             ]
         }
-        self.mock_requests.get(settings.GEOCODING_API_URL, text=json.dumps(api_response), status_code=200)
+        self.adapter.register_uri("GET", settings.GEOCODING_API_URL, text=json.dumps(api_response), status_code=200)
         geocode = Geocode()
         result = geocode.search("test")
         self.assertEqual(result.get("features")[0].get("geometry").get("coordinates"), polygonCoordinates)
 
-        @override_settings(GEOCODING_API_URL="http://nominatim.url/", GEOCODING_API_TYPE="nominatim")
+        @override_settings(GEOCODING_API_URL="mock://nominatim.url/", GEOCODING_API_TYPE="nominatim")
         def test_nominatim_success(self):
             nominatim_response = [
                 {

--- a/eventkit_cloud/utils/tests/test_geocode.py
+++ b/eventkit_cloud/utils/tests/test_geocode.py
@@ -1,8 +1,9 @@
 import json
 import logging
-from unittest.mock import patch
-
 import requests_mock
+import requests
+
+from unittest.mock import patch
 from django.conf import settings
 from django.test import TestCase, override_settings
 

--- a/eventkit_cloud/utils/tests/test_geocode_auth.py
+++ b/eventkit_cloud/utils/tests/test_geocode_auth.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from unittest.mock import patch
 
 import requests
 from django.conf import settings

--- a/eventkit_cloud/utils/tests/test_geocode_auth.py
+++ b/eventkit_cloud/utils/tests/test_geocode_auth.py
@@ -1,5 +1,5 @@
 import logging
-from unittest.mock import patch
+import os
 
 import requests
 from django.conf import settings
@@ -56,20 +56,26 @@ class TestGeoCodeAuth(TestCase):
         self.assertEquals(example_cookies, get_session_cookies())
         mock_cache.get.assert_called_once_with(CACHE_COOKIE_KEY)
 
+    @patch.dict(
+        os.environ, {"GEOCODING_AUTH_CERT_PATH": "/path/to/fake/file", "GEOCODING_AUTH_CERT_PASS_VAR": "123456"}
+    )
     @patch("eventkit_cloud.utils.geocoding.geocode_auth.cache")
-    @patch("eventkit_cloud.utils.geocoding.geocode_auth.auth_requests")
-    def test_authenticate(self, mock_auth_requests, mock_cache):
+    @patch("requests.Session.get")
+    @patch("requests.Response")
+    def test_authenticate(self, mock_response, mock_session_get, mock_cache):
         with self.settings(GEOCODING_AUTH_URL="http://test.test"):
             example_token = "test_token"
             example_response = {"token": example_token}
-            mock_auth_requests.get().json.return_value = example_response
+            mock_response.json.return_value = example_response
+            mock_session_get.return_value = mock_response
             self.assertEquals(example_token, authenticate())
             mock_cache.set.assert_called_once_with(CACHE_TOKEN_KEY, example_token, CACHE_TOKEN_TIMEOUT)
             mock_cache.reset_mock()
 
         with self.settings(GEOCODING_AUTH_URL="http://test.test"):
             example_response = {}
-            mock_auth_requests.get().json.return_value = example_response
+            mock_response.json.return_value = example_response
+            mock_session_get.return_value = mock_response
             self.assertIsNone(authenticate())
             mock_cache.set.assert_called_once_with(CACHE_TOKEN_KEY, settings.GEOCODING_AUTH_URL, CACHE_TOKEN_TIMEOUT)
             mock_cache.reset_mock()
@@ -78,6 +84,7 @@ class TestGeoCodeAuth(TestCase):
             self.assertIsNone(authenticate())
 
         with self.settings(GEOCODING_AUTH_URL="http://test.test"):
-            mock_auth_requests.get().json.side_effect = requests.exceptions.RequestException()
+            mock_response.json.side_effect = requests.exceptions.RequestException()
+            mock_session_get.return_value = mock_response
             self.assertIsNone(authenticate())
             mock_cache.delete.assert_called_once_with(CACHE_TOKEN_KEY)

--- a/eventkit_cloud/utils/tests/test_overpass.py
+++ b/eventkit_cloud/utils/tests/test_overpass.py
@@ -72,7 +72,7 @@ class TestOverpass(TestCase):
 
     @patch("django.db.connection.close")
     @patch("eventkit_cloud.tasks.models.ExportTaskRecord")
-    @patch("eventkit_cloud.utils.overpass.auth_requests.post")
+    @patch("requests.Session.post")
     def test_run_query(self, mock_post, export_task, mock_close):
         verify_ssl = getattr(settings, "SSL_VERIFICATION", True)
         export_task_instance = Mock(progress=0, estimated_finish=None)
@@ -95,7 +95,7 @@ class TestOverpass(TestCase):
         mock_response.iter_content.return_value = sample_data
         mock_post.return_value = mock_response
         op.run_query()
-        mock_post.assert_called_once_with(self.url, cert_info=None, data=overpass_query, stream=True, verify=verify_ssl)
+        mock_post.assert_called_once_with(self.url, data=overpass_query, stream=True)
         mock_close.assert_called()
         f = open(out)
         data = f.read()

--- a/eventkit_cloud/utils/tests/test_overpass.py
+++ b/eventkit_cloud/utils/tests/test_overpass.py
@@ -74,7 +74,6 @@ class TestOverpass(TestCase):
     @patch("eventkit_cloud.tasks.models.ExportTaskRecord")
     @patch("requests.Session.post")
     def test_run_query(self, mock_post, export_task, mock_close):
-        verify_ssl = getattr(settings, "SSL_VERIFICATION", True)
         export_task_instance = Mock(progress=0, estimated_finish=None)
         export_task.objects.get.return_value = export_task_instance
         # Only important that it's not None

--- a/eventkit_cloud/utils/tests/test_pcf.py
+++ b/eventkit_cloud/utils/tests/test_pcf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
-from unittest.mock import patch
 import os
 from unittest.mock import patch
 

--- a/eventkit_cloud/utils/tests/test_pcf.py
+++ b/eventkit_cloud/utils/tests/test_pcf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import logging
+from unittest.mock import patch
 import os
 from unittest.mock import patch
 

--- a/eventkit_cloud/utils/tests/test_provider_check.py
+++ b/eventkit_cloud/utils/tests/test_provider_check.py
@@ -102,7 +102,7 @@ class TestProviderCheck(TransactionTestCase):
         result_status = json.loads(pc.check())["status"]
         self.assertEqual(get_status(CheckResults.NO_URL), result_status)
 
-    @patch("eventkit_cloud.utils.provider_check.auth_requests.get")
+    @patch("requests.Session.get")
     def test_check_wfs(self, get):
         url = "http://example.com/wfs?"
         layer = "exampleLayer"
@@ -133,7 +133,7 @@ class TestProviderCheck(TransactionTestCase):
 
         self.check_ows(get, "wfs", pc, invalid_content, empty_content, no_intersect_content, valid_content)
 
-    @patch("eventkit_cloud.utils.provider_check.auth_requests.get")
+    @patch("requests.Session.get")
     def test_check_wcs(self, get):
         url = "http://example.com/wcs?"
         coverage = "exampleCoverage"
@@ -169,7 +169,7 @@ class TestProviderCheck(TransactionTestCase):
 
         self.check_ows(get, "wcs", pc, invalid_content, empty_content, no_intersect_content, valid_content)
 
-    @patch("eventkit_cloud.utils.provider_check.auth_requests.get")
+    @patch("requests.Session.get")
     def test_check_wms(self, get):
         url = "http://example.com/wms?"
         layer = "exampleLayer"
@@ -220,7 +220,7 @@ class TestProviderCheck(TransactionTestCase):
 
         self.check_ows(get, "wms", pc, invalid_content, empty_content, no_intersect_content, valid_content)
 
-    @patch("eventkit_cloud.utils.provider_check.auth_requests.get")
+    @patch("requests.Session.get")
     def test_check_wmts(self, get):
         url = "http://example.com/wmts?"
         layer = "exampleLayer"

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -6,12 +6,10 @@ import tempfile
 from string import Template
 
 import yaml
-from django.conf import settings
 
 from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.tasks.task_process import TaskProcess
 from eventkit_cloud.utils import auth_requests
-from eventkit_cloud.utils.auth_requests import get_or_update_session
 from eventkit_cloud.utils.gdalutils import get_dimensions, merge_geotiffs, retry, get_chunked_bbox
 
 logger = logging.getLogger(__name__)

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -8,6 +8,7 @@ from string import Template
 import yaml
 from django.conf import settings
 
+from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.tasks.task_process import TaskProcess
 from eventkit_cloud.utils import auth_requests
 from eventkit_cloud.utils.auth_requests import get_or_update_session
@@ -166,7 +167,7 @@ class WCSConverter(object):
         tile_bboxes = get_chunked_bbox(self.bbox, (width, height))
 
         geotiffs = []
-        session = get_or_update_session(cert_info=self.config.get("cert_info"))
+        session = get_or_update_session(cert_info=self.config.get("cert_info"), slug=self.slug)
         for idx, coverage in enumerate(coverages):
             params["COVERAGE"] = coverage
             file_path, ext = os.path.splitext(self.out)
@@ -190,12 +191,7 @@ class WCSConverter(object):
                         params["height"] = self.config.get("tile_size")
 
                     params["bbox"] = ",".join(map(str, _tile_bbox))
-                    req = session.get(
-                        self.service_url,
-                        params=params,
-                        stream=True,
-                        verify=getattr(settings, "SSL_VERIFICATION", True),
-                    )
+                    req = session.get(self.service_url, params=params, stream=True)
                     try:
                         size = int(req.headers.get("content-length"))
                     except (ValueError, TypeError):


### PR DESCRIPTION
Refactor the way authentication works, get rid of auth_requests.get/head/post in favor of session objects. 

Here's the existing docs for provider auth:
![image](https://user-images.githubusercontent.com/14204943/118514963-28ee9f80-b6f2-11eb-98fc-57f71f96f488.png)
That actually seems relatively clear to me, if we want to change anything I'm not sure what to change.