### PR TITLE
Only try to call logout if the user is logged in

### DIFF
--- a/conda/recipes/django-audit-logging/meta.yaml
+++ b/conda/recipes/django-audit-logging/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "django-audit-logging" %}
-{% set version = "0.2.3" %}
+{% set version = "0.2.4" %}
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_value = "60322bf894f9d8c433c1f30990160ac9b440772609c58de497d4449d58b3b393" %}
+{% set hash_value = "c5c08669f57dcb18b121de1b3fe97fd01cb7c33c8f6a7112d87e5715c86694da" %}
 
 package:
   name: '{{ name|lower }}'

--- a/eventkit_cloud/auth/views.py
+++ b/eventkit_cloud/auth/views.py
@@ -97,7 +97,8 @@ def logout(request):
     If user is an Oauth user it will pass back an OAuth redirect to be handled by UI.
     """
     is_oauth = hasattr(request.user, "oauth")
-    auth_logout(request)
+    if request.user.is_authenticated:
+        auth_logout(request)
     response = redirect("login")
     if getattr(settings, "OAUTH_LOGOUT_URL", None):
         if is_oauth:

--- a/eventkit_cloud/ui/views.py
+++ b/eventkit_cloud/ui/views.py
@@ -109,7 +109,9 @@ def auth(request):
 
 def logout(request):
     """Logs out user"""
-    auth_logout(request)
+    # TODO: Deduplicate this with auth module.
+    if request.user.is_authenticated:
+        auth_logout(request)
     response = redirect("login")
     if settings.SESSION_USER_LAST_ACTIVE_AT in request.session:
         del request.session[settings.SESSION_USER_LAST_ACTIVE_AT]


### PR DESCRIPTION
Fixes a bug where the logout method and signal would be called even if the user was already logged out.