### PR TITLE
Resolve Finalize Run Task Errors

### DIFF
--- a/eventkit_cloud/tasks/task_factory.py
+++ b/eventkit_cloud/tasks/task_factory.py
@@ -181,8 +181,9 @@ class TaskFactory:
                     run_uid=run_uid,
                     locking_task_key=run_uid,
                     callback_task=create_finalize_run_task_collection(
-                        run_uid,
-                        run_zip_task_chain,
+                        run_uid=run_uid,
+                        run_provider_task_record_uid=run_task_record.uid,
+                        run_zip_task_chain=run_zip_task_chain,
                         run_zip_file_slug_sets=run_zip_file_slug_sets,
                         apply_args=finalize_task_settings,
                     ),


### PR DESCRIPTION
Add missing parameters to create_finalize_run_task_collection, fixing a bug where in certain cases datapacks were erroring out before they started processing.  In order to test this PR, pull it down and run a datapack.  Ensure that the datapack completes and does not error out before start or hang on the finalize step.