### PR TITLE
Use Refresh Token to Update Access Tokens

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -225,6 +225,7 @@ OAUTH targets specific servers, but it was written to be fairly generic and upda
 |OAUTH_RESPONSE_TYPE| The type of authorization request (default `code`) |
 |OAUTH_TOKEN_URL| The URL to request a user token with the Auth Code |
 |OAUTH_TOKEN_KEY| The key of the actual token from the OAUTH_TOKEN_URL response. |
+|OAUTH_REFRESH_KEY| The key of the refresh token from the OAUTH_TOKEN_URL response. |
 |OAUTH_LOGOUT_URL| The URL to log the user out. |
 |OAUTH_REDIRECT_URI| The URL that the Oauth server should send the user after authorization. |
 |OAUTH_SCOPE| The level of permission for authorization. |

--- a/eventkit_cloud/auth/auth.py
+++ b/eventkit_cloud/auth/auth.py
@@ -201,43 +201,20 @@ def get_user_data_from_schema(data):
 
 
 def request_access_tokens(auth_code: str) -> (str, str):
-
-    logger.debug(f'Requesting: code="{auth_code}"')
-    try:
-        session = get_or_update_session()
-        response = session.post(
-            settings.OAUTH_TOKEN_URL,
-            auth=(settings.OAUTH_CLIENT_ID, settings.OAUTH_CLIENT_SECRET),
-            data={"grant_type": "authorization_code", "code": auth_code, "redirect_uri": settings.OAUTH_REDIRECT_URI},
-        )
-        logger.debug(f"Received response: {response.text}")
-        response.raise_for_status()
-    except requests.ConnectionError as err:
-        logger.error(f"Could not reach Token Server: {err}")
-        raise OAuthServerUnreachable()
-    except requests.HTTPError as err:
-        status_code = err.response.status_code
-        if status_code == 401:
-            logger.error(f"OAuth server rejected user auth code: {err.response.text}")
-            raise Unauthorized("OAuth server rejected auth code")
-        logger.error(f"OAuth server returned HTTP {status_code}", err.response.text)
-        raise OAuthError(status_code)
-    access = response.json()
-    access_token = access.get(settings.OAUTH_TOKEN_KEY)
-    refresh_token = access.get(settings.OAUTH_REFRESH_KEY)
-    if not access_token:
-        logger.error(f"OAuth server response missing `{settings.OAUTH_TOKEN_KEY}`.  Response Text:\n{response.text}")
-        raise InvalidOauthResponse(f"missing `{settings.OAUTH_TOKEN_KEY}`", response.text)
-    return access_token, refresh_token
+    return get_access_tokens(
+        {"grant_type": "authorization_code", "code": auth_code, "redirect_uri": settings.OAUTH_REDIRECT_URI}
+    )
 
 
 def refresh_access_tokens(refresh_token: str) -> (str, str):
+    return get_access_tokens({"grant_type": "refresh_token", "refresh_token": refresh_token})
+
+
+def get_access_tokens(data):
     try:
         session = get_or_update_session()
         response = session.post(
-            settings.OAUTH_TOKEN_URL,
-            auth=(settings.OAUTH_CLIENT_ID, settings.OAUTH_CLIENT_SECRET),
-            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+            settings.OAUTH_TOKEN_URL, auth=(settings.OAUTH_CLIENT_ID, settings.OAUTH_CLIENT_SECRET), data=data,
         )
         logger.debug(f"Received response: {response.text}")
         response.raise_for_status()

--- a/eventkit_cloud/auth/tests/test_auth.py
+++ b/eventkit_cloud/auth/tests/test_auth.py
@@ -3,13 +3,13 @@
 
 import json
 import logging
+from unittest.mock import patch
 
 import requests
 import requests_mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
-from unittest.mock import patch
 
 from eventkit_cloud.auth.auth import (
     get_user,
@@ -21,6 +21,7 @@ from eventkit_cloud.auth.auth import (
     OAuthServerUnreachable,
     OAuthError,
     Error,
+    refresh_access_tokens,
 )
 
 logger = logging.getLogger(__name__)
@@ -124,8 +125,54 @@ class TestAuth(TestCase):
         with self.assertRaises(OAuthError):
             request_access_tokens(OAuthError)
 
-    def test_get_user_data_from_schema(self):
+    @override_settings(
+        OAUTH_TOKEN_URL="http://example.url/token",
+        OAUTH_CLIENT_ID="ID_CODE",
+        OAUTH_CLIENT_SECRET="SECRET_CODE",
+        OAUTH_REDIRECT_URI="http://example.url/callback",
+        OAUTH_TOKEN_KEY="access_token",
+        OAUTH_REFRESH_KEY="refresh_token",
+    )
+    def test_refresh_access_tokens(self):
+        example_access_token = "1234"
+        example_refresh_token = "2345"
 
+        # Test unauthorized users
+        self.mock_requests.post(settings.OAUTH_TOKEN_URL, status_code=401)
+        with self.assertRaises(Unauthorized):
+            refresh_access_tokens(example_refresh_token)
+
+        # Test bad/unexpected responses
+        self.mock_requests.post(
+            settings.OAUTH_TOKEN_URL, text=json.dumps({settings.OAUTH_REFRESH_KEY: None}), status_code=200
+        )
+        with self.assertRaises(InvalidOauthResponse):
+            refresh_access_tokens(example_refresh_token)
+
+        # Test valid responses
+        self.mock_requests.post(
+            settings.OAUTH_TOKEN_URL,
+            text=json.dumps(
+                {settings.OAUTH_TOKEN_KEY: example_access_token, settings.OAUTH_REFRESH_KEY: example_refresh_token}
+            ),
+            status_code=200,
+        )
+        returned_token, returned_refresh_token = refresh_access_tokens(example_refresh_token)
+        self.assertEqual(example_access_token, returned_token)
+        self.assertEqual(example_refresh_token, returned_refresh_token)
+
+        # Test connection issues
+        with patch("requests.Session.post") as mock_post:
+            mock_post.side_effect = requests.ConnectionError()
+            with self.assertRaises(OAuthServerUnreachable):
+                refresh_access_tokens(OAuthServerUnreachable)
+
+        # Test remote server error
+        self.mock_requests.post(settings.OAUTH_TOKEN_URL, status_code=404)
+        with self.assertRaises(OAuthError):
+            refresh_access_tokens(OAuthError)
+
+    def test_get_user_data_from_schema(self):
         example_schema = {
             "identification": ["DN"],
             "commonname": "username",

--- a/eventkit_cloud/auth/views.py
+++ b/eventkit_cloud/auth/views.py
@@ -13,7 +13,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from rest_framework.views import APIView
 
-from eventkit_cloud.auth.auth import request_access_token, fetch_user_from_token, OAuthError, Unauthorized
+from eventkit_cloud.auth.auth import request_access_tokens, fetch_user_from_token, OAuthError, Unauthorized
 from eventkit_cloud.core.helpers import get_id
 
 logger = getLogger(__name__)
@@ -45,8 +45,9 @@ def oauth(request, redirect_url=None):
 
 def callback(request):
     try:
-        access_token = request_access_token(request.GET.get("code"))
+        access_token, refresh_token = request_access_tokens(request.GET.get("code"))
         request.session["access_token"] = access_token
+        request.session["refresh_token"] = refresh_token
         user = fetch_user_from_token(access_token)
         state = request.GET.get("state")
         if user:

--- a/eventkit_cloud/auth/views.py
+++ b/eventkit_cloud/auth/views.py
@@ -13,7 +13,13 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from rest_framework.views import APIView
 
-from eventkit_cloud.auth.auth import request_access_tokens, fetch_user_from_token, OAuthError, Unauthorized
+from eventkit_cloud.auth.auth import (
+    request_access_tokens,
+    fetch_user_from_token,
+    OAuthError,
+    Unauthorized,
+    refresh_access_tokens,
+)
 from eventkit_cloud.core.helpers import get_id
 
 logger = getLogger(__name__)
@@ -96,10 +102,16 @@ def has_valid_access_token(request) -> bool:
                 fetch_user_from_token(access_token)
                 return True
             except (OAuthError, Unauthorized):
-                logger.info("Invalid access token, trying to log back in.")
-                return False
+                logger.info("Invalid access token, trying to refresh access token.")
+                access_token, refresh_token = refresh_access_tokens(request.session.get("refresh_token"))
+                request.session["access_token"] = access_token
+                request.session["refresh_token"] = refresh_token
+                try:
+                    fetch_user_from_token(access_token)
+                    return True
+                except (OAuthError, Unauthorized):
+                    return False
         else:
-            logger.info("No access token available, trying to log back in.")
             return False
     else:
         # If OAuth isn't enabled, allow without checking for a valid token.

--- a/eventkit_cloud/settings/prod.py
+++ b/eventkit_cloud/settings/prod.py
@@ -165,6 +165,7 @@ if os.getenv("OAUTH_AUTHORIZATION_URL"):
     OAUTH_LOGOUT_URL = os.getenv("OAUTH_LOGOUT_URL")
     OAUTH_TOKEN_URL = os.getenv("OAUTH_TOKEN_URL")
     OAUTH_TOKEN_KEY = os.getenv("OAUTH_TOKEN_KEY", "access_token")
+    OAUTH_REFRESH_KEY = os.getenv("OAUTH_TOKEN_KEY", "refresh_token")
     OAUTH_RESPONSE_TYPE = os.getenv("OAUTH_RESPONSE_TYPE", "code")
     OAUTH_REDIRECT_URI = os.getenv("OAUTH_REDIRECT_URI")
     OAUTH_SCOPE = os.getenv("OAUTH_SCOPE")


### PR DESCRIPTION
This PR adds refresh token functionality into our OAuth workflow, allowing for the refresh token to be used to get a new access token if the previous access token has expired.  