### PR TITLE
Fix backwards download progress

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1480,11 +1480,11 @@ def arcgis_feature_service_export_task(
                 "distinct_field": layer.get("distinct_field"),
             }
 
-            try:
-                download_concurrently(layers.values(), configuration.get("concurrency"), feature_data=True)
-            except Exception as e:
-                logger.error(f"ArcGIS provider download error: {e}")
-                raise e
+        try:
+            download_concurrently(layers.values(), configuration.get("concurrency"), feature_data=True)
+        except Exception as e:
+            logger.error(f"ArcGIS provider download error: {e}")
+            raise e
 
         for layer_name, layer in layers.items():
             out = gdalutils.convert(

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -476,7 +476,7 @@ class TestExportTasks(ExportTaskBase):
             bbox=[1, 2, 3, 4],
         )
         mock_download_data.assert_called_with(
-            str(saved_export_task.uid), ANY, expected_input_path[3], cert_info=None, task_points=100
+            str(saved_export_task.uid), ANY, expected_input_path[3], cert_info=None, task_points=400
         )
 
     @patch("eventkit_cloud.utils.gdalutils.convert")
@@ -898,7 +898,7 @@ class TestExportTasks(ExportTaskBase):
         )
 
         mock_download_feature_data.assert_called_with(
-            str(saved_export_task.uid), expected_input_url, ANY, cert_info=None, task_points=100
+            str(saved_export_task.uid), expected_input_url, ANY, cert_info=None, task_points=400
         )
 
         mock_convert.assert_called_once_with(
@@ -1038,7 +1038,7 @@ class TestExportTasks(ExportTaskBase):
             bbox=bbox,
         )
         mock_download_feature_data.assert_called_with(
-            str(saved_export_task.uid), expected_input_url, "dir/chunk3.json", cert_info=None, task_points=100
+            str(saved_export_task.uid), expected_input_url, "dir/chunk3.json", cert_info=None, task_points=400
         )
 
     @patch("celery.app.task.Task.request")


### PR DESCRIPTION
Fix feature service backwards progress by fixing repetitive download of some layers of feature services. 
Fix inaccurate download progress by accounting for subtasks in concurrent downloads. 

Test with Arcgis-feature and with a non feature service provider. 