### PR TITLE
skip zips for only single data source

### DIFF
--- a/eventkit_cloud/tasks/task_factory.py
+++ b/eventkit_cloud/tasks/task_factory.py
@@ -123,7 +123,7 @@ class TaskFactory:
             user_details = {"username": "TaskFactory-parse_tasks"}
 
         if run_uid:
-            run = ExportRun.objects.get(uid=run_uid)
+            run: ExportRun = ExportRun.objects.prefetch_related("job__data_provider_tasks").get(uid=run_uid)
             job = run.job
             run_dir = get_run_staging_dir(run.uid)
 
@@ -223,7 +223,8 @@ class TaskFactory:
                         ).set(**finalize_task_settings)
 
                         # add zip if required
-                        if provider_task.provider.zip:
+                        # skip zip if there is only one source in the data pack (they would be redundant files).
+                        if provider_task.provider.zip and len(job.data_provider_tasks.all()) > 1:
                             zip_export_provider_sig = get_zip_task_chain(
                                 data_provider_task_record_uid=provider_task_record_uid,
                                 data_provider_task_record_uids=[provider_task_record_uid],

--- a/eventkit_cloud/tasks/tests/test_task_factory.py
+++ b/eventkit_cloud/tasks/tests/test_task_factory.py
@@ -90,7 +90,7 @@ class TestExportTaskFactory(TestCase):
         task_factory_chain.assert_called()
         finalize_task.s.assert_called()
         mock_os.makedirs.assert_called()
-        self.assertEqual(3, create_task.call_count)
+        self.assertEqual(2, create_task.call_count)
 
         # Test that run is prevented and deleted if the user has not agreed to the licenses.
         mock_invalid_licenses.return_value = ["invalid-licenses"]


### PR DESCRIPTION
Skip zipping data if only one source.  To test create an export with a datasource that has zip selected in the admin console.  Then create another export with that same data source and another source.  The second data run should have a Project File (zip) under the data source where the first run will not. 