### PR TITLE
Add ArcGIS Feature Service Paginated Requests

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,6 +97,12 @@ The built EventKit containers can be pushed to a platform like Kubernetes or som
 Additionally it can be deployed on [Pivotal Cloud Foundry](https://github.com/EventKit/eventkit-cloud/blob/master/docs/pcf.md).
 
 ## For Developers
+
+#### Debugging
+
+When debugging file conversion issues it can be helpful to use the environment settings `KEEP_STAGE=True`, 
+which will not delete the staged files after the run completes/fails.
+
 #### Using ESLint
 To use ESLint while working on the EventKit front-end, first make sure you have Node.js and NPM installed in your local dev environment.
 You can find the instructions for installing them here https://docs.npmjs.com/getting-started/installing-node

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -12,7 +12,7 @@ import urllib.parse
 import uuid
 import xml.etree.ElementTree as ET
 from concurrent import futures
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from distutils import dir_util
 from functools import reduce
 from json import JSONDecodeError
@@ -33,7 +33,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from gdal_utils import convert, get_band_statistics, get_meta
 from numpy import linspace
-from requests import Response
+from requests import Response, Session
 
 from eventkit_cloud.core.helpers import get_or_update_session, handle_auth
 from eventkit_cloud.jobs.enumerations import GeospatialDataType
@@ -946,9 +946,34 @@ def download_concurrently(layers: ValuesView, concurrency=None, feature_data=Fal
     return layers
 
 
+def check_arcgis_feature_response(file_path: str, max_record_count: int = None):
+    with open(file_path) as f:
+        try:
+            json_response = json.load(f)
+        except JSONDecodeError:
+            logger.error("Unable to read JSON from file")
+            logger.info("The file contents are:")
+            logger.info(f.read())
+            raise
+
+        if json_response.get("error"):
+            logger.error(json_response)
+            raise Exception("The service did not receive a valid response.")
+
+        if "features" not in json_response:
+            # If no features are returned it would be good to let user know, but failing and retrying here
+            # doesn't seem to be the best approach.
+            # Without features and fields gdal will blow up.
+            json_response["features"] = []
+            json_response["fields"] = []
+        # TODO: raise exception IFF features == max_record_count
+    return json_response
+
+
 @retry
 def download_arcgis_feature_data(
-    task_uid: str, input_url: str, out_file: str, task_points=100, session=None, *args, **kwargs
+        task_uid: str, input_url: str, out_file: str, task_points: int = 100, session: Session = None,
+        service_description: dict = None, *args, **kwargs
 ):
     # This function is necessary because ArcGIS servers often either
     # respond with a 200 status code but also return an error message in the response body,
@@ -957,31 +982,24 @@ def download_arcgis_feature_data(
     logger.debug("Downloading feature data for %s", task_uid)
     if session:
         logger.debug("session %s", session.adapters)
+    service_description = service_description or dict()
+    pagination = False
+    max_record_count = None
+    with suppress(KeyError):
+        pagination = service_description["advancedQueryCapabilities"]["supportsPagination"]
+        max_record_count = service_description["maxRecordCount"]
     try:
         json_response = None
-        out_file = download_data(task_uid, input_url, out_file, session=session, task_points=task_points)
+        logger.debug(f"Downloading data from: {input_url}")
+        if pagination:
+            # TODO: do pagination make paginated requests while there are requests to be made...
+            # make max_record_count -= 1  so that when checking WITHOUT pagination we know if we hit our limit.
+            # use resulOffset and resultRecordCount
+        else:
+            out_file = download_data(task_uid, input_url, out_file, session=session, task_points=task_points)
+            feature_response = check_arcgis_feature_response(out_file)
         with open(out_file) as f:
-            try:
-                json_response = json.load(f)
-            except JSONDecodeError:
-                logger.error("Unable to read JSON from file")
-                logger.info("The file contents are:")
-                logger.info(f.read())
-                raise
-
-            if json_response.get("error"):
-                logger.error(json_response)
-                raise Exception("The service did not receive a valid response.")
-
-            if "features" not in json_response:
-                # If no features are returned it would be good to let user know, but failing and retrying here
-                # doesn't seem to be the best approach.
-                logger.error(f"No features were returned for {input_url}")
-                # Without features and fields gdal will blow up.
-                json_response["features"] = []
-                json_response["fields"] = []
-                json.dump(json_response, f)
-
+            json.dump(feature_response, f)
     except Exception as e:
         if json_response:
             logger.info(json_response)
@@ -1000,18 +1018,34 @@ def download_chunks(
     feature_data=False,
     level=15,
     size=None,
+    session=None,
     *args,
     **kwargs,
 ):
     tile_bboxes = get_chunked_bbox(bbox, size=size, level=level)
     chunks = []
+    service_description = {}
+    if feature_data:
+        service_url = None
+        try:
+            parsed_url = urllib.urlparse(base_url)
+            service_url = parsed_url._replace(path=parsed_url.path.removesuffix("/query")).geturl()
+            result = session.get(service_url, params={"f": "json"})
+            result.raise_for_status()
+            service_description = result.json()
+        except requests.exceptions.HTTPError as err:
+            if service_url:
+                logger.error("Could not get service description for %s", service_url)
+            else:
+                logger.error("There was an error parsing the url to get a description for %s", base_url)
     for _index, _tile_bbox in enumerate(tile_bboxes):
         # Replace bbox placeholder here, allowing for the bbox as either a list or tuple
         url = base_url.replace("BBOX_PLACEHOLDER", urllib.parse.quote(str([*_tile_bbox]).strip("[]")))
         outfile = os.path.join(stage_dir, f"chunk{_index}.json")
 
         download_function = download_arcgis_feature_data if feature_data else download_data
-        download_function(task_uid, url, outfile, task_points=(task_points * len(tile_bboxes)), *args, **kwargs)
+        download_function(task_uid, url, outfile, task_points=(task_points * len(tile_bboxes)),
+                          service_description=service_description, *args, **kwargs)
         chunks.append(outfile)
     return chunks
 


### PR DESCRIPTION
## Description of Improvement

Adds paginated requests for ArcGIS feature services that have more features than we can fetch at one time. 

## How to test

Using an ArcGIS feature provider, select a large enough area with a significant number of features, and ensure that the DataPack completes correctly.  Open the DataPack in QGIS and ensure that you see all of the features.

## Quality Assurance 

The following items have been updated:
 - [x] Linters pass.
 - [x] Unittests pass.
 - [x] The docs have been updated for any changes to the settings module.
 - [x] New tests have been added to reproduce the functionality of the above description.
 - [x] Comments have been added to declare intent, or because of some wild comprehension statement.
 - [x] UI enhancements have screenshots attached below.
 - [x] Screenshots, code, or descriptions don't include proprietary information. 
 
## Screenshots

:smile:
