### PR TITLE
Readonly data provider serializer

### DIFF
--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -1020,8 +1020,8 @@ def basic_data_provider_serializer(data_provider: DataProvider, context: dict = 
                                 "thumbnail_url": get_thumbnail_url(data_provider),
                                 "license": basic_license_list_serializer(data_provider.license),
                                 ## Can add these after we convert config to jsonfield.
-                                # "metadata": data_provider.config and data_provider.metadata,
-                                # "footprint_url": data_provider.footprint_url,
+                                "metadata": data_provider.config and data_provider.metadata,
+                                "footprint_url": data_provider.footprint_url,
                                 "max_data_size": data_provider.get_max_data_size(request and request.user),
                                 "max_selection": data_provider.get_max_selection_size(request and request.user),
                                 "use_bbox": data_provider.export_provider_type and data_provider.export_provider_type.use_bbox,

--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -7,10 +7,11 @@ See DEFAULT_RENDERER_CLASSES setting in core.settings.contrib for the enabled re
 """
 import json
 import logging
+
 # -*- coding: utf-8 -*-
 import pickle
 from collections import OrderedDict
-from typing import List, Union, Iterable, Optional
+from typing import List, Union, Optional
 from urllib.parse import urlsplit, ParseResult
 
 from audit_logging.models import AuditEvent
@@ -23,7 +24,6 @@ from django.db.models import QuerySet
 from django.utils.translation import ugettext as _
 from notifications.models import Notification
 from rest_framework import serializers
-from rest_framework.request import Request
 from rest_framework.serializers import ValidationError
 from rest_framework_gis import serializers as geo_serializers
 from rest_framework_gis.fields import GeometrySerializerMethodField
@@ -365,9 +365,7 @@ class SimpleJobSerializer(serializers.Serializer):
 def basic_license_list_serializer(license: Optional[License]):
     """Serialize Licenses."""
     if license:
-        return {"slug": license.slug,
-                "name": license.name,
-                "text": license.text}
+        return {"slug": license.slug, "name": license.name, "text": license.text}
 
 
 class LicenseSerializer(serializers.ModelSerializer):
@@ -937,7 +935,9 @@ class ExportFormatSerializer(serializers.ModelSerializer):
         return obj.supported_projections.all().values("uid", "name", "srid", "description")
 
 
-def filtered_basic_data_provider_serializer(data_providers: Union[DataProvider, List[DataProvider]], many=False, **kwargs):
+def filtered_basic_data_provider_serializer(
+    data_providers: Union[DataProvider, List[DataProvider]], many=False, **kwargs
+):
 
     if not data_providers:
         return [{}]
@@ -948,10 +948,10 @@ def filtered_basic_data_provider_serializer(data_providers: Union[DataProvider, 
     if not many and len(data_providers) > 1:
         raise Exception("Trying to serialize more than one providers without many=True.")
 
-    serialized_data_providers = [{"id": data_provider.id,
-                                  "uid": data_provider.uid,
-                                  "hidden": True,
-                                  "display": False} for data_provider in data_providers]
+    serialized_data_providers = [
+        {"id": data_provider.id, "uid": data_provider.uid, "hidden": True, "display": False}
+        for data_provider in data_providers
+    ]
     if not many:
         serialized_data_providers = serialized_data_providers[0]
     return serialized_data_providers
@@ -970,20 +970,29 @@ class FilteredDataProviderSerializer(serializers.ModelSerializer):
     def get_display(self, obj):
         return False
 
+
 def basic_format_serializer(export_format, fields):
     return {field: getattr(export_format, field) for field in fields}
 
 
-def basic_data_provider_serializer(data_provider: DataProvider, context: dict = None, proxy_formats: dict = None,
-                                   include_geometry: bool = False, format_fields: List[str]=None, **kwargs):
+def basic_data_provider_serializer(
+    data_provider: DataProvider,
+    context: dict = None,
+    proxy_formats: dict = None,
+    include_geometry: bool = False,
+    format_fields: List[str] = None,
+    **kwargs,
+):
 
     format_fields = format_fields or []
 
     request = context.get("request")
 
     def get_supported_formats(obj):
-        export_formats = [basic_format_serializer(export_format, format_fields) for export_format in
-                          obj.export_provider_type.supported_formats.all()]
+        export_formats = [
+            basic_format_serializer(export_format, format_fields)
+            for export_format in obj.export_provider_type.supported_formats.all()
+        ]
         if proxy_formats:
             proxy_format_list = proxy_formats.get(obj.slug) or []
             export_formats.append(proxy_format_list)
@@ -1007,41 +1016,48 @@ def basic_data_provider_serializer(data_provider: DataProvider, context: dict = 
                 ).geturl()
         return ""
 
-    serialized_data_provider = {"id": data_provider.id,
-                                "uid": data_provider.uid,
-                                "name": data_provider.name,
-                                "slug": data_provider.slug,
-                                "label": data_provider.label,
-                                "preview_url": data_provider.preview_url,
-                                "service_copyright": data_provider.service_copyright,
-                                "service_description": data_provider.service_description,
-                                "type": data_provider.export_provider_type and data_provider.export_provider_type.type_name,
-                                "supported_formats": get_supported_formats(data_provider),
-                                "thumbnail_url": get_thumbnail_url(data_provider),
-                                "license": basic_license_list_serializer(data_provider.license),
-                                ## Can add these after we convert config to jsonfield.
-                                "metadata": data_provider.config and data_provider.metadata,
-                                "footprint_url": data_provider.footprint_url,
-                                "max_data_size": data_provider.get_max_data_size(request and request.user),
-                                "max_selection": data_provider.get_max_selection_size(request and request.user),
-                                "use_bbox": data_provider.export_provider_type and data_provider.export_provider_type.use_bbox,
-                                "hidden": False,
-                                "data_type": data_provider.data_type,
-                                "created_at": data_provider.created_at,
-                                "updated_at": data_provider.updated_at,
-                                "layer": data_provider.layer,
-                                "level_from": data_provider.level_from,
-                                "level_to": data_provider.level_to,
-                                "zip": data_provider.zip,
-                                "display": data_provider.display,
-                                "export_provider_type": data_provider.export_provider_type and data_provider.export_provider_type.id,
-                                "attribute_class": data_provider.attribute_class and data_provider.attribute_class.id}
+    serialized_data_provider = {
+        "id": data_provider.id,
+        "uid": data_provider.uid,
+        "name": data_provider.name,
+        "slug": data_provider.slug,
+        "label": data_provider.label,
+        "preview_url": data_provider.preview_url,
+        "service_copyright": data_provider.service_copyright,
+        "service_description": data_provider.service_description,
+        "type": data_provider.export_provider_type and data_provider.export_provider_type.type_name,
+        "supported_formats": get_supported_formats(data_provider),
+        "thumbnail_url": get_thumbnail_url(data_provider),
+        "license": basic_license_list_serializer(data_provider.license),
+        "metadata": data_provider.config and data_provider.metadata,
+        "footprint_url": data_provider.footprint_url,
+        "max_data_size": data_provider.get_max_data_size(request and request.user),
+        "max_selection": data_provider.get_max_selection_size(request and request.user),
+        "use_bbox": data_provider.export_provider_type and data_provider.export_provider_type.use_bbox,
+        "hidden": False,
+        "data_type": data_provider.data_type,
+        "created_at": data_provider.created_at,
+        "updated_at": data_provider.updated_at,
+        "layer": data_provider.layer,
+        "level_from": data_provider.level_from,
+        "level_to": data_provider.level_to,
+        "zip": data_provider.zip,
+        "display": data_provider.display,
+        "export_provider_type": data_provider.export_provider_type and data_provider.export_provider_type.id,
+        "attribute_class": data_provider.attribute_class and data_provider.attribute_class.id,
+    }
     if include_geometry:
         serialized_data_provider["the_geom"] = json.loads(data_provider.the_geom.geojson)
     return serialized_data_provider
 
-def basic_data_provider_list_serializer(data_providers: List[DataProvider], context: dict = None, many: bool = False,
-                                        include_geometry: bool = False, ** kwargs):
+
+def basic_data_provider_list_serializer(
+    data_providers: List[DataProvider],
+    context: dict = None,
+    many: bool = False,
+    include_geometry: bool = False,
+    **kwargs,
+):
 
     if not data_providers:
         return [{}]
@@ -1062,22 +1078,33 @@ def basic_data_provider_list_serializer(data_providers: List[DataProvider], cont
             else:
                 proxy_formats[provider_slug] = [export_format]
 
-    serialized_providers = [basic_data_provider_serializer(data_provider, context=context, format_fields=format_fields,
-                                           proxy_formats=proxy_formats, include_geometry=include_geometry) for data_provider in data_providers]
+    serialized_providers = [
+        basic_data_provider_serializer(
+            data_provider,
+            context=context,
+            format_fields=format_fields,
+            proxy_formats=proxy_formats,
+            include_geometry=include_geometry,
+        )
+        for data_provider in data_providers
+    ]
     if not many:
         serialized_providers = serialized_providers[0]
 
     return serialized_providers
 
+
 def basic_geojson_serializer(serialized_object: dict, geometry_field: str, *args, **kwargs):
-    return {"id": serialized_object.pop(id, None),
-            "type": "Feature",
-            "geometry": serialized_object.pop(geometry_field, None),
-            "bbox": None, # TODO: Add bbox?
-            "properties": serialized_object
+    return {
+        "id": serialized_object.pop(id, None),
+        "type": "Feature",
+        "geometry": serialized_object.pop(geometry_field, None),
+        "bbox": None,  # TODO: Add bbox?
+        "properties": serialized_object,
     }
 
-def basic_geojson_list_serializer(serialized_objects: List[dict], geometry_field:str, many=False, *args, **kwargs):
+
+def basic_geojson_list_serializer(serialized_objects: List[dict], geometry_field: str, many=False, *args, **kwargs):
     if not isinstance(serialized_objects, (List, QuerySet)):
         serialized_objects = [serialized_objects]
 
@@ -1085,10 +1112,13 @@ def basic_geojson_list_serializer(serialized_objects: List[dict], geometry_field
         raise Exception("Trying to serialize more than one providers without many=True.")
 
     if many:
-        return {"type": "FeatureCollection",
-                "features": [basic_geojson_serializer(feature, geometry_field) for feature in serialized_objects]}
+        return {
+            "type": "FeatureCollection",
+            "features": [basic_geojson_serializer(feature, geometry_field) for feature in serialized_objects],
+        }
     else:
         return basic_geojson_serializer(serialized_objects[0], geometry_field)
+
 
 class DataProviderSerializer(serializers.ModelSerializer):
     model_url = serializers.HyperlinkedIdentityField(view_name="api:providers-detail", lookup_field="slug")
@@ -1199,20 +1229,6 @@ class DataProviderGeoFeatureSerializer(DataProviderSerializer, GeoFeatureModelSe
     def get_bbox(self, obj):
         return obj.the_geom.extent
 
-
-class DataProviderGeoFeatureSerializer(DataProviderSerializer, GeoFeatureModelSerializer):
-    data_provider_geom = GeometrySerializerMethodField()
-    bbox = GeometrySerializerMethodField()
-
-    class Meta(DataProviderSerializer.Meta):
-        geo_field = "data_provider_geom"
-        bbox_geo_field = "bbox"
-
-    def get_data_provider_geom(self, obj):
-        return obj.the_geom
-
-    def get_bbox(self, obj):
-        return obj.the_geom.extent
 
 class FilteredDataProviderGeoFeatureSerializer(FilteredDataProviderSerializer, GeoFeatureModelSerializer):
     """

--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -7,10 +7,11 @@ See DEFAULT_RENDERER_CLASSES setting in core.settings.contrib for the enabled re
 """
 import json
 import logging
-
 # -*- coding: utf-8 -*-
 import pickle
 from collections import OrderedDict
+from typing import List, Union, Iterable, Optional
+from urllib.parse import urlsplit, ParseResult
 
 from audit_logging.models import AuditEvent
 from django.conf import settings
@@ -18,9 +19,11 @@ from django.contrib.auth.models import User, Group
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.cache import cache
+from django.db.models import QuerySet
 from django.utils.translation import ugettext as _
 from notifications.models import Notification
 from rest_framework import serializers
+from rest_framework.request import Request
 from rest_framework.serializers import ValidationError
 from rest_framework_gis import serializers as geo_serializers
 from rest_framework_gis.fields import GeometrySerializerMethodField
@@ -29,9 +32,7 @@ from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from eventkit_cloud.api import validators
 from eventkit_cloud.api.utils import get_run_zip_file
 from eventkit_cloud.core.models import GroupPermission, GroupPermissionLevel, attribute_class_filter
-
 from eventkit_cloud.jobs.helpers import get_valid_regional_justification
-
 from eventkit_cloud.jobs.models import (
     ExportFormat,
     Projection,
@@ -359,6 +360,14 @@ class SimpleJobSerializer(serializers.Serializer):
                     if format.slug not in formats:
                         formats.append(format.slug)
         return formats
+
+
+def basic_license_list_serializer(license: Optional[License]):
+    """Serialize Licenses."""
+    if license:
+        return {"slug": license.slug,
+                "name": license.name,
+                "text": license.text}
 
 
 class LicenseSerializer(serializers.ModelSerializer):
@@ -928,6 +937,26 @@ class ExportFormatSerializer(serializers.ModelSerializer):
         return obj.supported_projections.all().values("uid", "name", "srid", "description")
 
 
+def filtered_basic_data_provider_serializer(data_providers: Union[DataProvider, List[DataProvider]], many=False, **kwargs):
+
+    if not data_providers:
+        return [{}]
+
+    if not isinstance(data_providers, (List, QuerySet)):
+        data_providers = [data_providers]
+
+    if not many and len(data_providers) > 1:
+        raise Exception("Trying to serialize more than one providers without many=True.")
+
+    serialized_data_providers = [{"id": data_provider.id,
+                                  "uid": data_provider.uid,
+                                  "hidden": True,
+                                  "display": False} for data_provider in data_providers]
+    if not many:
+        serialized_data_providers = serialized_data_providers[0]
+    return serialized_data_providers
+
+
 class FilteredDataProviderSerializer(serializers.ModelSerializer):
 
     hidden = serializers.ReadOnlyField(default=True)
@@ -941,6 +970,125 @@ class FilteredDataProviderSerializer(serializers.ModelSerializer):
     def get_display(self, obj):
         return False
 
+def basic_format_serializer(export_format, fields):
+    return {field: getattr(export_format, field) for field in fields}
+
+
+def basic_data_provider_serializer(data_provider: DataProvider, context: dict = None, proxy_formats: dict = None,
+                                   include_geometry: bool = False, format_fields: List[str]=None, **kwargs):
+
+    format_fields = format_fields or []
+
+    request = context.get("request")
+
+    def get_supported_formats(obj):
+        export_formats = [basic_format_serializer(export_format, format_fields) for export_format in
+                          obj.export_provider_type.supported_formats.all()]
+        if proxy_formats:
+            proxy_format_list = proxy_formats.get(obj.slug) or []
+            export_formats.append(proxy_format_list)
+        return export_formats
+
+    def get_thumbnail_url(obj):
+        thumbnail = obj.thumbnail
+        if thumbnail is not None:
+            if getattr(settings, "USE_S3", False):
+                return get_presigned_url(thumbnail.download_url, expires=3000)
+            # Otherwise, grab the hostname from the request and tack on the relative url.
+            if request:
+                split_request = urlsplit(request.build_absolute_uri())
+                return ParseResult(
+                    scheme=split_request.scheme,
+                    netloc=split_request.netloc,
+                    path=f"{thumbnail.download_url}",
+                    params="",
+                    query="",
+                    fragment="",
+                ).geturl()
+        return ""
+
+    serialized_data_provider = {"id": data_provider.id,
+                                "uid": data_provider.uid,
+                                "name": data_provider.name,
+                                "slug": data_provider.slug,
+                                "label": data_provider.label,
+                                "preview_url": data_provider.preview_url,
+                                "service_copyright": data_provider.service_copyright,
+                                "service_description": data_provider.service_description,
+                                "type": data_provider.export_provider_type and data_provider.export_provider_type.type_name,
+                                "supported_formats": get_supported_formats(data_provider),
+                                "thumbnail_url": get_thumbnail_url(data_provider),
+                                "license": basic_license_list_serializer(data_provider.license),
+                                ## Can add these after we convert config to jsonfield.
+                                # "metadata": data_provider.config and data_provider.metadata,
+                                # "footprint_url": data_provider.footprint_url,
+                                "max_data_size": data_provider.get_max_data_size(request and request.user),
+                                "max_selection": data_provider.get_max_selection_size(request and request.user),
+                                "use_bbox": data_provider.export_provider_type and data_provider.export_provider_type.use_bbox,
+                                "hidden": False,
+                                "data_type": data_provider.data_type,
+                                "created_at": data_provider.created_at,
+                                "updated_at": data_provider.updated_at,
+                                "layer": data_provider.layer,
+                                "level_from": data_provider.level_from,
+                                "level_to": data_provider.level_to,
+                                "zip": data_provider.zip,
+                                "display": data_provider.display,
+                                "export_provider_type": data_provider.export_provider_type and data_provider.export_provider_type.id,
+                                "attribute_class": data_provider.attribute_class and data_provider.attribute_class.id}
+    if include_geometry:
+        serialized_data_provider["the_geom"] = json.loads(data_provider.the_geom.geojson)
+    return serialized_data_provider
+
+def basic_data_provider_list_serializer(data_providers: List[DataProvider], context: dict = None, many: bool = False,
+                                        include_geometry: bool = False, ** kwargs):
+
+    if not data_providers:
+        return [{}]
+
+    if not isinstance(data_providers, (List, QuerySet)):
+        data_providers = [data_providers]
+
+    if not many and len(data_providers) > 1:
+        raise Exception("Trying to serialize more than one providers without many=True.")
+
+    format_fields = ["uid", "name", "slug", "description"]
+
+    proxy_formats = {}
+    for export_format in ExportFormat.objects.exclude(options={}).values(*format_fields):
+        for provider_slug in export_format["options"].get("providers"):
+            if proxy_formats.get(provider_slug):
+                proxy_formats[provider_slug] += export_format
+            else:
+                proxy_formats[provider_slug] = [export_format]
+
+    serialized_providers = [basic_data_provider_serializer(data_provider, context=context, format_fields=format_fields,
+                                           proxy_formats=proxy_formats, include_geometry=include_geometry) for data_provider in data_providers]
+    if not many:
+        serialized_providers = serialized_providers[0]
+
+    return serialized_providers
+
+def basic_geojson_serializer(serialized_object: dict, geometry_field: str, *args, **kwargs):
+    return {"id": serialized_object.pop(id, None),
+            "type": "Feature",
+            "geometry": serialized_object.pop(geometry_field, None),
+            "bbox": None, # TODO: Add bbox?
+            "properties": serialized_object
+    }
+
+def basic_geojson_list_serializer(serialized_objects: List[dict], geometry_field:str, many=False, *args, **kwargs):
+    if not isinstance(serialized_objects, (List, QuerySet)):
+        serialized_objects = [serialized_objects]
+
+    if not many and len(serialized_objects) > 1:
+        raise Exception("Trying to serialize more than one providers without many=True.")
+
+    if many:
+        return {"type": "FeatureCollection",
+                "features": [basic_geojson_serializer(feature, geometry_field) for feature in serialized_objects]}
+    else:
+        return basic_geojson_serializer(serialized_objects[0], geometry_field)
 
 class DataProviderSerializer(serializers.ModelSerializer):
     model_url = serializers.HyperlinkedIdentityField(view_name="api:providers-detail", lookup_field="slug")
@@ -1051,6 +1199,20 @@ class DataProviderGeoFeatureSerializer(DataProviderSerializer, GeoFeatureModelSe
     def get_bbox(self, obj):
         return obj.the_geom.extent
 
+
+class DataProviderGeoFeatureSerializer(DataProviderSerializer, GeoFeatureModelSerializer):
+    data_provider_geom = GeometrySerializerMethodField()
+    bbox = GeometrySerializerMethodField()
+
+    class Meta(DataProviderSerializer.Meta):
+        geo_field = "data_provider_geom"
+        bbox_geo_field = "bbox"
+
+    def get_data_provider_geom(self, obj):
+        return obj.the_geom
+
+    def get_bbox(self, obj):
+        return obj.the_geom.extent
 
 class FilteredDataProviderGeoFeatureSerializer(FilteredDataProviderSerializer, GeoFeatureModelSerializer):
     """

--- a/eventkit_cloud/api/tests/test_serializers.py
+++ b/eventkit_cloud/api/tests/test_serializers.py
@@ -1,0 +1,60 @@
+import json
+from unittest.mock import Mock
+
+from django.test import TestCase
+from rest_framework.renderers import JSONRenderer
+
+from eventkit_cloud.api.serializers import (
+    basic_field_serializer,
+    filtered_basic_data_provider_serializer,
+    basic_data_provider_list_serializer,
+    DataProviderSerializer,
+)
+from eventkit_cloud.jobs.models import DataProvider
+
+
+class TestSerializers(TestCase):
+    """
+    Test cases for serializers not otherwise covered in view testing.
+    """
+
+    fixtures = ("osm_provider.json", "datamodel_presets.json")
+    maxDiff = None
+
+    def setUp(self):
+        self.data_provider = DataProvider.objects.get(slug="osm")
+
+    def test_basic_field_serializer(self):
+        example_model = {"prop1": "value1", "prop2": "value2", "prop3": "value3"}
+        model = Mock(**example_model)
+        fields = ["prop1", "prop3"]
+        expected_result = {"prop1": "value1", "prop3": "value3"}
+        self.assertEqual(basic_field_serializer(model, fields), expected_result)
+
+    def test_filtered_basic_data_provider_serializer(self):
+        expected_result = [
+            {"id": self.data_provider.id, "uid": self.data_provider.uid, "hidden": True, "display": False}
+        ]
+        self.assertEqual(filtered_basic_data_provider_serializer(self.data_provider, many=True), expected_result)
+        self.assertEqual(filtered_basic_data_provider_serializer(self.data_provider), expected_result[0])
+        self.assertEqual(filtered_basic_data_provider_serializer([]), [{}])
+        with self.assertRaises(Exception):
+            filtered_basic_data_provider_serializer([Mock(), Mock()])
+
+    def test_basic_data_provider_list_serializer(self):
+        queryset = DataProvider.objects.all()[:1]
+        readonly_serializer = json.loads(
+            JSONRenderer().render(basic_data_provider_list_serializer(queryset, many=True))
+        )
+        drf_serializer = json.loads(
+            JSONRenderer().render(DataProviderSerializer(queryset, many=True, context={"request": None}).data)
+        )
+        self.assertCountEqual(readonly_serializer[0], drf_serializer[0])
+        data_provider = DataProvider.objects.first()
+        readonly_serializer = json.loads(JSONRenderer().render(basic_data_provider_list_serializer(data_provider)))
+        drf_serializer = json.loads(
+            JSONRenderer().render(DataProviderSerializer(data_provider, context={"request": None}).data)
+        )
+        self.assertCountEqual(readonly_serializer, drf_serializer)
+        with self.assertRaises(Exception):
+            basic_data_provider_list_serializer(DataProvider.objects.all())

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -18,6 +18,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse
 from rest_framework.serializers import ValidationError
 from rest_framework.test import APITestCase
+from yaml import CLoader, CDumper
 
 from eventkit_cloud.api.pagination import LinkHeaderPagination
 from eventkit_cloud.api.views import get_models, get_provider_task, ExportRunViewSet
@@ -54,9 +55,9 @@ logger = logging.getLogger(__name__)
 
 def add_max_data_size(provider, max_data_size):
     config = provider.config
-    config = yaml.load(config)
+    config = yaml.load(config, Loader=CLoader)
     config["max_data_size"] = max_data_size
-    provider.config = yaml.dump(config)
+    provider.config = yaml.dump(config, Dumper=CDumper)
     provider.save()
 
 

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -68,7 +68,8 @@ from eventkit_cloud.api.serializers import (
     UserJobActivitySerializer,
     ExportRunGeoFeatureSerializer,
     DataProviderGeoFeatureSerializer,
-    FilteredDataProviderGeoFeatureSerializer,
+    FilteredDataProviderGeoFeatureSerializer, basic_data_provider_serializer, filtered_basic_data_provider_serializer,
+    basic_data_provider_list_serializer, basic_geojson_list_serializer,
 )
 from eventkit_cloud.api.utils import (
     get_run_zip_file,
@@ -860,6 +861,10 @@ class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
         return super(LicenseViewSet, self).retrieve(self, request, slug, *args, **kwargs)
 
 
+class BasicFilteredDataProviderSerializer:
+    pass
+
+
 class DataProviderViewSet(EventkitViewSet):
     """
     Endpoint exposing the supported data providers.
@@ -878,6 +883,18 @@ class DataProviderViewSet(EventkitViewSet):
         ):
             return DataProviderGeoFeatureSerializer, FilteredDataProviderGeoFeatureSerializer
         return DataProviderSerializer, FilteredDataProviderSerializer
+
+    def get_readonly_serializer_classes(self):
+        if (
+            self.request.query_params.get("format", "").lower() == "geojson"
+            or self.request.headers.get("content-type") == "application/geo+json"
+        ):
+            return (lambda queryset, *args, **kwargs: basic_geojson_list_serializer(basic_data_provider_list_serializer(queryset, include_geometry=True, *args, **kwargs),
+                                                                   "the_geom", *args, **kwargs),
+            lambda queryset, *args, **kwargs: basic_geojson_list_serializer(filtered_basic_data_provider_serializer(queryset, include_geometry=True, *args, **kwargs),
+                                                            "the_geom", *args, **kwargs))
+        return (lambda queryset, *args, **kwargs: basic_data_provider_list_serializer(queryset, *args, **kwargs),
+                lambda queryset, *args, **kwargs: filtered_basic_data_provider_serializer(queryset, *args, **kwargs))
 
     def get_queryset(self):
         """
@@ -919,24 +936,52 @@ class DataProviderViewSet(EventkitViewSet):
         * slug: optional lookup field
         * return: A list of data providers.
         """
+        from django.db import connection, reset_queries
+        import time
+        start = time.time()
+        logger.error(f"Getting serializer classes")
+        serializer, filtered_serializer = self.get_readonly_serializer_classes()
 
-        serializer, filtered_serializer = self.get_serializer_classes(*args, **kwargs)
+        # serializer, filtered_serializer = self.get_basic_serializer_classes(*args, **kwargs)
         # The cache_key will be different if serializing a geojson or an api json.
         cache_key = get_query_cache_key(DataProvider, request.user.username, "serialized", serializer)
         data = cache.get(cache_key)
+        reset_queries()
         if not data:
-            providers, filtered_providers = attribute_class_filter(self.get_queryset(), self.request.user)
-            data = serializer(providers, many=True, context={"request": request}).data
-            filtered_data = filtered_serializer(filtered_providers, many=True).data
+            queryset = self.get_queryset()
+            logger.error(f"Getting attribute_class_filter: {time.time() - start}")
+            providers, filtered_providers = attribute_class_filter(queryset, self.request.user)
+            logger.error(f"finished.: {time.time() - start}")
+            logger.error(f"attribute_class_filter queries: {len(connection.queries)}")
+            reset_queries()
+            logger.error(f"Serializing: {time.time() - start}")
+            data = serializer(providers, many=True, context={"request": request})
+            filtered_data = filtered_serializer(filtered_providers, many=True, context={"request": request})
+
+            logger.error(f"Serializing queries: {len(connection.queries)}")
+            # logger.error(connection.queries[:10])
+            logger.error(f"Finished: {time.time() - start}")
+            reset_queries()
+            logger.error(f"Type of data: {type(data)}")
             if isinstance(data, list):
                 data += filtered_data
             else:
                 filtered_data.update(data)
                 data = filtered_data
+            logger.error(f"joining data queries: {len(connection.queries)}")
+            reset_queries()
 
+            # logger.error([q.get("time") for q in connection.queries])
+            logger.error(f"updating cache: {time.time() - start}")
             if cache.add(cache_key, data, timeout=DEFAULT_TIMEOUT):
                 DataProvider.update_cache_key_list(cache_key)
+                cache.clear()
+            logger.error(f"caching queries: {len(connection.queries)}")
+            reset_queries()
 
+        logger.error(f"total queries: {len(connection.queries)}")
+        logger.error(f"Total Time to respond: {time.time() - start}")
+        # logger.error(connection.queries[1:10])
         return Response(data)
 
     def retrieve(self, request, slug=None, *args, **kwargs):
@@ -946,11 +991,11 @@ class DataProviderViewSet(EventkitViewSet):
         * return: The data provider with the given slug.
         """
         providers, filtered_providers = attribute_class_filter(self.get_queryset().filter(slug=slug), self.request.user)
-        serializer, filtered_serializer = self.get_serializer_classes(*args, **kwargs)
+        serializer, filtered_serializer = self.get_readonly_serializer_classes()
         if providers:
-            return Response(serializer(providers.get(slug=slug), context={"request": request}).data)
+            return Response(serializer(providers.get(slug=slug), context={"request": request}))
         elif filtered_providers:
-            return Response(filtered_serializer(providers.get(slug=slug)).data)
+            return Response(filtered_serializer(providers.get(slug=slug)))
 
     @action(methods=["post"], detail=False)
     def filter(self, request, *args, **kwargs):
@@ -977,10 +1022,10 @@ class DataProviderViewSet(EventkitViewSet):
             except ValidationError as e:
                 logger.debug(e.detail)
                 raise ValidationError(code="validation_error", detail=e.detail)
-            serializer, filtered_serializer = self.get_serializer_classes(*args, **kwargs)
+            serializer, filtered_serializer = self.get_readonly_serializer_classes()
             providers, filtered_providers = attribute_class_filter(queryset, self.request.user)
-            data = serializer(providers, many=True, context={"request": request}).data
-            filtered_data = filtered_serializer(filtered_providers, many=True).data
+            data = serializer(providers, many=True, context={"request": request})
+            filtered_data = filtered_serializer(filtered_providers, many=True)
             if isinstance(data, list):
                 data += filtered_data
             else:

--- a/eventkit_cloud/jobs/models.py
+++ b/eventkit_cloud/jobs/models.py
@@ -20,6 +20,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers import serialize
 from django.db.models import Q, QuerySet, Case, Value, When
 from django.utils import timezone
+from yaml import CLoader, CDumper
 
 from eventkit_cloud import settings
 from eventkit_cloud.core.helpers import get_or_update_session
@@ -429,7 +430,7 @@ class DataProvider(UIDMixin, TimeStampedModelMixin, CachedModelMixin):
 
         if not self.config:
             return None
-        config = yaml.load(self.config)
+        config = yaml.load(self.config, Loader=CLoader)
         url = config.get("sources", {}).get("info", {}).get("req", {}).get("url")
         type = config.get("sources", {}).get("info", {}).get("type")
         if url:
@@ -441,7 +442,7 @@ class DataProvider(UIDMixin, TimeStampedModelMixin, CachedModelMixin):
 
         if not self.config:
             return None
-        config = yaml.load(self.config)
+        config = yaml.load(self.config, Loader=CLoader)
 
         url = config.get("sources", {}).get("footprint", {}).get("req", {}).get("url")
         if url:
@@ -484,7 +485,7 @@ class DataProvider(UIDMixin, TimeStampedModelMixin, CachedModelMixin):
 
     @property
     def max_data_size(self):
-        config = yaml.load(self.config)
+        config = yaml.load(self.config, Loader=CLoader)
         return None if config is None else config.get("max_data_size", None)
 
     def get_max_data_size(self, user=None):
@@ -1077,4 +1078,4 @@ def clean_config(config: str, return_dict: bool = False) -> Union[str, dict]:
         conf.pop(service_key, None)
     if return_dict:
         return conf
-    return yaml.dump(conf)
+    return yaml.dump(conf, Dumper=CDumper)

--- a/eventkit_cloud/jobs/tests/test_models.py
+++ b/eventkit_cloud/jobs/tests/test_models.py
@@ -11,6 +11,7 @@ from django.contrib.gis.db.models.functions import Intersection
 from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import GEOSGeometry, Polygon, MultiPolygon
 from django.test import TestCase
+from yaml import CDumper
 
 from eventkit_cloud.jobs.enumerations import GeospatialDataType
 from eventkit_cloud.jobs.models import (
@@ -434,7 +435,7 @@ class TestDataProvider(TestCase):
         expected_metadata = {"url": expected_url, "type": "arcgis"}
         mock_get_mapproxy_metadata_url.return_value = expected_url
         config = {"sources": {"info": {"type": "arcgis", "req": {"url": example_url}}}}
-        self.data_provider.config = yaml.dump(config)
+        self.data_provider.config = yaml.dump(config, Dumper=CDumper)
         self.assertEqual(expected_metadata, self.data_provider.metadata)
 
     @patch("eventkit_cloud.utils.mapproxy.get_mapproxy_footprint_url")
@@ -443,7 +444,7 @@ class TestDataProvider(TestCase):
         expected_url = "http://ek.test/footprint/"
         mock_get_mapproxy_footprint_url.return_value = expected_url
         config = {"sources": {"footprint": {"req": {"url": example_url}}}}
-        self.data_provider.config = yaml.dump(config)
+        self.data_provider.config = yaml.dump(config, Dumper=CDumper)
         self.assertEqual(expected_url, self.data_provider.footprint_url)
 
     def test_layers(self):
@@ -466,14 +467,14 @@ class TestDataProvider(TestCase):
         # Test OSM configuration
         expected_layers = ["layer1", "layer2"]
         self.data_provider.type = GeospatialDataType.VECTOR.value
-        self.data_provider.config = yaml.dump({layer: "data" for layer in expected_layers})
+        self.data_provider.config = yaml.dump({layer: "data" for layer in expected_layers}, Dumper=CDumper)
         self.assertEqual(self.data_provider.layers, expected_layers)
 
         # Test multilayer feature service
         expected_layers = ["layer1", "layer2"]
         self.data_provider.export_provider_type.type_name = "wfs"
         self.data_provider.type = GeospatialDataType.VECTOR.value
-        self.data_provider.config = yaml.dump({"vector_layers": [{"name": layer} for layer in expected_layers]})
+        self.data_provider.config = yaml.dump({"vector_layers": [{"name": layer} for layer in expected_layers]}, Dumper=CDumper)
         self.assertEqual(self.data_provider.layers, expected_layers)
 
     def test_get_use_bbox_no_export_type(self):

--- a/eventkit_cloud/jobs/tests/test_models.py
+++ b/eventkit_cloud/jobs/tests/test_models.py
@@ -474,7 +474,9 @@ class TestDataProvider(TestCase):
         expected_layers = ["layer1", "layer2"]
         self.data_provider.export_provider_type.type_name = "wfs"
         self.data_provider.type = GeospatialDataType.VECTOR.value
-        self.data_provider.config = yaml.dump({"vector_layers": [{"name": layer} for layer in expected_layers]}, Dumper=CDumper)
+        self.data_provider.config = yaml.dump(
+            {"vector_layers": [{"name": layer} for layer in expected_layers]}, Dumper=CDumper
+        )
         self.assertEqual(self.data_provider.layers, expected_layers)
 
     def test_get_use_bbox_no_export_type(self):

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -30,6 +30,7 @@ from django.db import DatabaseError, transaction
 from django.db.models import Q
 from django.template.loader import get_template
 from django.utils import timezone
+from yaml import CLoader
 
 from eventkit_cloud.celery import app, TaskPriority
 from eventkit_cloud.core.helpers import sendnotification, NotificationVerb, NotificationLevel
@@ -365,7 +366,7 @@ def osm_data_collection_pipeline(
         logger.error("No configuration was provided for OSM export")
         raise RuntimeError("The configuration field is required for OSM data providers")
 
-    pbf_file = yaml.load(config).get("pbf_file")
+    pbf_file = yaml.load(config, Loader=CLoader).get("pbf_file")
 
     if pbf_file:
         logger.info(f"Using PBF file: {pbf_file} instead of overpass.")

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -17,6 +17,7 @@ from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
+from yaml import CLoader, CDumper
 
 from eventkit_cloud.celery import TaskPriority, app
 from eventkit_cloud.jobs.models import DatamodelPreset, DataProvider, Job, DataProviderType
@@ -618,7 +619,7 @@ class TestExportTasks(ExportTaskBase):
         example_overpass_query = "some_query; out;"
         example_config = {"overpass_query": example_overpass_query}
         osm_data_collection_pipeline(
-            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config)
+            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config, Dumper=CDumper)
         )
         mock_connect.assert_called_once()
         mock_overpass.Overpass.assert_called_once()
@@ -629,7 +630,7 @@ class TestExportTasks(ExportTaskBase):
         # Test canceling the provider task on an empty geopackage.
         mock_geopackage.Geopackage().run.return_value = None
         osm_data_collection_pipeline(
-            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config)
+            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config, Dumper=CDumper)
         )
         mock_cancel_provider_task.assert_called_once()
 
@@ -642,7 +643,7 @@ class TestExportTasks(ExportTaskBase):
         example_pbf_file = "test.pbf"
         example_config = {"pbf_file": example_pbf_file}
         osm_data_collection_pipeline(
-            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config)
+            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config, Dumper=CDumper)
         )
 
         mock_overpass.Overpass.assert_not_called()
@@ -1842,7 +1843,7 @@ class TestExportTasks(ExportTaskBase):
         example_format_slug = "fmt"
         self.provider.export_provider_type = DataProviderType.objects.get(type_name="ogcapi-process")
         self.provider.slug = expected_provider_slug
-        self.provider.config = yaml.dump({"ogcapi_process": {"id": "test"}})
+        self.provider.config = yaml.dump({"ogcapi_process": {"id": "test"}}, Dumper=CDumper)
         self.provider.save()
 
         expected_outfile = "/path/to/file.ext"
@@ -2008,7 +2009,7 @@ class TestExportTasks(ExportTaskBase):
                           cert_pass: "something"
                         """
 
-        configuration = yaml.load(config)["ogcapi_process"]
+        configuration = yaml.load(config, Loader=CLoader)["ogcapi_process"]
         service_url = "http://example.test/v1/"
         session_token = "_some_token_"
         example_download_url = "https://example.test/path.zip"

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -619,7 +619,10 @@ class TestExportTasks(ExportTaskBase):
         example_overpass_query = "some_query; out;"
         example_config = {"overpass_query": example_overpass_query}
         osm_data_collection_pipeline(
-            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config, Dumper=CDumper)
+            example_export_task_record_uid,
+            self.stage_dir,
+            bbox=example_bbox,
+            config=yaml.dump(example_config, Dumper=CDumper),
         )
         mock_connect.assert_called_once()
         mock_overpass.Overpass.assert_called_once()
@@ -630,7 +633,10 @@ class TestExportTasks(ExportTaskBase):
         # Test canceling the provider task on an empty geopackage.
         mock_geopackage.Geopackage().run.return_value = None
         osm_data_collection_pipeline(
-            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config, Dumper=CDumper)
+            example_export_task_record_uid,
+            self.stage_dir,
+            bbox=example_bbox,
+            config=yaml.dump(example_config, Dumper=CDumper),
         )
         mock_cancel_provider_task.assert_called_once()
 
@@ -643,7 +649,10 @@ class TestExportTasks(ExportTaskBase):
         example_pbf_file = "test.pbf"
         example_config = {"pbf_file": example_pbf_file}
         osm_data_collection_pipeline(
-            example_export_task_record_uid, self.stage_dir, bbox=example_bbox, config=yaml.dump(example_config, Dumper=CDumper)
+            example_export_task_record_uid,
+            self.stage_dir,
+            bbox=example_bbox,
+            config=yaml.dump(example_config, Dumper=CDumper),
         )
 
         mock_overpass.Overpass.assert_not_called()


### PR DESCRIPTION
Switches the data provider viewset to readonly custom serializers to speed up queries.  To test ensure that the `/api/providers` , `/api/providers/filter`, and `/api/providers/<slug>` endpoints renders the same as previously.  Ensure that it works with both format=json and format=geojson.   It should load significantly faster and use fewer database queries. 

This also switches the yaml libraries to use the C based backends.