### PR TITLE
Change select all functionality to select visible

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -539,7 +539,6 @@ export function ExportInfo(props: Props) {
                 });
             }
         });
-        console.log("SELECTED FORMATS: ", selectedFormats);
         updateExportInfoCallback({formats: selectedFormats});
     };
 
@@ -634,8 +633,8 @@ export function ExportInfo(props: Props) {
         // current array of providers
         let selectedProviders = [];
         if (e.target.checked) {
-            // set providers to the list of ALL providers
-            selectedProviders = [...providers.filter(provider => provider.display)];
+            // set providers to the list of visible providers
+            selectedProviders = [...getCurrentProviders().filter(provider => provider.display)];
         }
 
         // update the state with the new array of options
@@ -1246,7 +1245,7 @@ export function ExportInfo(props: Props) {
                             <Checkbox
                                 classes={{root: classes.checkbox, checked: classes.checked}}
                                 name="SelectAll"
-                                checked={exportInfo.providers && exportInfo.providers.length === providers.filter(
+                                checked={exportInfo.providers && exportInfo.providers.length === getCurrentProviders().filter(
                                     provider => provider.display).length}
                                 onChange={onSelectAll}
                                 style={{width: '24px', height: '24px'}}
@@ -1257,7 +1256,7 @@ export function ExportInfo(props: Props) {
                                     flexWrap: 'wrap', fontSize: '16px',
                                 }}
                             >
-                                            Select All
+                                            {(providerFilterList.length || isFilteringByProviderGeometry) ? 'Select Visible': 'Select All'}
                                             </span>
                         </div>
                         <div className={classes.sectionBottom}>


### PR DESCRIPTION
This PR changes our Select All functionality.  When the data providers are filtered down by any of our filters, the text will change to Select Visible and the functionality will match.  In order to test this PR, use one of the filters and then check Select Visible.  Then remove the filter and you'll see that only the previously visible providers are selected.