### PR TITLE
Fix license window not closing

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
@@ -228,7 +228,7 @@ export function DataProvider(props: Props) {
     }
 
     function handleLicenseClose() {
-        setLicenseOpen(true);
+        setLicenseOpen(false);
     }
 
     function handleExpand() {


### PR DESCRIPTION
Fixes the data provider license window in step 2 of the 'create datapack' process