### PR TITLE
Update celery commands to remove deprecated syntax

### DIFF
--- a/eventkit_cloud/tasks/scheduled_tasks.py
+++ b/eventkit_cloud/tasks/scheduled_tasks.py
@@ -396,12 +396,12 @@ def get_celery_health_check_command(node_type: str):
 def get_celery_tasks_scale_by_run():
     default_command = (
         "echo '************STARTING NEW WORKER****************' && hostname && echo {celery_group_name} & "
-        "CELERY_GROUP_NAME={celery_group_name} exec celery worker -A eventkit_cloud --concurrency=1 "
+        "CELERY_GROUP_NAME={celery_group_name} exec celery -A eventkit_cloud worker --concurrency=1 "
         "--loglevel=$LOG_LEVEL -n large@%h -Q {celery_group_name}.large & CELERY_GROUP_NAME={celery_group_name} "
-        "exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery "
-        "& CELERY_GROUP_NAME={celery_group_name} exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL "
+        "exec celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n celery@%h -Q celery "
+        "& CELERY_GROUP_NAME={celery_group_name} exec celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL "
         "-n priority@%h -Q {celery_group_name}.priority,$HOSTNAME.priority & CELERY_GROUP_NAME={celery_group_name} "
-        "exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n worker@%h -Q {celery_group_name}"
+        "exec celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n worker@%h -Q {celery_group_name}"
     )
 
     celery_tasks = {
@@ -424,12 +424,12 @@ def get_celery_tasks_scale_by_task():
     """
     celery_group_name = getattr(settings, "CELERY_GROUP_NAME", socket.gethostname())
 
-    priority_queue_command = " & exec celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL --concurrency=1 -n priority@%h -Q $CELERY_GROUP_NAME.priority,$HOSTNAME.priority"  # NOQA
+    priority_queue_command = " & exec celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL --concurrency=1 -n priority@%h -Q $CELERY_GROUP_NAME.priority,$HOSTNAME.priority"  # NOQA
 
     celery_tasks = OrderedDict(
         {
             f"{celery_group_name}": {
-                "command": "celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME "
+                "command": "celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME "
                 + priority_queue_command
                 + get_celery_health_check_command("worker"),
                 # NOQA
@@ -437,7 +437,7 @@ def get_celery_tasks_scale_by_task():
                 "memory": 2048,
             },
             f"{celery_group_name}.large": {
-                "command": "celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n large@%h -Q $CELERY_GROUP_NAME.large "  # NOQA
+                "command": "celery -A eventkit_cloud worker --concurrency=1 --loglevel=$LOG_LEVEL -n large@%h -Q $CELERY_GROUP_NAME.large "  # NOQA
                 + priority_queue_command
                 + get_celery_health_check_command("large"),
                 # NOQA
@@ -445,7 +445,7 @@ def get_celery_tasks_scale_by_task():
                 "memory": 4096,
             },
             "celery": {
-                "command": "celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery "
+                "command": "celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n celery@%h -Q celery "
                 + priority_queue_command
                 + get_celery_health_check_command("celery"),
                 "disk": 2048,
@@ -453,7 +453,7 @@ def get_celery_tasks_scale_by_task():
                 "limit": 6,
             },
             f"{celery_group_name}.priority": {
-                "command": "celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n priority@%h -Q $CELERY_GROUP_NAME.priority "  # NOQA
+                "command": "celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n priority@%h -Q $CELERY_GROUP_NAME.priority "  # NOQA
                 + get_celery_health_check_command("priority"),  # NOQA
                 # NOQA
                 "disk": 2048,

--- a/eventkit_cloud/tasks/tests/test_scheduled_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_scheduled_tasks.py
@@ -175,12 +175,12 @@ class TestScaleCeleryTask(TestCase):
         ordered_celery_tasks = OrderedDict(
             {
                 "queue1": {
-                    "command": "celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n worker@%h -Q queue1 ",
+                    "command": "celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n worker@%h -Q queue1 ",
                     "disk": 2048,
                     "memory": 2048,
                 },
                 "celery": {
-                    "command": "celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery ",
+                    "command": "celery -A eventkit_cloud worker --loglevel=$LOG_LEVEL -n celery@%h -Q celery ",
                     "disk": 2048,
                     "memory": 3072,
                     "limit": 2,

--- a/scripts/run-celery-beat.sh
+++ b/scripts/run-celery-beat.sh
@@ -2,4 +2,4 @@
 
 rm -rf celerybeat.pid &
 celery -A eventkit_cloud beat --loglevel=$LOG_LEVEL &
-celery worker -A eventkit_cloud --concurrency=1 --loglevel=$LOG_LEVEL -n scale@%h -Q scale
+celery -A eventkit_cloud worker --concurrency=1 --loglevel=$LOG_LEVEL -n scale@%h -Q scale

--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-celery worker -A eventkit_cloud -Ofair --concurrency=$RUNS_CONCURRENCY --loglevel=$LOG_LEVEL -n runs@%h -Q runs & \
-celery worker -A eventkit_cloud -Ofair --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME & \
-celery worker -A eventkit_cloud -Ofair --concurrency=1 --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
-celery worker -A eventkit_cloud -Ofair --concurrency=1 --loglevel=$LOG_LEVEL -n priority@%h -Q $CELERY_GROUP_NAME.priority,$HOSTNAME.priority & \
-celery worker -A eventkit_cloud -Ofair --concurrency=$OSM_CONCURRENCY --loglevel=$LOG_LEVEL -n large@%h -Q $CELERY_GROUP_NAME.large
+celery -A eventkit_cloud worker -Ofair --concurrency=$RUNS_CONCURRENCY --loglevel=$LOG_LEVEL -n runs@%h -Q runs & \
+celery -A eventkit_cloud worker -Ofair --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $CELERY_GROUP_NAME & \
+celery -A eventkit_cloud worker -Ofair --concurrency=1 --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
+celery -A eventkit_cloud worker -Ofair --concurrency=1 --loglevel=$LOG_LEVEL -n priority@%h -Q $CELERY_GROUP_NAME.priority,$HOSTNAME.priority & \
+celery -A eventkit_cloud worker -Ofair --concurrency=$OSM_CONCURRENCY --loglevel=$LOG_LEVEL -n large@%h -Q $CELERY_GROUP_NAME.large


### PR DESCRIPTION
Celery 5.0 no longer allows for the global options to be positioned after the sub-command. Instead, they must be positioned as an option for the celery command itself.  So this PR updates all of our celery command line calls to reflect the latest syntax.