### PR TITLE
Replace eventlet with gevent

### DIFF
--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -21,7 +21,7 @@ priority=999
 directory = /var/lib/eventkit
 command = /var/lib/.virtualenvs/eventkit/bin/gunicorn eventkit_cloud.wsgi:application
            --bind cloud.eventkit.dev:6080
-           --worker-class eventlet
+           --worker-class gevent
            --workers 2
            --threads 4
            --access-logfile /var/log/eventkit/eventkit_cloud-access-log.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - memcached
     expose:
       - "6080"
-    command: gunicorn eventkit_cloud.wsgi:application -c eventkit_cloud/gunicorn.py --bind 0.0.0.0:6080 --worker-class eventlet --workers 8 --threads 2 --name eventkit --user eventkit --no-sendfile --reload
+    command: gunicorn eventkit_cloud.wsgi:application -c eventkit_cloud/gunicorn.py --bind 0.0.0.0:6080 --worker-class gevent --workers 8 --threads 2 --name eventkit --user eventkit --no-sendfile --reload
     environment:
       - DATABASE_URL=postgres://eventkit:eventkit_exports@postgis:5432/eventkit_exports
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672/
@@ -100,7 +100,7 @@ services:
       - memcached
     expose:
       - "6080"
-    command: gunicorn eventkit_cloud.wsgi:application -c eventkit_cloud/gunicorn.py --bind 0.0.0.0:6080 --worker-class eventlet --workers 8 --threads 2 --name eventkit --user eventkit --no-sendfile --reload --timeout 60
+    command: gunicorn eventkit_cloud.wsgi:application -c eventkit_cloud/gunicorn.py --bind 0.0.0.0:6080 --worker-class gevent --workers 8 --threads 2 --name eventkit --user eventkit --no-sendfile --reload --timeout 60
     environment:
       - DATABASE_URL=postgres://eventkit:eventkit_exports@postgis:5432/eventkit_exports
       - BROKER_URL=amqp://guest:guest@rabbitmq:5672/

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ django-storages==1.11.1
 django-timezone-field==4.1.2
 djangorestframework==3.12.4
 djangorestframework-gis==0.17.0
-eventlet==0.30.2
 GDAL==3.2.1
+gevent==21.12.0
 gunicorn==20.1.0
 MapProxy==1.13.2
 numpy==1.21.2


### PR DESCRIPTION
This PR replaces our usage of eventlet with gevent.  Gunicorn is able to use either of these for greenlets.  In order to test, you'll have to rebuild your conda dependencies and images so that gevent gets installed.  Make sure that the application comes online and that you can browse the application as expected.