### PR TITLE
fix duplicate geotiff and run status

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -2085,23 +2085,25 @@ def finalize_run_task(result=None, run_uid=None, stage_dir=None, apply_args=None
     """
     result = result or {}
 
-    run = ExportRun.objects.get(uid=run_uid)
+    run: ExportRun = ExportRun.objects.prefetch_related("data_provider_task_records").get(uid=run_uid)
     run.status = TaskState.COMPLETED.value
     verb = NotificationVerb.RUN_COMPLETED.value
     notification_level = NotificationLevel.SUCCESS.value
-    provider_tasks = run.data_provider_task_records.exclude(slug="run")
-
+    data_provider_task_records = run.data_provider_task_records.all()
     # mark run as incomplete if any tasks fail
-    if any(getattr(TaskState, task.status, None) in TaskState.get_incomplete_states() for task in provider_tasks):
+    if any(
+        getattr(TaskState, task.status, None) in TaskState.get_incomplete_states()
+        for task in data_provider_task_records
+    ):
         run.status = TaskState.INCOMPLETE.value
         notification_level = NotificationLevel.WARNING.value
         verb = NotificationVerb.RUN_FAILED.value
-    if all(getattr(TaskState, task.status, None) == TaskState.CANCELED for task in provider_tasks):
+    if all(getattr(TaskState, task.status, None) == TaskState.CANCELED for task in data_provider_task_records):
         run.status = TaskState.CANCELED.value
         verb = NotificationVerb.RUN_CANCELED.value
         notification_level = NotificationLevel.WARNING.value
-    finished = timezone.now()
-    run.finished_at = finished
+
+    run.finished_at = timezone.now()
     run.save()
 
     # sendnotification to user via django notifications

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -83,22 +83,6 @@ class TaskChainBuilder(object):
         job_name = normalize_name(job.name)
         # get the formats to export
         formats: List[ExportFormat] = list(data_provider_task.formats.all())
-        export_tasks = {}
-
-        # If WCS we will want geotiff...
-        if "wcs" in primary_export_task.name.lower():
-            formats += [ExportFormat.objects.prefetch_related("supported_projections").get(slug="gtiff")]
-
-        # build a list of celery tasks based on the export formats...
-        # for export_format in formats:
-        #     export_format_slug = "ogcapi-process" if export_format.options.proxy else export_format.slug
-        #     try:
-        #         export_tasks[export_format] = {"obj": create_format_task(export_format_slug), "task_uid": None}
-        #     except KeyError as e:
-        #         logger.debug("KeyError: export_tasks[{}] - {}".format(export_format_slug, e))
-        #     except ImportError as e:
-        #         msg = "Error importing export task: {0}".format(e)
-        #         logger.debug(msg)
 
         data_provider_task_record: DataProviderTaskRecord = DataProviderTaskRecord.objects.create(
             run=run, name=data_provider.name, provider=data_provider, status=TaskState.PENDING.value, display=True,


### PR DESCRIPTION
Fixes duplicate geotiffs on WCS tasks, also fixes API where the run data provider task record would always be running. 