### PR TITLE
Improve Datapack Started and Finished times output

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartInfoTable.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartInfoTable.tsx
@@ -14,6 +14,11 @@ export interface Props {
 export class DataCartInfoTable extends React.Component<Props, {}> {
     render() {
         const { dataPack } = this.props;
+        let finishedAt = 'Not Started';
+        if (dataPack.started_at) {
+            finishedAt = dataPack.finished_at
+                ? moment(dataPack.finished_at).format('M/D/YY h:mma') : 'Currently Processing...';
+        }
         return (
             <div>
                 <CustomTableRow
@@ -29,12 +34,14 @@ export class DataCartInfoTable extends React.Component<Props, {}> {
                 <CustomTableRow
                     title="Started"
                 >
-                    {moment(dataPack.started_at).format('M/D/YY h:mma')}
+                    {dataPack.started_at
+                        ? moment(dataPack.started_at).format('M/D/YY h:mma') : "Not Started"}
+
                 </CustomTableRow>
                 <CustomTableRow
                     title="Finished"
                 >
-                    {dataPack.finished_at === null ? 'Currently Processing...' : moment(dataPack.finished_at).format('M/D/YY h:mma')}
+                    {finishedAt}
                 </CustomTableRow>
             </div>
         );

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartInfoTable.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartInfoTable.spec.tsx
@@ -16,9 +16,22 @@ describe('DataCartInfoTable component', () => {
         ...(global as any).eventkit_test_props,
     };
 
-    const wrapper = shallow(<DataCartInfoTable {...props} />);
-
     it('should render the 4 needed rows', () => {
+        const wrapper = shallow(<DataCartInfoTable {...props} />);
         expect(wrapper.find(CustomTableRow)).toHaveLength(4);
+    });
+
+    it('should render not started when not started', () => {
+        props.dataPack.started_at = null
+        const wrapper = shallow(<DataCartInfoTable {...props} />);
+        expect(wrapper.find({title:"Started"}).text()).toContain("Not Started");
+        expect(wrapper.find({title:"Finished"}).text()).toContain("Not Started");
+    });
+
+    it('should render processing when not finished', () => {
+        props.dataPack.started_at = '2017-03-24T15:52:35.637258Z'
+        props.dataPack.finished_at = null
+        const wrapper = shallow(<DataCartInfoTable {...props} />);
+        expect(wrapper.find({title:"Finished"}).text()).toContain("Currently Processing...");
     });
 });


### PR DESCRIPTION
When the datapack isn't started both fields will now report not started.  After the data pack is started the finished time will report that it is processing.  