### PR TITLE
Remove UID from eventkit zipfile name

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1832,6 +1832,7 @@ def create_zip_task(
     :param result: The celery task result value, it should be a dict with the current state.
     :param data_provider_task_record_uid: A data provider task record UID to zip.
     :param data_provider_task_record_uids: A list of data provider task record UIDs to zip.
+    :param run_zip_file_uid: The UUID of the zip file.
     :return: The run files, or a single zip file if data_provider_task_record_uid is passed.
     """
 
@@ -1884,10 +1885,7 @@ def create_zip_task(
         # and add the static resources
         include_files = list(set(include_files))
 
-        if run_zip_file_uid:
-            zip_file_name = f"{metadata['name']}-{run_zip_file_uid}.zip"
-        else:
-            zip_file_name = f"{metadata['name']}.zip"
+        zip_file_name = f"{metadata['name']}.zip"
 
         result["result"] = zip_files(
             include_files=include_files,

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -1522,7 +1522,7 @@ class TestExportTasks(ExportTaskBase):
         data_provider_task_record_uids = ["0d08ddf6-35c1-464f-b271-75f6911c3f78"]
         mock_get_metadata.return_value = metadata
         run_zip_file = RunZipFile.objects.create(run=self.run)
-        expected_zip = f"{metadata['name']}-{run_zip_file.uid}.zip"
+        expected_zip = f"{metadata['name']}.zip"
         mock_zip_files.return_value = expected_zip
 
         returned_zip = create_zip_task.run(


### PR DESCRIPTION
This PR removes the random UID that was being added to the finished datapack.  In order to test this PR, create a new export and download the main datapack zipfile when it completes.  Check the filename to make sure it's just datapackname-projectname-eventkit.zip without a random UID tacked on.