### PR TITLE
Update calls and urls to django-audit-logging

### DIFF
--- a/conda/recipes/django-audit-logging/meta.yaml
+++ b/conda/recipes/django-audit-logging/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "django-audit-logging" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.3" %}
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}
 {% set hash_value = "83f29fd12006283cbee2e3d951b810e36677e1547d93ed137f2af76995f4e2e5" %}

--- a/conda/recipes/django-audit-logging/meta.yaml
+++ b/conda/recipes/django-audit-logging/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   fn: '{{ name }}-{{ version }}.{{ file_ext }}'
-  url: https://github.com/venicegeo/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/eventkit/{{ name }}/archive/v{{ version }}.tar.gz
   '{{ hash_type }}': '{{ hash_value|lower }}'
 
 build:
@@ -31,14 +31,14 @@ test:
     - audit_logging
 
 about:
-  home: https://github.com/venicegeo/django-audit-logging
+  home: https://github.com/eventkit/django-audit-logging
   license: GPLV2
   license_family: GPL
   license_file: ''
   summary: 'Django-Audit-Logging'
   description: "This tool is adds logging support to a django application."
-  doc_url: 'https://github.com/venicegeo/django-audit-logging/blob/master/README.md'
-  dev_url: 'https://github.com/venicegeo/django-audit-logging'
+  doc_url: 'https://github.com/eventkit/django-audit-logging/blob/master/README.md'
+  dev_url: 'https://github.com/eventkit/django-audit-logging'
 
 extra:
   recipe-maintainers:

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -328,7 +328,12 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {
+                "user_id": self.user.id,
+                "username": "demo",
+                "is_superuser": False,
+                "is_staff": False,
+            }
             mock_pickup.assert_called_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -397,7 +402,12 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {
+                "user_id": self.user.id,
+                "username": "demo",
+                "is_superuser": False,
+                "is_staff": False,
+            }
             mock_pickup.assert_called_once_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -450,7 +460,12 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {
+                "user_id": self.user.id,
+                "username": "demo",
+                "is_superuser": False,
+                "is_staff": False,
+            }
             mock_pickup.assert_called_once_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -502,7 +517,12 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {
+                "user_id": self.user.id,
+                "username": "demo",
+                "is_superuser": False,
+                "is_staff": False,
+            }
             mock_pickup.assert_called_once_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -751,7 +771,12 @@ class TestBBoxSearch(APITestCase):
 
             with self.settings(CELERY_SCALE_BY_RUN=False):
                 self.client.post(url, request_data, format="json")
-                expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": True, "is_staff": False}
+                expected_user_details = {
+                    "user_id": self.user.id,
+                    "username": "demo",
+                    "is_superuser": True,
+                    "is_staff": False,
+                }
                 mock_pickup.assert_called_with(
                     run_uid="some_run_uid", user_details=expected_user_details, session_token=None
                 )

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -328,7 +328,7 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
             mock_pickup.assert_called_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -397,7 +397,7 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
             mock_pickup.assert_called_once_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -450,7 +450,7 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
             mock_pickup.assert_called_once_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -502,7 +502,7 @@ class TestJobViewSet(APITestCase):
 
         with self.settings(CELERY_SCALE_BY_RUN=False):
             self.client.post(url, request_data, format="json")
-            expected_user_details = {"username": "demo", "is_superuser": False, "is_staff": False}
+            expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": False, "is_staff": False}
             mock_pickup.assert_called_once_with(
                 run_uid="some_run_uid", user_details=expected_user_details, session_token=None
             )
@@ -751,7 +751,7 @@ class TestBBoxSearch(APITestCase):
 
             with self.settings(CELERY_SCALE_BY_RUN=False):
                 self.client.post(url, request_data, format="json")
-                expected_user_details = {"username": "demo", "is_superuser": True, "is_staff": False}
+                expected_user_details = {"user_id": self.user.id, "username": "demo", "is_superuser": True, "is_staff": False}
                 mock_pickup.assert_called_with(
                     run_uid="some_run_uid", user_details=expected_user_details, session_token=None
                 )

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -2468,6 +2468,7 @@ def get_user_details(request):
     """
     logged_in_user = request.user
     return {
+        "user_id": logged_in_user.id,
         "username": logged_in_user.username,
         "is_superuser": logged_in_user.is_superuser,
         "is_staff": logged_in_user.is_staff,

--- a/eventkit_cloud/ui/views.py
+++ b/eventkit_cloud/ui/views.py
@@ -84,7 +84,8 @@ def auth(request):
     elif getattr(settings, "LDAP_SERVER_URI", getattr(settings, "DJANGO_MODEL_LOGIN")):
         if request.method == "POST":
             """Logs out user"""
-            auth_logout(request)
+            if request.user.is_authenticated:
+                auth_logout(request)
             username = request.POST.get("username")
             password = request.POST.get("password")
             user_data = authenticate(username=username, password=password)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.18.36
 celery==5.1.2
 Django==3.2.7
 dj-database-url==0.5.0
-git+https://github.com/venicegeo/django-audit-logging.git@v0.2.1#egg=django-audit-logging  # conda: django-audit-logging
+git+https://github.com/eventkit/django-audit-logging.git@v0.2.1#egg=django-audit-logging  # conda: django-audit-logging
 django-auth-ldap==2.2.0
 django-celery-beat==2.2.1
 django-extensions==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.18.36
 celery==5.1.2
 Django==3.2.7
 dj-database-url==0.5.0
-git+https://github.com/eventkit/django-audit-logging.git@v0.2.1#egg=django-audit-logging  # conda: django-audit-logging
+git+https://github.com/eventkit/django-audit-logging.git@v0.2.3#egg=django-audit-logging  # conda: django-audit-logging
 django-auth-ldap==2.2.0
 django-celery-beat==2.2.1
 django-extensions==3.1.3


### PR DESCRIPTION
This PR updates EventKit to use our own fork of django-audit-logging.  It also updates the calls to include the newly added user_id value of user_details.  It must be reviewed in sync with the related django-audit-logging PR.  https://github.com/EventKit/django-audit-logging/pull/1

The easiest way to review this PR is to clone the django-audit-logging repo directly into the EventKit directory, check out the PR branch and symlink site-packages/audit_logging to it so that you have the changes locally rather than having to rebuild.  You'll need to run migrations as well.  

In order to check the functionality properly, make sure you have some audit events already created before you run the migrations.  After running them, you should be able to go look at your previous audit events and see that they are now tied to a user.  Newly created events should also tie to a user if they have a username present.