### PR TITLE
Ensure session headers default to an empty dictionary

### DIFF
--- a/eventkit_cloud/core/helpers.py
+++ b/eventkit_cloud/core/helpers.py
@@ -183,7 +183,7 @@ def get_or_update_session(session=None, max_retries=3, headers=None, **auth_info
 
     logger.debug("Using %s for SSL verification.", str(ssl_verify))
     session.verify = ssl_verify
-    session.headers = headers
+    session.headers = headers or {}
     return session
 
 


### PR DESCRIPTION
In order to test this, try to save a Data Provider with ogcprocess-api as the export provider type and it should save successfully.  Previously this would cause an error because headers was NoneType.