### PR TITLE
fix land in arcgis and water in qgis

### DIFF
--- a/eventkit_cloud/tasks/templates/styles/Style.qgs
+++ b/eventkit_cloud/tasks/templates/styles/Style.qgs
@@ -232,7 +232,7 @@
       <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_land_polygonsnome_{{ job_date_time }}__{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</item>
-      <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</item>
+      <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</item>
       {% endfor %}
       {% endif %}
       {% if provider.slug == "osm" %}
@@ -254,7 +254,7 @@
       <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</item>
+      <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</item>
       {% endfor %}
       {% endif %}
       {%  if provider.type == "vector" %}
@@ -515,7 +515,7 @@
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</id>
+      <id>osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=boundary</datasource>
       <keywordList>
         <value></value>
@@ -9209,7 +9209,7 @@ def my_form_open(dialog, layer, feature):
       <xmax>{{ bbox.2 }}</xmax>
       <ymax>{{ bbox.3 }}</ymax>
       </extent>
-      <id>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</id>
+      <id>osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</id>
       <datasource>{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=boundary</datasource>
       <keywordList>
         <value></value>
@@ -23336,7 +23336,7 @@ def my_form_open(dialog, layer, feature):
     <Digitizing>
       <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
       <LayerSnappingList type="QStringList">
-        <value>osm_bounds_{{ provider.slug}}_{{ job_date_time }}</value>
+        <value>osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_amenities_points_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -587,6 +587,7 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result["result"])
         self.assertEqual(example_input_file, result["source"])
 
+    @patch("eventkit_cloud.tasks.export_tasks.sqlite3.connect")
     @patch("eventkit_cloud.tasks.export_tasks.cancel_export_provider_task.run")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_filepath")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_task_record")
@@ -609,6 +610,7 @@ class TestExportTasks(ExportTaskBase):
         mock_get_export_task_record,
         mock_get_export_filepath,
         mock_cancel_provider_task,
+        mock_connect
     ):
         provider_slug = "osm"
         mock_get_export_task_record.return_value = Mock(export_provider_task=Mock(provider=Mock(slug=provider_slug)))
@@ -624,7 +626,7 @@ class TestExportTasks(ExportTaskBase):
         osm_data_collection_pipeline(
             example_export_task_record_uid, stage_dir, bbox=example_bbox, config=yaml.dump(example_config)
         )
-
+        mock_connect.assert_called_once()
         mock_overpass.Overpass.assert_called_once()
         mock_pbf.OSMToPBF.assert_called_once()
         mock_feature_selection.example.assert_called_once()

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -627,6 +627,7 @@ def convert_vector(
             logger.info(f"calling gdal.VectorTranslate('{output_file}', '{_input_file}', {stringify_params(options)})")
             gdal.VectorTranslate(output_file, _input_file, **options)
     else:
+        logger.info(f"calling gdal.VectorTranslate('{output_file}', '{input_file}', {stringify_params(options)})")
         gdal.VectorTranslate(output_file, input_file, **options)
 
     if distinct_field:

--- a/eventkit_cloud/utils/geopackage.py
+++ b/eventkit_cloud/utils/geopackage.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 import os
+import sqlite3
 from string import Template
 
-import json
 from django.conf import settings
-from django.contrib.gis.geos import Polygon
-
-from eventkit_cloud.tasks.task_process import TaskProcess, update_progress  # NOQA
+from django.contrib.gis.geos import GEOSGeometry
 from osgeo import gdal, osr
-import sqlite3
 
-from .artifact import Artifact
 from eventkit_cloud.feature_selection.feature_selection import slugify
+from eventkit_cloud.tasks.task_process import TaskProcess, update_progress  # NOQA
 from eventkit_cloud.utils import gdalutils
-
+from .artifact import Artifact
 
 logger = logging.getLogger(__name__)
 
@@ -257,7 +255,7 @@ class Geopackage(object):
         output_gpkg,
         stage_dir,
         feature_selection,
-        aoi_geom: Polygon,
+        aoi_geom: GEOSGeometry,
         tempdir=None,
         per_theme=False,
         progress=None,


### PR DESCRIPTION
Fixes an issue in the land data for the arcgis script and the water in the QGIS document.  To test create an osm theme export on the edge of a land mass and run the arc script. Open the map and ensure that land polygons are visible.  Then open the qgis document and ensure the boundary polygon is present and blue where there isn't land.