### PR TITLE
Fix bug where user search input field was not updating properly

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.tsx
@@ -255,7 +255,7 @@ export class UserGroupsPage extends React.Component<Props, State> {
         this.state = {
             drawerOpen: !(isWidthDown('sm', this.props.width)),
             selectedUsers: [],
-            search: props.location.search || '',
+            search: queryString.parse(props.location.search).search as string || '',
             showAddUsers: false,
             showCreate: false,
             showLeave: false,
@@ -1022,7 +1022,7 @@ export class UserGroupsPage extends React.Component<Props, State> {
                         <TextField
                             type="text"
                             placeholder="Search Users"
-                            value={queryString.parse(this.props.location.search).search}
+                            value={this.state.search}
                             InputProps={{className: classes.input}}
                             onChange={this.handleSearchChange}
                             onKeyDown={this.handleSearchKeyDown}


### PR DESCRIPTION
In order to test this PR, navigate to the Users & Groups page and use the search functionality.  Try typing into the search bar and hitting enter in order to search.  After searching, you should be able to hit backspace and expect the character to be deleted properly and you can search again.