### PR TITLE
Fix Progress Percentage Updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ services:
       - DATABASE_URL=postgres://eventkit:eventkit_exports@postgis:5432/eventkit_exports
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
       - BROKER_API_URL=http://guest:guest@rabbitmq:15672/api/
+      - MEMCACHED=memcached:11211
       - CELERY_RESULT_BACKEND=cache+memcached://memcached:11211
       - CELERY_GROUP_NAME
       - CONCURRENCY=1


### PR DESCRIPTION
There was a disconnect between the eventkit and celery containers, as they were writing to different caches causing the progress percentage to stay at 0% even though progress was being made.  This PR ensures that they are both using the correct memcached cache locally.  In order to test this PR, create an export and monitor the Status & Download page.  Ensure that you see the progress bars updating.