### PR TITLE
fixes get_query_cache_key and deconflicts serializer cache

### DIFF
--- a/eventkit_cloud/core/helpers.py
+++ b/eventkit_cloud/core/helpers.py
@@ -46,7 +46,7 @@ def get_query_cache_key(*args):
         if hasattr(arg, "__name__"):
             cleaned_args += [normalize_name(str(arg.__name__))]
         else:
-            cleaned_args += [normalize_name(str(args))]
+            cleaned_args += [normalize_name(str(arg))]
     return "-".join(cleaned_args)
 
 


### PR DESCRIPTION
Fixes an issue with creating a cache key (i.e. grabs all args instead of current arg), and saves the geojson and json requests separately to ensure proper response is returned. 