### PR TITLE
allow return run request as geojson

### DIFF
--- a/eventkit_cloud/api/renderers.py
+++ b/eventkit_cloud/api/renderers.py
@@ -1,15 +1,5 @@
 # -*- coding: utf-8 -*-
-from rest_framework.renderers import BaseRenderer
-from rest_framework.renderers import BrowsableAPIRenderer
-
-
-class HOTExportApiRenderer(BrowsableAPIRenderer):
-    """Custom APIRenderer to remove editing forms from Browsable API."""
-
-    def get_context(self, data, accepted_media_type, renderer_context):
-        context = super(HOTExportApiRenderer, self).get_context(data, accepted_media_type, renderer_context)
-        context["display_edit_forms"] = False
-        return context
+from rest_framework.renderers import BaseRenderer, JSONRenderer
 
 
 class PlainTextRenderer(BaseRenderer):
@@ -20,3 +10,8 @@ class PlainTextRenderer(BaseRenderer):
         if isinstance(data, str):
             return data.encode(self.charset)
         return data
+
+
+class GeojsonRenderer(JSONRenderer):
+    format = "geojson"
+    media_type = "application/geo+json"

--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -23,6 +23,8 @@ from notifications.models import Notification
 from rest_framework import serializers
 from rest_framework.serializers import ValidationError
 from rest_framework_gis import serializers as geo_serializers
+from rest_framework_gis.fields import GeometrySerializerMethodField
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from eventkit_cloud.api.utils import get_run_zip_file
 from eventkit_cloud.core.models import GroupPermission, GroupPermissionLevel, attribute_class_filter
@@ -483,6 +485,21 @@ class ExportRunSerializer(serializers.ModelSerializer):
     def get_expiration(self, obj):
         if not obj.deleted:
             return obj.expiration
+
+
+class ExportRunGeoFeatureSerializer(ExportRunSerializer, GeoFeatureModelSerializer):
+    run_geom = GeometrySerializerMethodField()
+    bbox = GeometrySerializerMethodField()
+
+    class Meta(ExportRunSerializer.Meta):
+        geo_field = "run_geom"
+        bbox_geo_field = "bbox"
+
+    def get_run_geom(self, obj):
+        return obj.job.the_geom
+
+    def get_bbox(self, obj):
+        return obj.job.the_geom.extent
 
 
 class RunZipFileSerializer(serializers.ModelSerializer):

--- a/eventkit_cloud/api/urls.py
+++ b/eventkit_cloud/api/urls.py
@@ -65,3 +65,5 @@ urlpatterns = [
     re_path(r"^api/", include(notifications.urls)),
     re_path(r"^api/estimate$", EstimatorView.as_view()),
 ]
+
+# urlpatterns = format_suffix_patterns(urlpatterns, allowed=['geojson', 'json', 'html'])

--- a/eventkit_cloud/api/urls.py
+++ b/eventkit_cloud/api/urls.py
@@ -65,5 +65,3 @@ urlpatterns = [
     re_path(r"^api/", include(notifications.urls)),
     re_path(r"^api/estimate$", EstimatorView.as_view()),
 ]
-
-# urlpatterns = format_suffix_patterns(urlpatterns, allowed=['geojson', 'json', 'html'])

--- a/eventkit_cloud/settings/contrib.py
+++ b/eventkit_cloud/settings/contrib.py
@@ -11,7 +11,6 @@ INSTALLED_APPS += (
     "rest_framework_gis",
     "rest_framework.authtoken",
     "storages",
-    # 'social.apps.django_app.default'
 )
 
 # 3rd party specific app settings
@@ -28,10 +27,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
-    "DEFAULT_RENDERER_CLASSES": (
-        "rest_framework.renderers.JSONRenderer",
-        "eventkit_cloud.api.renderers.HOTExportApiRenderer",
-    ),
+    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
     "EXCEPTION_HANDLER": "eventkit_cloud.api.utils.eventkit_exception_handler",
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
     "DEFAULT_VERSION": "1.0",


### PR DESCRIPTION
Adds support for returning /api/runs response as a geojson.  To test, make a request to the runs api and add ?format=geojson to the url, or use the browsable api and select geojson. 