### PR TITLE
Display provider footprints on map

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
@@ -175,6 +175,8 @@ export class ExportAOI extends React.Component<Props, State> {
         this.updateBaseMap = this.updateBaseMap.bind(this);
         this.addFootprintsLayer = this.addFootprintsLayer.bind(this);
         this.removeFootprintsLayer = this.removeFootprintsLayer.bind(this);
+        this.addCoverageGeos = this.addCoverageGeos.bind(this);
+        this.removeCoverageGeos = this.removeCoverageGeos.bind(this);
         this.bufferFunction = () => { /* do nothing */
         };
         this.state = {
@@ -1006,6 +1008,18 @@ export class ExportAOI extends React.Component<Props, State> {
         this.setState({selectedBaseMap: mapLayer});
     }
 
+    private addCoverageGeos(features: Feature[]) {
+        features.forEach(feature => {
+            this.drawLayer.getSource().addFeature(feature);
+        }, this)
+    }
+
+    private removeCoverageGeos(features: Feature[]) {
+        features.forEach(feature => {
+            this.drawLayer.getSource().removeFeature(feature);
+        }, this)
+    }
+
     private addFootprintsLayer(mapLayer: MapLayer) {
         const mapLayers = [...this.state.mapLayers];
         const index = mapLayers.map(x => x.slug).indexOf(mapLayer.slug);
@@ -1098,6 +1112,8 @@ export class ExportAOI extends React.Component<Props, State> {
                             updateBaseMap={this.updateBaseMap}
                             addFootprintsLayer={this.addFootprintsLayer}
                             removeFootprintsLayer={this.removeFootprintsLayer}
+                            addCoverageGeos={this.addCoverageGeos}
+                            removeCoverageGeos={this.removeCoverageGeos}
                         />
                     </div>
                     <MapDisplayBar

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.tsx
@@ -131,6 +131,7 @@ export class ExportAOI extends React.Component<Props, State> {
     private drawFreeInteraction;
     private markerLayer;
     private bufferLayer;
+    private overlayLayer;
     private pinLayer;
     private pointer;
     private feature;
@@ -487,6 +488,7 @@ export class ExportAOI extends React.Component<Props, State> {
         this.drawLayer = generateDrawLayer();
         this.markerLayer = generateDrawLayer();
         this.bufferLayer = generateDrawLayer();
+        this.overlayLayer = generateDrawLayer();
         this.pinLayer = generateDrawLayer();
 
         this.pinLayer.setStyle(new Style({
@@ -506,6 +508,13 @@ export class ExportAOI extends React.Component<Props, State> {
         }));
 
         this.bufferLayer.setStyle(new Style({
+            stroke: new Stroke({
+                color: this.props.theme.eventkit.colors.primary,
+                width: 3,
+            }),
+        }));
+
+        this.overlayLayer.setStyle(new Style({
             stroke: new Stroke({
                 color: this.props.theme.eventkit.colors.primary,
                 width: 3,
@@ -606,7 +615,9 @@ export class ExportAOI extends React.Component<Props, State> {
         this.map.addLayer(this.drawLayer);
         this.map.addLayer(this.markerLayer);
         this.map.addLayer(this.bufferLayer);
+        this.map.addLayer(this.overlayLayer);
         this.map.addLayer(this.pinLayer);
+        this.overlayLayer.setZIndex(96);
         this.drawLayer.setZIndex(97);
         this.markerLayer.setZIndex(98);
         this.bufferLayer.setZIndex(99);
@@ -1010,13 +1021,13 @@ export class ExportAOI extends React.Component<Props, State> {
 
     private addCoverageGeos(features: Feature[]) {
         features.forEach(feature => {
-            this.drawLayer.getSource().addFeature(feature);
+            this.overlayLayer.getSource().addFeature(feature);
         }, this)
     }
 
     private removeCoverageGeos(features: Feature[]) {
         features.forEach(feature => {
-            this.drawLayer.getSource().removeFeature(feature);
+            this.overlayLayer.getSource().removeFeature(feature);
         }, this)
     }
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -52,7 +52,6 @@ const jss = (theme: Theme & Eventkit.Theme) => createStyles({
         top: 'auto',
         width: '250px',
         height: 'calc(100vh - 180px)',
-        boxShadow: '0px 1px 5px 0px rgba(0,0,0,0.2), 0px 2px 2px 0px rgba(0,0,0,0.14), 0px 3px 1px -2px rgba(0,0,0,0.12)',
     },
     drawerHeader: {
         width: '100%',
@@ -81,8 +80,6 @@ const jss = (theme: Theme & Eventkit.Theme) => createStyles({
         borderBottomRightRadius: '0px',
         height: 'auto',
         marginTop: '14px',
-        backgroundColor: theme.eventkit.colors.secondary,
-        boxShadow: '0px 3px 15px rgba(0, 0, 0, 0.2) ',
     },
     tab: {
         opacity: 1,
@@ -91,13 +88,12 @@ const jss = (theme: Theme & Eventkit.Theme) => createStyles({
         borderTopLeftRadius: '2px',
         borderBottomLeftRadius: '2px',
         borderBottomRightRadius: '0px',
-        backgroundColor: 'lightgrey',
         '& img': {
-            boxShadow: '0px 1px 3px 0px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 2px 1px -1px rgba(0,0,0,0.12)',
+            backgroundColor: theme.eventkit.colors.secondary,
         },
         '&$selected': {
             '& img': {
-                backgroundColor: theme.eventkit.colors.secondary,
+                backgroundColor: 'white',
             }
         }
     },
@@ -323,8 +319,8 @@ export function MapDrawer(props: Props) {
             text: new Text({
                 text: featureName,
                 font: '14px Calibri,sans-serif',
-                stroke: new Stroke({color: theme.eventkit.colors.text_primary, width: 1}),
-                fill: new Fill({color: theme.eventkit.colors.text_primary}),
+                stroke: new Stroke({color: theme.eventkit.colors.text_primary, width: 3}),
+                fill: new Fill({color: theme.eventkit.colors.white}),
             })
         });
         return style

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -8,7 +8,7 @@ import {
     Theme,
     withStyles,
     Icon,
-    Divider, Link, Menu, MenuItem
+    Divider, Link,
 } from "@material-ui/core";
 import {connect} from "react-redux";
 import CardMedia from '@material-ui/core/CardMedia';
@@ -34,7 +34,6 @@ import RequestDataSource from "./RequestDataSource";
 import {useEffect, useState} from "react";
 import UnavailableFilterPopup from "../DataPackPage/UnavailableFilterPopup";
 import MapDrawerOptions from "./MapDrawerOptions";
-import {arrayHasValue} from "../../utils/generic";
 import isEqual from 'lodash.isequal';
 
 const jss = (theme: Theme & Eventkit.Theme) => createStyles({
@@ -309,7 +308,6 @@ export function MapDrawer(props: Props) {
 
     function getRandomColor() {
         var rgb = [];
-
         for (var i = 0; i < 3; i++)
             rgb.push(Math.floor(Math.random() * 255));
         return rgb
@@ -458,8 +456,8 @@ export function MapDrawer(props: Props) {
                                         <img
                                             className={classes.imageIcon}
                                             src={theme.eventkit.images.overlays}
-                                            alt="Coverages"
-                                            title="Coverages"
+                                            alt="Coverage"
+                                            title="Coverage"
                                         />
                                     </Icon>
                                 </Card>)}
@@ -592,7 +590,7 @@ export function MapDrawer(props: Props) {
                         <div style={{height: '100%'}}>
                             <div style={{display: 'block'}} className={classes.heading}>
                                 <div style={{display: 'flex'}}>
-                                    <strong style={{fontSize: '18px', margin: 'auto 0'}}>Coverages</strong>
+                                    <strong style={{fontSize: '18px', margin: 'auto 0'}}>Coverage</strong>
                                     <Clear
                                         className={classes.clear}
                                         color="primary"
@@ -601,7 +599,7 @@ export function MapDrawer(props: Props) {
                                 </div>
                                 <div style={{display: 'flex'}}>
                                     <strong style={{margin: 'auto 0'}}>
-                                        Select coverage footprints
+                                        Select footprints
                                     </strong>
                                     <span style={{marginLeft: 'auto', marginRight: '3px'}}>
                                     <MapDrawerOptions

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -397,7 +397,7 @@ export function MapDrawer(props: Props) {
                                     <Icon classes={{root: classes.iconRoot}}>
                                         <img
                                             className={classes.imageIcon}
-                                            src={theme.eventkit.images.basemap}
+                                            src={theme.eventkit.images.overlays}
                                             alt="Coverages"
                                             title="Coverages"
                                         />

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -13,7 +13,7 @@ import {
 import {connect} from "react-redux";
 import CardMedia from '@material-ui/core/CardMedia';
 import Card from '@material-ui/core/Card';
-
+import Checkbox from '@material-ui/core/Checkbox';
 import Radio from "@material-ui/core/Radio";
 import {Tab, Tabs} from "@material-ui/core";
 import Typography from "@material-ui/core/Typography";
@@ -323,7 +323,7 @@ export function MapDrawer(props: Props) {
                 >
                     <VerticalTabs
                         className={classes.tabs}
-                        value={(selectedTab) ? selectedTab : ''}
+                        value={(selectedTab) ? selectedTab : false}
                         onChange={handleChange}
                     >
                         <Tab
@@ -364,144 +364,249 @@ export function MapDrawer(props: Props) {
                         />
                     </VerticalTabs>
 
-                    <div style={{display: selectedTab === 'basemap' ? 'block' : 'none'}} className={classes.heading}>
-                        <div style={{display: 'flex'}}>
-                            <strong style={{fontSize: '18px', margin: 'auto 0'}}>Basemaps</strong>
-                            <Clear
-                                className={classes.clear}
-                                color="primary"
-                                onClick={(event) => setSelectedTab('basemap')}
-                            />
-                        </div>
-                        <div style={{display: 'flex'}}>
-                            <strong style={{margin: 'auto 0'}}>
-                                Select a basemap
-                            </strong>
-                            <span style={{marginLeft: 'auto', marginRight: '3px'}}>
-                            <MapDrawerOptions
-                                providers={providers}
-                                setProviders={setFilteredProviders}
-                                onEnabled={(offset: number) => setOffSet(offset)}
-                                onDisabled={() => setOffSet(0)}
-                            />
-                            </span>
-                        </div>
-                    </div>
-                    <div style={{display: selectedTab === 'coverage' ? 'block' : 'none'}} className={classes.heading}>
-                        <div style={{display: 'flex'}}>
-                            <strong style={{fontSize: '18px', margin: 'auto 0'}}>Coverages</strong>
-                            <Clear
-                                className={classes.clear}
-                                color="primary"
-                                onClick={(event) => setSelectedTab('coverage')}
-                            />
-                        </div>
-                        <div style={{display: 'flex'}}>
-                            <strong style={{margin: 'auto 0'}}>
-                                Select provider coverages to display
-                            </strong>
-                            <span style={{marginLeft: 'auto', marginRight: '3px'}}>
-                            <MapDrawerOptions
-                                providers={providers}
-                                setProviders={setFilteredProviders}
-                                onEnabled={(offset: number) => setOffSet(offset)}
-                                onDisabled={() => setOffSet(0)}
-                            />
-                            </span>
-                        </div>
-                    </div>
+                    {selectedTab === 'basemap' &&
+                        <div style={{height: '100%'}}>
+                            <div style={{display: 'block'}} className={classes.heading}>
+                                <div style={{display: 'flex'}}>
+                                    <strong style={{fontSize: '18px', margin: 'auto 0'}}>Basemaps</strong>
+                                    <Clear
+                                        className={classes.clear}
+                                        color="primary"
+                                        onClick={(event) => setSelectedTab('')}
+                                    />
+                                </div>
+                                <div style={{display: 'flex'}}>
+                                    <strong style={{margin: 'auto 0'}}>
+                                        Select a basemap
+                                    </strong>
+                                    <span style={{marginLeft: 'auto', marginRight: '3px'}}>
+                                    <MapDrawerOptions
+                                        providers={providers}
+                                        setProviders={setFilteredProviders}
+                                        onEnabled={(offset: number) => setOffSet(offset)}
+                                        onDisabled={() => setOffSet(0)}
+                                    />
+                                    </span>
+                                </div>
+                            </div>
 
-                    <div className={classes.scrollBar} style={areProvidersHidden ? {} : {height: 'calc(100% - 100px)'}}>
-                        <CustomScrollbar>
-                            <div style={{height: `${offSet}px`}} />
-                            <List style={{padding: '10px'}}>
-                                {(sources || []).map((source, ix) => (
-                                        <div key={ix}>
-                                            <ListItem className={`${classes.listItem} ${classes.noPadding}`}>
-                                            <span style={{marginRight: '2px'}}>
-                                                <Radio
-                                                    checked={selectedBaseMap === ix}
-                                                    value={ix}
-                                                    classes={{
-                                                        root: classes.checkbox, checked: classes.checked,
-                                                    }}
-                                                    onClick={(e) => handleExpandClick(e, sources)}
-                                                    name="source"
-                                                />
-                                            </span>
-                                                <div>
-                                                    <div style={{display: 'flex'}}>
-                                                        {source.thumbnail_url &&
-                                                        <CardMedia
-                                                            className={classes.thumbnail}
-                                                            image={source.thumbnail_url}
+                            <div className={classes.scrollBar}
+                                 style={areProvidersHidden ? {} : {height: 'calc(100% - 115px)'}}>
+                                <CustomScrollbar>
+                                    <div style={{height: `${offSet}px`}}/>
+                                    <List style={{padding: '10px'}}>
+                                        {(sources || []).map((source, ix) => (
+                                                <div key={ix}>
+                                                    <ListItem className={`${classes.listItem} ${classes.noPadding}`}>
+                                                    <span style={{marginRight: '2px'}}>
+                                                        <Radio
+                                                            checked={selectedBaseMap === ix}
+                                                            value={ix}
+                                                            classes={{
+                                                                root: classes.checkbox, checked: classes.checked,
+                                                            }}
+                                                            onClick={(e) => handleExpandClick(e, sources)}
+                                                            name="source"
                                                         />
-                                                        }
-                                                        <ListItemText
-                                                            className={classes.noPadding}
-                                                            disableTypography
-                                                            primary={
-                                                                <Typography
-                                                                    className={classes.buttonLabel}
-                                                                >
-                                                                    {source.name}
-                                                                </Typography>
-                                                            }
-                                                        />
-                                                    </div>
-                                                    <div className={classes.buttonLabelSecondary}>
-                                                        {source.data_type && source.data_type[0].toUpperCase() + source.data_type.substring(1)}
+                                                    </span>
+                                                        <div>
+                                                            <div style={{display: 'flex'}}>
+                                                                {source.thumbnail_url &&
+                                                                <CardMedia
+                                                                    className={classes.thumbnail}
+                                                                    image={source.thumbnail_url}
+                                                                />
+                                                                }
+                                                                <ListItemText
+                                                                    className={classes.noPadding}
+                                                                    disableTypography
+                                                                    primary={
+                                                                        <Typography
+                                                                            className={classes.buttonLabel}
+                                                                        >
+                                                                            {source.name}
+                                                                        </Typography>
+                                                                    }
+                                                                />
+                                                            </div>
+                                                            <div className={classes.buttonLabelSecondary}>
+                                                                {source.data_type && source.data_type[0].toUpperCase() + source.data_type.substring(1)}
+                                                            </div>
+                                                        </div>
+                                                    </ListItem>
+                                                    <div
+                                                        className={classes.footprint_options}
+                                                    >
+                                                        {showFootprintData(ix, sources)}
                                                     </div>
                                                 </div>
-                                            </ListItem>
-                                            <div
-                                                className={classes.footprint_options}
-                                            >
-                                                {showFootprintData(ix, sources)}
-                                            </div>
-                                        </div>
-                                    )
-                                )}
-                            </List>
-                        </CustomScrollbar>
-                    </div>
-                    <Divider style={{margin: '0 5px 0 5px'}}/>
-
-                    <div
-                        className={`${classes.stickyRow} ${areProvidersHidden ? classes.stickyRowSources : ''}`}
-                    >
-                        <div
-                            className={classes.stickyRowItems}
-                            style={{paddingLeft: '8px', paddingTop: '8px', display: 'flex',}}
-                        >
-                            <div style={{marginRight: '8px'}}>
-                                <RequestDataSource open={requestDataSourceOpen}
-                                                   onClose={() => setRequestDataSourceOpen(false)}/>
-                                <div>
-                                    Data Source Missing?
-                                </div>
-                                <Link onClick={() => setRequestDataSourceOpen(true)}
-                                      style={{fontSize: '12px', cursor: 'pointer'}}>
-                                    Request New Data Source
-                                </Link>
+                                            )
+                                        )}
+                                    </List>
+                                </CustomScrollbar>
                             </div>
-                            <div>
-                                <Button
-                                    className={`${classes.button} ${classes.stickRowyItems}`}
-                                    color="primary"
-                                    variant="contained"
-                                    disabled={selectedBaseMap === -1 || (!selectedBaseMap && selectedBaseMap !== 0)}
-                                    // -1 clear the map
-                                    onClick={() => {
-                                        updateBaseMap(-1, sources);
-                                    }}
+                            <Divider style={{margin: '0 5px 0 5px'}}/>
+
+                            <div
+                                className={`${classes.stickyRow} ${areProvidersHidden ? classes.stickyRowSources : ''}`}
+                            >
+                                <div
+                                    className={classes.stickyRowItems}
+                                    style={{paddingLeft: '8px', paddingTop: '8px', display: 'flex',}}
                                 >
-                                    Reset
-                                </Button>
+                                    <div style={{marginRight: '8px'}}>
+                                        <RequestDataSource open={requestDataSourceOpen}
+                                                           onClose={() => setRequestDataSourceOpen(false)}/>
+                                        <div>
+                                            Data Source Missing?
+                                        </div>
+                                        <Link onClick={() => setRequestDataSourceOpen(true)}
+                                              style={{fontSize: '12px', cursor: 'pointer'}}>
+                                            Request New Data Source
+                                        </Link>
+                                    </div>
+                                    <div>
+                                        <Button
+                                            className={`${classes.button} ${classes.stickRowyItems}`}
+                                            color="primary"
+                                            variant="contained"
+                                            disabled={selectedBaseMap === -1 || (!selectedBaseMap && selectedBaseMap !== 0)}
+                                            // -1 clear the map
+                                            onClick={() => {
+                                                updateBaseMap(-1, sources);
+                                            }}
+                                        >
+                                            Reset
+                                        </Button>
+                                    </div>
+                                </div>
+                                {areProvidersHidden && <UnavailableFilterPopup/>}
                             </div>
                         </div>
-                        {areProvidersHidden && <UnavailableFilterPopup/>}
-                    </div>
+                    }
+
+                    {selectedTab === 'coverage' &&
+                        <div style={{height: '100%'}}>
+                            <div style={{display: 'block'}} className={classes.heading}>
+                                <div style={{display: 'flex'}}>
+                                    <strong style={{fontSize: '18px', margin: 'auto 0'}}>Coverages</strong>
+                                    <Clear
+                                        className={classes.clear}
+                                        color="primary"
+                                        onClick={(event) => setSelectedTab('')}
+                                    />
+                                </div>
+                                <div style={{display: 'flex'}}>
+                                    <strong style={{margin: 'auto 0'}}>
+                                        Select coverage footprints
+                                    </strong>
+                                    <span style={{marginLeft: 'auto', marginRight: '3px'}}>
+                                    <MapDrawerOptions
+                                        providers={providers}
+                                        setProviders={setFilteredProviders}
+                                        onEnabled={(offset: number) => setOffSet(offset)}
+                                        onDisabled={() => setOffSet(0)}
+                                    />
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div className={classes.scrollBar}
+                                 style={areProvidersHidden ? {} : {height: 'calc(100% - 115px)'}}>
+                                <CustomScrollbar>
+                                    <div style={{height: `${offSet}px`}}/>
+                                    <List style={{padding: '10px'}}>
+                                        {(sources || []).map((source, ix) => (
+                                                <div key={ix}>
+                                                    <ListItem className={`${classes.listItem} ${classes.noPadding}`}>
+                                                    <span style={{marginRight: '2px'}}>
+
+                                                        <Checkbox
+                                                            checked={selectedBaseMap === ix}
+                                                            value={ix}
+                                                            classes={{
+                                                                root: classes.checkbox, checked: classes.checked,
+                                                            }}
+                                                            onClick={(e) => handleExpandClick(e, sources)}
+                                                            name="source"
+                                                        />
+
+                                                    </span>
+                                                        <div>
+                                                            <div style={{display: 'flex'}}>
+                                                                {source.thumbnail_url &&
+                                                                <CardMedia
+                                                                    className={classes.thumbnail}
+                                                                    image={source.thumbnail_url}
+                                                                />
+                                                                }
+                                                                <ListItemText
+                                                                    className={classes.noPadding}
+                                                                    disableTypography
+                                                                    primary={
+                                                                        <Typography
+                                                                            className={classes.buttonLabel}
+                                                                        >
+                                                                            {source.name}
+                                                                        </Typography>
+                                                                    }
+                                                                />
+                                                            </div>
+                                                            <div className={classes.buttonLabelSecondary}>
+                                                                {source.data_type && source.data_type[0].toUpperCase() + source.data_type.substring(1)}
+                                                            </div>
+                                                        </div>
+                                                    </ListItem>
+                                                    <div
+                                                        className={classes.footprint_options}
+                                                    >
+                                                        {showFootprintData(ix, sources)}
+                                                    </div>
+                                                </div>
+                                            )
+                                        )}
+                                    </List>
+                                </CustomScrollbar>
+                            </div>
+                            <Divider style={{margin: '0 5px 0 5px'}}/>
+
+                            <div
+                                className={`${classes.stickyRow} ${areProvidersHidden ? classes.stickyRowSources : ''}`}
+                            >
+                                <div
+                                    className={classes.stickyRowItems}
+                                    style={{paddingLeft: '8px', paddingTop: '8px', display: 'flex',}}
+                                >
+                                    <div style={{marginRight: '8px'}}>
+                                        <RequestDataSource open={requestDataSourceOpen}
+                                                           onClose={() => setRequestDataSourceOpen(false)}/>
+                                        <div>
+                                            Data Source Missing?
+                                        </div>
+                                        <Link onClick={() => setRequestDataSourceOpen(true)}
+                                              style={{fontSize: '12px', cursor: 'pointer'}}>
+                                            Request New Data Source
+                                        </Link>
+                                    </div>
+                                    <div>
+                                        <Button
+                                            className={`${classes.button} ${classes.stickRowyItems}`}
+                                            color="primary"
+                                            variant="contained"
+                                            disabled={selectedBaseMap === -1 || (!selectedBaseMap && selectedBaseMap !== 0)}
+                                            // -1 clear the map
+                                            onClick={() => {
+                                                updateBaseMap(-1, sources);
+                                            }}
+                                        >
+                                            Reset
+                                        </Button>
+                                    </div>
+                                </div>
+                                {areProvidersHidden && <UnavailableFilterPopup/>}
+                            </div>
+                        </div>
+                    }
 
                 </Drawer>
             </div>

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -294,8 +294,33 @@ export function MapDrawer(props: Props) {
     }
 
     function colorWithAlpha(color, alpha) {
-        const [r, g, b] = Array.from(olColor.asArray(color));
+        const [r, g, b] = color
         return olColor.asString([r, g, b, alpha]);
+    }
+
+    function getRandomColor() {
+        var rgb = [];
+
+        for (var i = 0; i < 3; i++)
+            rgb.push(Math.floor(Math.random() * 255));
+        return rgb
+    }
+
+    function getFeatureStyle(featureName) {
+        let randomColor = getRandomColor()
+        let fillColor = colorWithAlpha(randomColor, 0.2)
+        let strokeColor = colorWithAlpha(randomColor, 0.8)
+        let style = new Style({
+            stroke: new Stroke({color: strokeColor, width: 2}),
+            fill: new Fill({color: fillColor}),
+            text: new Text({
+                text: featureName,
+                font: '14px Calibri,sans-serif',
+                stroke: new Stroke({color: theme.eventkit.colors.text_primary, width: 1}),
+                fill: new Fill({color: theme.eventkit.colors.text_primary}),
+            })
+        });
+        return style
     }
 
     const drawerOpen = !!selectedTab;
@@ -343,21 +368,9 @@ export function MapDrawer(props: Props) {
             ...filteredProviders.filter(_provider =>
                 !_provider.hidden && !!_provider.the_geom && !!_provider.display).map(_provider => {
 
-                let color = colorWithAlpha('#' + Math.floor(Math.random() * 16777215).toString(16), 0.25)
-                let style = new Style({
-                    stroke: new Stroke({color: color}),
-                    fill: new Fill({color: color, opacity: 0.9}),
-                    text: new Text({
-                        text: _provider.name,
-                        font: '12px Calibri,sans-serif',
-                        stroke: new Stroke({
-                            color: color, width: 2
-                        })
-                    })
-                });
-
                 const features = []
                 const geos = _provider.the_geom.coordinates
+                const style = getFeatureStyle(_provider.name)
                 geos.forEach(function(coords) {
                     const polygon = new Polygon(coords);
                     const feature = new Feature({

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -203,7 +203,7 @@ export function MapDrawer(props: Props) {
     const {providers, classes} = props;
 
     const [expandedSources, setExpandedSources] = useState([]);
-    const [selectedTab, setSelectedTab] = useState(false);
+    const [selectedTab, setSelectedTab] = useState('');
     const [selectedBaseMap, setBaseMap] = useState(-1);
     const [requestDataSourceOpen, setRequestDataSourceOpen] = useState(false);
 
@@ -218,7 +218,7 @@ export function MapDrawer(props: Props) {
 
     function handleChange(event, newValue) {
         if (selectedTab === newValue) {
-            setSelectedTab(false);
+            setSelectedTab('');
         } else {
             setSelectedTab(newValue);
         }
@@ -323,7 +323,7 @@ export function MapDrawer(props: Props) {
                 >
                     <VerticalTabs
                         className={classes.tabs}
-                        value={(selectedTab) ? selectedTab : false}
+                        value={(selectedTab) ? selectedTab : ''}
                         onChange={handleChange}
                     >
                         <Tab
@@ -344,15 +344,33 @@ export function MapDrawer(props: Props) {
                                     </Icon>
                                 </Card>)}
                         />
+                        <Tab
+                            value="coverage"
+                            classes={{
+                                root: classes.tab,
+                                selected: classes.selected,
+                            }}
+                            label={(
+                                <Card className={classes.tabHeader}>
+                                    <Icon classes={{root: classes.iconRoot}}>
+                                        <img
+                                            className={classes.imageIcon}
+                                            src={theme.eventkit.images.basemap}
+                                            alt="Coverages"
+                                            title="Coverages"
+                                        />
+                                    </Icon>
+                                </Card>)}
+                        />
                     </VerticalTabs>
-                    <div style={{display: 'block'}} className={classes.heading}>
+
+                    <div style={{display: selectedTab === 'basemap' ? 'block' : 'none'}} className={classes.heading}>
                         <div style={{display: 'flex'}}>
                             <strong style={{fontSize: '18px', margin: 'auto 0'}}>Basemaps</strong>
                             <Clear
                                 className={classes.clear}
                                 color="primary"
-                                onClick={(event) => setSelectedTab(false)}
-
+                                onClick={(event) => setSelectedTab('basemap')}
                             />
                         </div>
                         <div style={{display: 'flex'}}>
@@ -369,6 +387,30 @@ export function MapDrawer(props: Props) {
                             </span>
                         </div>
                     </div>
+                    <div style={{display: selectedTab === 'coverage' ? 'block' : 'none'}} className={classes.heading}>
+                        <div style={{display: 'flex'}}>
+                            <strong style={{fontSize: '18px', margin: 'auto 0'}}>Coverages</strong>
+                            <Clear
+                                className={classes.clear}
+                                color="primary"
+                                onClick={(event) => setSelectedTab('coverage')}
+                            />
+                        </div>
+                        <div style={{display: 'flex'}}>
+                            <strong style={{margin: 'auto 0'}}>
+                                Select provider coverages to display
+                            </strong>
+                            <span style={{marginLeft: 'auto', marginRight: '3px'}}>
+                            <MapDrawerOptions
+                                providers={providers}
+                                setProviders={setFilteredProviders}
+                                onEnabled={(offset: number) => setOffSet(offset)}
+                                onDisabled={() => setOffSet(0)}
+                            />
+                            </span>
+                        </div>
+                    </div>
+
                     <div className={classes.scrollBar} style={areProvidersHidden ? {} : {height: 'calc(100% - 100px)'}}>
                         <CustomScrollbar>
                             <div style={{height: `${offSet}px`}} />
@@ -460,6 +502,7 @@ export function MapDrawer(props: Props) {
                         </div>
                         {areProvidersHidden && <UnavailableFilterPopup/>}
                     </div>
+
                 </Drawer>
             </div>
         </div>

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -293,8 +293,13 @@ export function MapDrawer(props: Props) {
         }
     }
 
+    function clearCoverageGeos() {
+        selectedCoverages.forEach((cov) => props.removeCoverageGeos(cov.features));
+        setSelectedCoverages([]);
+    }
+
     function colorWithAlpha(color, alpha) {
-        const [r, g, b] = color
+        const [r, g, b] = color;
         return olColor.asString([r, g, b, alpha]);
     }
 
@@ -308,8 +313,8 @@ export function MapDrawer(props: Props) {
 
     function getFeatureStyle(featureName) {
         let randomColor = getRandomColor()
-        let fillColor = colorWithAlpha(randomColor, 0.2)
-        let strokeColor = colorWithAlpha(randomColor, 0.8)
+        let fillColor = colorWithAlpha(randomColor, 0.1)
+        let strokeColor = colorWithAlpha(randomColor, 0.7)
         let style = new Style({
             stroke: new Stroke({color: strokeColor, width: 2}),
             fill: new Fill({color: fillColor}),
@@ -325,7 +330,6 @@ export function MapDrawer(props: Props) {
 
     const drawerOpen = !!selectedTab;
     const areProvidersHidden = providers.find(provider => provider.hidden === true);
-
 
     const [ offSet, setOffSet ] = useState(0);
 
@@ -667,11 +671,9 @@ export function MapDrawer(props: Props) {
                                             className={`${classes.button} ${classes.stickRowyItems}`}
                                             color="primary"
                                             variant="contained"
-                                            disabled={selectedBaseMap === -1 || (!selectedBaseMap && selectedBaseMap !== 0)}
-                                            // -1 clear the map
-                                            // TODO: change click handler to clear coverage layers
+                                            disabled={selectedCoverages === undefined || selectedCoverages.length == 0}
                                             onClick={() => {
-                                                updateBaseMap(-1, sources);
+                                                clearCoverageGeos();
                                             }}
                                         >
                                             Reset

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawerOptions.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawerOptions.tsx
@@ -7,6 +7,7 @@ import {renderIf} from "../../utils/renderIf";
 import Radio from "@material-ui/core/Radio";
 import {useDebouncedState, useProviderIdentity} from "../../utils/hooks/hooks";
 import {arrayHasValue, shouldDisplay as providerShouldDisplay} from "../../utils/generic";
+import {unionBy} from 'lodash';
 
 
 const jss = (theme: Theme & Eventkit.Theme) => createStyles({
@@ -115,6 +116,7 @@ export interface Filter {
 interface Props {
     // filter name, number of sources relevant, whether it's enabled
     providers: Eventkit.Provider[];
+    selected: Eventkit.Provider[];
     setProviders: (providers: Eventkit.Provider[]) => void;
     onEnabled: (offset: number) => void;
     onDisabled: () => void;
@@ -215,9 +217,11 @@ export function MapDrawerOptions(props: Props) {
                 _sourceName => _sourceName.toLowerCase().includes(filterNameValue.toLowerCase())
             );
         }
-        props.setProviders(providerNames.map(
+        let filteredProviders = providerNames.map(
             _sourceName => props.providers.find(_source => _sourceName === _source.name) || []
-        ));
+        )
+        let filteredWithSelected = unionBy(filteredProviders, props.selected || [], 'slug')
+        props.setProviders([...filteredWithSelected]);
     }, [filterNameValue, _filters]);
 
 

--- a/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
+++ b/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
@@ -139,7 +139,7 @@ declare namespace Eventkit {
         created_at: string;
     }
 
-    interface CoveragePoly {
+    interface Geom {
         type: string;
         coordinates: any[];
     }
@@ -175,7 +175,7 @@ declare namespace Eventkit {
         thumbnail_url: string;
         hidden: boolean;
         data_type: string;
-        the_geom: CoveragePoly;
+        the_geom: Geom;
     }
 
     interface Format {

--- a/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
+++ b/eventkit_cloud/ui/static/ui/app/eventkit.d.ts
@@ -139,6 +139,11 @@ declare namespace Eventkit {
         created_at: string;
     }
 
+    interface CoveragePoly {
+        type: string;
+        coordinates: any[];
+    }
+
     interface Provider {
         id: number;
         model_url: string;
@@ -170,6 +175,7 @@ declare namespace Eventkit {
         thumbnail_url: string;
         hidden: boolean;
         data_type: string;
+        the_geom: CoveragePoly;
     }
 
     interface Format {

--- a/eventkit_cloud/ui/static/ui/app/styles/eventkit_theme.js
+++ b/eventkit_cloud/ui/static/ui/app/styles/eventkit_theme.js
@@ -2,6 +2,7 @@ import topo_light from '../../images/topoBackground.png';
 import topo_dark from '../../images/ek_topo_pattern.png';
 import logo from '../../images/eventkit-logo.1.png';
 import basemap from '../../images/icn_basemap.svg';
+import overlays from '../../images/icn_overlays.svg';
 import favicon from '../../images/favicon.png';
 import reddotfavicon from '../../images/reddotfavicon.png';
 import map_pin from '../../images/icn_poi_pin.svg';
@@ -46,6 +47,7 @@ export const images = {
     topo_light,
     logo,
     basemap,
+    overlays,
     favicon,
     reddotfavicon,
     map_pin,

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportAOI.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportAOI.spec.tsx
@@ -655,11 +655,11 @@ describe('ExportAOI component', () => {
         const addInteractionSpy = sinon.spy(Map.prototype, 'addInteraction');
         const addLayerSpy = sinon.spy(Map.prototype, 'addLayer');
         instance.initializeOpenLayers();
-        expect(layerSpy.callCount).toBe(4);
+        expect(layerSpy.callCount).toBe(5);
         expect(boxSpy.calledOnce).toBe(true);
         expect(freeSpy.calledOnce).toBe(true);
         expect(addInteractionSpy.calledThrice).toBe(true);
-        expect(addLayerSpy.callCount).toBe(4);
+        expect(addLayerSpy.callCount).toBe(5);
         layerSpy.restore();
         boxSpy.restore();
         freeSpy.restore();

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/MapDrawer.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/MapDrawer.spec.tsx
@@ -46,7 +46,16 @@ describe('FilterDrawer component', () => {
             display: true,
             export_provider_type: 2,
             supported_formats: ['fmt1'],
-            preview_url: 'url/path/1'
+            preview_url: 'url/path/1',
+            the_geom: {
+                coordinates: [
+                    [
+                        [
+                            [-111, 45], [-103, 45], [-104, 41], [-111, 41], [-111, 45]
+                        ]
+                    ]
+                ]
+            }
         },
         {
             id: 3,
@@ -61,7 +70,8 @@ describe('FilterDrawer component', () => {
             display: false,
             export_provider_type: 2,
             supported_formats: ['fmt1'],
-            preview_url: 'url/path/2'
+            preview_url: 'url/path/2',
+            the_geom: null
         },
         {
             id: 1337,
@@ -76,6 +86,23 @@ describe('FilterDrawer component', () => {
             display: true,
             export_provider_type: 2,
             supported_formats: ['fmt1'],
+            the_geom: {
+                coordinates: [
+                    [
+                        [
+                            [40, 40], [20, 45], [45, 30], [40, 40]
+                        ]
+                    ],
+                    [
+                        [
+                            [20, 35], [45, 20], [30, 5], [10, 10], [10, 30], [20, 35]
+                        ],
+                        [
+                            [30, 20], [20, 25], [20, 15], [30, 20]
+                        ]
+                    ]
+                ]
+            }
         },
     ];
 
@@ -84,13 +111,15 @@ describe('FilterDrawer component', () => {
             url: '/url/path/1',
             name: 'source a',
             type: 'type a',
-            thumbnail_url: '/thumbnail/url/path/1'
+            thumbnail_url: '/thumbnail/url/path/1',
+            footprint_url: '/thumbnail/url/path/1'
         },
         {
             url: '/url/path/2',
             name: 'source b',
             type: 'type b',
-            thumbnail_url: '/thumbnail/url/path/2'
+            thumbnail_url: '/thumbnail/url/path/2',
+            footprint_url: '/thumbnail/url/path/2'
         }
     ];
 
@@ -113,22 +142,12 @@ describe('FilterDrawer component', () => {
 
     beforeEach(setup);
 
-    it('should render all the basic components', () => {
-        expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
-        expect(wrapper.find(VerticalTabs)).toHaveLength(1);
-        expect(wrapper.find(Tab)).toHaveLength(1);
-        expect(wrapper.find(Drawer)).toHaveLength(wrapper.find(Tab).length);
-        // Of the 3 providers, only one should be displayed
-        // BaseMaps are only added when a preview_url exists AND the provider should be displayed.
-        expect(wrapper.find(ListItem)).toHaveLength(1);
-        expect(wrapper.find('#dataSource-dialog')).toHaveLength(1);
-    });
+    // TESTS FOR OVERALL COMPONENT FUNCTIONALITY
 
     it('tab should have appropriate values', () => {
         // The drawer opens and closes based on the selected tab value, these need to stay in sync.
-        wrapper.find(Tab).forEach(node => {
-            expect(node.props().value).toBe("basemap");
-        });
+        expect(wrapper.find(Tab).at(0).props().value).toBe('basemap');
+        expect(wrapper.find(Tab).at(1).props().value).toBe('coverage');
     });
 
     it('should start with the basemap drawer closed', () => {
@@ -136,18 +155,75 @@ describe('FilterDrawer component', () => {
         expect(wrapper.find(Drawer).get(0).props.open).toBe(false);
     });
 
+    // TESTS FOR BASEMAP TAB FUNCTIONALITY
+
+    it('should render all the basic components', () => {
+        // open/render the basemap tab first
+        wrapper.find(Tab).at(0).simulate('click');
+        expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
+        expect(wrapper.find(VerticalTabs)).toHaveLength(1);
+        expect(wrapper.find(Tab)).toHaveLength(2);
+        expect(wrapper.find(Drawer)).toHaveLength(1);
+        // Of the 3 providers, only one should be displayed
+        // BaseMaps are only added when a preview_url exists AND the provider should be displayed.
+        expect(wrapper.find(ListItem)).toHaveLength(1);
+        expect(wrapper.find('#dataSource-dialog')).toHaveLength(1);
+    });
+
     it('should start with the data source dialog closed', () => {
         act(() => wrapper.update());
+        // open/render the basemap tab first
+        wrapper.find(Tab).at(0).simulate('click');
         expect(wrapper.find('#dataSource-dialog').html()).toContain('false');
     });
 
     it('should fire the handleExpandClick function when source checkbox is clicked', () => {
+        act(() => wrapper.update());
         const mockedEvent = sinon.spy();
         const mockCallBack = sinon.spy();
 
         mockCallBack(mockedEvent, sources);
 
+        // open/render the basemap tab first
+        wrapper.find(Tab).at(0).simulate('click');
+
         wrapper.find(Radio).at(0).simulate('click');
         expect(mockCallBack.calledOnce).toBe(true);
     });
+
+    // TESTS FOR COVERAGE TAB FUNCTIONALITY
+
+    it('should render all the basic components', () => {
+        // open/render the coverage tab first
+        wrapper.find(Tab).at(1).simulate('click');
+        expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
+        expect(wrapper.find(VerticalTabs)).toHaveLength(1);
+        expect(wrapper.find(Tab)).toHaveLength(2);
+        expect(wrapper.find(Drawer)).toHaveLength(1);
+        // Of the 3 providers, 2 should be displayed
+        // Coverages are only added when 'the_geom' exists AND the provider should be displayed.
+        expect(wrapper.find(ListItem)).toHaveLength(2);
+        expect(wrapper.find('#dataSource-dialog')).toHaveLength(1);
+    });
+
+    it('should start with the data source dialog closed', () => {
+        act(() => wrapper.update());
+        // open/render the coverage tab first
+        wrapper.find(Tab).at(1).simulate('click');
+        expect(wrapper.find('#dataSource-dialog').html()).toContain('false');
+    });
+
+    it('should fire the handleCoverageClick function when source checkbox is clicked', () => {
+        const mockedEvent = sinon.spy();
+        const mockCallBack = sinon.spy();
+
+        mockCallBack(mockedEvent, sources);
+
+        // open/render the basemap tab first
+        wrapper.find(Tab).at(0).simulate('click');
+
+        wrapper.find(Radio).at(0).simulate('click');
+        expect(mockCallBack.calledOnce).toBe(true);
+    });
+
 });


### PR DESCRIPTION
Adds 'coverage' tab next to basemaps tab. 
Adds functionality to drawer/sidebar to allow user to select + filter footprints.
Changes filtering to stop filtering selected providers in basemaps/coverages tab, to match Create Step 2 functionality. 
Adds ability to render footprints on map with labels. 
Adds randomized colors to footprints.
