### PR TITLE
Fix filtering on coverages page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawer.tsx
@@ -35,6 +35,7 @@ import {useEffect, useState} from "react";
 import UnavailableFilterPopup from "../DataPackPage/UnavailableFilterPopup";
 import MapDrawerOptions from "./MapDrawerOptions";
 import isEqual from 'lodash.isequal';
+import {shouldDisplay as providerShouldDisplay} from "../../utils/generic";
 
 const jss = (theme: Theme & Eventkit.Theme) => createStyles({
     container: {
@@ -219,6 +220,14 @@ export function MapDrawer(props: Props) {
     const [selectedBaseMap, setBaseMap] = useState(null);
     const [selectedCoverages, setSelectedCoverages] = useState([]);
     const [requestDataSourceOpen, setRequestDataSourceOpen] = useState(false);
+
+    const shouldDisplayBasemapProvider = (provider: Eventkit.Provider) => {
+        return !!(providerShouldDisplay(provider) && provider.preview_url)
+    }
+
+    const shouldDisplayCoverageProvider = (provider: Eventkit.Provider) => {
+        return !!(providerShouldDisplay(provider) && provider.the_geom)
+    }
 
     function updateBaseMap(newBaseMapSource: BaseMapSource) {
         setBaseMap(newBaseMapSource);
@@ -479,6 +488,7 @@ export function MapDrawer(props: Props) {
                                     <MapDrawerOptions
                                         providers={providers}
                                         selected={[getSourceProvider(selectedBaseMap)]}
+                                        providerShouldDisplay={shouldDisplayBasemapProvider}
                                         setProviders={setFilteredProviders}
                                         onEnabled={(offset: number) => setOffSet(offset)}
                                         onDisabled={() => setOffSet(0)}
@@ -601,6 +611,7 @@ export function MapDrawer(props: Props) {
                                     <MapDrawerOptions
                                         providers={providers}
                                         selected={selectedCoverages.map((cov) => cov.provider)}
+                                        providerShouldDisplay={shouldDisplayCoverageProvider}
                                         setProviders={setFilteredCoverageProviders}
                                         onEnabled={(offset: number) => setOffSet(offset)}
                                         onDisabled={() => setOffSet(0)}

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawerOptions.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/MapDrawerOptions.tsx
@@ -6,7 +6,7 @@ import {Chip, Grow, Link, Paper, TextField, withStyles} from "@material-ui/core"
 import {renderIf} from "../../utils/renderIf";
 import Radio from "@material-ui/core/Radio";
 import {useDebouncedState, useProviderIdentity} from "../../utils/hooks/hooks";
-import {arrayHasValue, shouldDisplay as providerShouldDisplay} from "../../utils/generic";
+import {arrayHasValue} from "../../utils/generic";
 import {unionBy} from 'lodash';
 
 
@@ -118,6 +118,7 @@ interface Props {
     providers: Eventkit.Provider[];
     selected: Eventkit.Provider[];
     setProviders: (providers: Eventkit.Provider[]) => void;
+    providerShouldDisplay: (provider: Eventkit.Provider) => boolean;
     onEnabled: (offset: number) => void;
     onDisabled: () => void;
     classes: { [className: string]: string };
@@ -130,7 +131,7 @@ export function MapDrawerOptions(props: Props) {
     const [ visibleProviders, setVisibleProviders ] = useState([]);
     useProviderIdentity(() => {
         setVisibleProviders(props.providers.filter(
-            _provider => providerShouldDisplay(_provider) && _provider.preview_url)
+            _provider => props.providerShouldDisplay(_provider))
         );
     }, props.providers);
 

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/MapDrawerOptions.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/MapDrawerOptions.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {render, screen, getByText, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect'
 import {MapDrawerOptions} from "../../components/CreateDataPack/MapDrawerOptions";
+import {shouldDisplay as providerShouldDisplay} from "../../utils/generic";
 
 jest.mock("@material-ui/core/Grow", () => {
     const React = require('react');
@@ -122,6 +123,9 @@ describe('FilterDrawer component', () => {
     const getProps = () => ({
         providers,
         setProviders: jest.fn(),
+        providerShouldDisplay: (provider: Eventkit.Provider) => {
+            return !!(providerShouldDisplay(provider) && provider.preview_url)
+        },
         onEnabled: jest.fn(),
         onDisabled: jest.fn(),
         classes: {},
@@ -176,6 +180,16 @@ describe('FilterDrawer component', () => {
         expect(screen.queryByText('Raster (2)')).toBeInTheDocument();
         expect(screen.queryByText('Vector (1)')).toBeInTheDocument();
         expect(screen.getByText('Other (1)')).toBeInTheDocument();
+    });
+
+    it('should render the zero providers for each filter when display function always returns false', () => {
+        setup({ providerShouldDisplay: (provider: Eventkit.Provider) => {return false;}});
+        const filterLink = screen.getByText('Filter');
+        fireEvent.click(filterLink);
+        expect(screen.queryByText('Filter by Name:')).toBeInTheDocument();
+        expect(screen.queryByText('Raster (0)')).toBeInTheDocument();
+        expect(screen.queryByText('Vector (0)')).toBeInTheDocument();
+        expect(screen.getByText('Other (0)')).toBeInTheDocument();
     });
 
     it('should render appropriate chips when filter option is clicked', () => {


### PR DESCRIPTION
Fix issue where data type filters would display 0 providers of their type when there were providers of that type. 