### PR TITLE
Bump django-audit-logging to 0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.18.36
 celery==5.1.2
 Django==3.2.7
 dj-database-url==0.5.0
-git+https://github.com/eventkit/django-audit-logging.git@v0.2.3#egg=django-audit-logging  # conda: django-audit-logging
+git+https://github.com/eventkit/django-audit-logging.git@v0.2.4#egg=django-audit-logging  # conda: django-audit-logging
 django-auth-ldap==2.2.0
 django-celery-beat==2.2.1
 django-extensions==3.1.3


### PR DESCRIPTION
Bring the requirements file in line with the latest changes to django-audit-logging.