### PR TITLE
Ensure Webpack Dockerfile Uses Correct package-lock.json

### DIFF
--- a/config/Dockerfile_webpack
+++ b/config/Dockerfile_webpack
@@ -20,6 +20,7 @@ USER eventkit
 WORKDIR /var/lib/eventkit
 
 COPY ./package.json /var/lib/eventkit/
+COPY ./package-lock.json /var/lib/eventkit/
 
 RUN npm install --quiet
 

--- a/config/Dockerfile_webpack
+++ b/config/Dockerfile_webpack
@@ -19,8 +19,7 @@ USER eventkit
 
 WORKDIR /var/lib/eventkit
 
-COPY ./package.json /var/lib/eventkit/
-COPY ./package-lock.json /var/lib/eventkit/
+COPY ./package.json ./package-lock.json /var/lib/eventkit/
 
 RUN npm install --quiet
 


### PR DESCRIPTION
In order to test this, build Webpack without it first and try to run your containers.  You'll see a bunch of TypeScript compilation errors because it's trying to use a newer version of TypeScript than the project is currently using.  Then pull this branch down and rebuild the Webpack Dockerfile and bring your containers back down and up.  The compilation errors should be resolved.