### PR TITLE
Put OSM water ontop of land in qgis

### DIFF
--- a/eventkit_cloud/tasks/templates/styles/Style.qgs
+++ b/eventkit_cloud/tasks/templates/styles/Style.qgs
@@ -107,6 +107,9 @@
         <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=waterways_lines" name="waterways">
           <customproperties/>
         </layer-tree-layer>
+        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = &quot;water&quot;" name="water">
+          <customproperties/>
+        </layer-tree-layer>
         <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = 'grassland'" name="grassland">
           <customproperties/>
         </layer-tree-layer>
@@ -123,9 +126,6 @@
           <customproperties/>
         </layer-tree-layer>
         <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=aviation_polygons" name="aviation polygons">
-          <customproperties/>
-        </layer-tree-layer>
-        <layer-tree-layer expanded="1" providerKey="ogr" checked="Qt::Checked" id="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" source="{% if file_details.file_ext == '.zip'%}/vsizip/{% endif %}./{{ file_details.file_path }}|layername=natural_polygons|subset=&quot;natural&quot; = &quot;water&quot;" name="water">
           <customproperties/>
         </layer-tree-layer>
         <layer-tree-group expanded="1" checked="Qt::Checked" name="background">
@@ -246,13 +246,13 @@
       <item>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
+      <item>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
-      <item>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</item>
       <item>osm_bounds_{{ provider.slug}}_{{ job_date_time }}_{{ file_details.projection }}_{{ file_details.file_ext|slugify }}</item>
       {% endfor %}
@@ -412,6 +412,11 @@
             <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
+        <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="water" showFeatureCount="0">
+          <filegroup open="true" hidden="false">
+            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
+          </filegroup>
+        </legendlayer>
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="grassland" showFeatureCount="0">
           <filegroup open="true" hidden="false">
             <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
@@ -440,11 +445,6 @@
         <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="aviation polygons" showFeatureCount="0">
           <filegroup open="true" hidden="false">
             <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
-          </filegroup>
-        </legendlayer>
-        <legendlayer drawingOrder="-1" open="true" checked="Qt::Checked" name="water" showFeatureCount="0">
-          <filegroup open="true" hidden="false">
-            <legendlayerfile isInOverview="0" layerid="{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}" visible="1"/>
           </filegroup>
         </legendlayer>
         <legendgroup open="true" checked="Qt::Checked" name="background">
@@ -23361,13 +23361,13 @@ def my_form_open(dialog, layer, feature):
         <value>{{ job_name.split|join:"_" }}_roads_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_buildings_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_waterways_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
+        <value>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_natural_polygons_grassland_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_leisure_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_landuse_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_amenities_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_aviation_lines_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_aviation_polygons_any_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
-        <value>{{ job_name.split|join:"_" }}_natural_polygons_water_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>{{ job_name.split|join:"_" }}_land_polygons_{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
         <value>osm_bounds_{{ provider.slug}}__{{ provider.slug}}_{{ file_details.projection }}_{{ job_date_time }}_{{ file_details.file_ext|slugify }}</value>
       </LayerSnappingList>


### PR DESCRIPTION
Fixes layer ordering so that water layers (rivers and lakes) appear over land boundaries (e.g. grasslands).  If water (or any other rendering errors appear in arcgis, ensure that the missing field is listed in the configuration for the data provider (i.e. add waterways to natural in the config). 