### PR TITLE
Fix size increase request error 

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
@@ -166,9 +166,9 @@ export function DataProvider(props: Props) {
 
     useEffect(() => {
         const limits = providerLimits.find(limits => limits.slug === props.provider.slug);
-        const {size = {value: -1}} = providerInfo.estimates || {};
-        const {maxArea = 0, maxDataSize = 0} = limits || {};
-        if (limits) {
+        if (providerInfo.estimates && limits) {
+            const {size = {value: -1}} = providerInfo.estimates;
+            const {maxArea = 0, maxDataSize = 0} = limits;
             const area = limits.useBbox ? aoiBboxArea : aoiArea;
             setOverArea(maxArea && area > maxArea);
             setOverSize(!arrayHasValue(noMaxDataSize, provider.slug) && (maxDataSize && size.value > maxDataSize));

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/EstimateContainer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/EstimateContainer.tsx
@@ -280,7 +280,7 @@ function EstimateContainer(props: Props) {
             const haveAvailableEstimates = providerSlugs.filter((slug) => {
                 // Filter out providers that DO NOT have a size estimate
                 const estimate = providerEstimates[slug];
-                return estimate && estimate.size;
+                return estimate;
             });
             // Providers without a max data size will fall back to AoI.
             const noMaxDataSize = [...providerLimits.filter(limits => !limits.maxDataSize).map(limits => limits.slug)];

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ProviderStatusCheck.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ProviderStatusCheck.tsx
@@ -151,7 +151,7 @@ export function ProviderStatusCheck(props: Props) {
         title = 'CANNOT SELECT';
     } else {
         if (!props.isProviderLoading) {
-            if ((props.overSize && props.overArea) || (!props.overSize && props.overArea)) {
+            if (props.overArea) {
                 status = STATUS.OVER_AREA_SIZE
             }
             if (!props.overSize && !props.overArea) {

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ProviderStatusCheck.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ProviderStatusCheck.spec.tsx
@@ -66,9 +66,12 @@ describe('ProviderStatusCheck component', () => {
             expect(wrapper.find(ActionDone)).toHaveLength(1);
         });
 
-        it('should show the fatal icon when over size', () => {
-            setup({overSize: true});
-            expect(wrapper.find(AlertError)).toHaveLength(1);
+        it('should show the success icon when only over size', () => {
+            const props = defaultProps();
+            setup({
+                overArea: false,
+                overSize: true, availability: {status: 'SUCCESS', type: ''}});
+            expect(wrapper.find(ActionDone)).toHaveLength(1);
         });
 
         it('should show the fatal icon when over area', () => {
@@ -76,11 +79,18 @@ describe('ProviderStatusCheck component', () => {
             expect(wrapper.find(AlertError)).toHaveLength(1);
         });
 
-        it('should show the success icon when over area on backend but under size', () => {
+        it('should show the fatal icon when over area on backend but under size', () => {
             setup({
                 overArea: true, providerHasEstimates: true,
                 overSize: false, availability: {status: 'WARN', type: 'SELECTION_TOO_LARGE'}});
-            expect(wrapper.find(ActionDone)).toHaveLength(1);
+            expect(wrapper.find(AlertError)).toHaveLength(1);
+        });
+
+        it('should show the fatal icon when no estimates but status over size', () => {
+            setup({
+                overArea: false,
+                overSize: false, availability: {status: 'WARN', type: 'SELECTION_TOO_LARGE'}});
+            expect(wrapper.find(AlertError)).toHaveLength(1);
         });
 
         it('should show the fatal icon when over area but under size', () => {


### PR DESCRIPTION
Fix an error that was a result of estimates not being loaded before the size increase request button was pressed. 
Changed to not display error icon until after estimates are loaded. Changed behavior for when estimate check errors out as well. 