### PR TITLE
pin history types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2813,13 +2813,10 @@
       }
     },
     "@types/history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-hy8b7Y1J8OGe6LbAjj3xniQrj3v6lsivCcrmf4TzSgPzLkhIeKgc5IZnT7ReIqmEuodjfO8EYAuoFvIrHi/+jQ==",
-      "dev": true,
-      "requires": {
-        "history": "*"
-      }
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.2.tgz",
+      "integrity": "sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==",
+      "dev": true
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@testing-library/react": "10.4.5",
     "@types/enzyme": "3.10.5",
     "@types/geojson": "7946.0.7",
+    "@types/history": "4.7.2",
     "@types/jest": "26.0.4",
     "@types/material-ui": "0.21.7",
     "@types/react": "16.9.41",


### PR DESCRIPTION
Fixes an issue with the wrong dependency being pulled in causing an error in history when building the UI.  To confirm fix, install dependencies and build the ui.
```
npm install
npm run build
```