### PR TITLE
adds support for arcgis-feature configuration based on the service

### DIFF
--- a/eventkit_cloud/jobs/models.py
+++ b/eventkit_cloud/jobs/models.py
@@ -6,36 +6,41 @@ import logging
 import multiprocessing
 import uuid
 from enum import Enum
-from typing import TYPE_CHECKING
-from typing import Union, List
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import yaml
 from django.contrib.auth.models import Group, User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.db import models
-from django.contrib.gis.geos import GEOSGeometry, GeometryCollection, Polygon, MultiPolygon
+from django.contrib.gis.geos import (
+    GeometryCollection,
+    GEOSGeometry,
+    MultiPolygon,
+    Polygon,
+)
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers import serialize
-from django.db.models import Q, QuerySet, Case, Value, When
+from django.db.models import Case, Q, QuerySet, Value, When
 from django.utils import timezone
-from yaml import CLoader, CDumper
+from yaml import CDumper, CLoader
 
 from eventkit_cloud import settings
 from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.core.models import (
+    AttributeClass,
     CachedModelMixin,
     DownloadableMixin,
-    TimeStampedModelMixin,
-    UIDMixin,
-    AttributeClass,
     GroupPermissionLevel,
     LowerCaseCharField,
+    TimeStampedModelMixin,
+    UIDMixin,
 )
 from eventkit_cloud.jobs.enumerations import GeospatialDataType
 from eventkit_cloud.utils.services import get_client
-from eventkit_cloud.utils.services.check_result import get_status_result, CheckResult
+from eventkit_cloud.utils.services.check_result import CheckResult, get_status_result
+from eventkit_cloud.utils.services.types import LayerDescription
 
 if TYPE_CHECKING:
     from eventkit_cloud.utils.services.base import GisClient
@@ -367,7 +372,10 @@ class DataProvider(UIDMixin, TimeStampedModelMixin, CachedModelMixin):
             logger.error("Use of settings.OVERPASS_API_URL is deprecated and will be removed in 1.13")
             url = settings.OVERPASS_API_URL
         Client = get_client(self.export_provider_type.type_name)
-        return Client(url, self.layer, aoi_geojson=None, slug=self.slug, config=load_provider_config(self.config))
+        config = None
+        if self.config:
+            config = load_provider_config(self.config)
+        return Client(url, self.layer, aoi_geojson=None, slug=self.slug, config=config)
 
     def check_status(self, aoi_geojson: dict = None):
         try:
@@ -449,29 +457,37 @@ class DataProvider(UIDMixin, TimeStampedModelMixin, CachedModelMixin):
             return get_mapproxy_footprint_url(self.slug)
 
     @property
-    def layers(self) -> List[str]:
+    def layers(self) -> Dict[LayerDescription]:
         """
         Used to populate the list of vector layers, typically for contextual or styling information.
         :return: A list of layer names.
         """
         if self.data_type != GeospatialDataType.VECTOR.value:
-            return []
-        if not self.config:
-            # Often layer names are configured using an index number but this number is not very
-            # useful when using the data so fall back to the slug which should be more meaningful.
-            if not self.layer:  # check for NoneType or empty string
-                return [self.slug]
-            try:
-                int(self.layer)
-                return [self.slug]  # self.layer is an integer, so use the slug for better context.
-            except ValueError:
-                return [self.layer]  # If we got here, layer is not None or an integer so use that.
-        config = clean_config(self.config, return_dict=True)
-        # As of EK 1.9.0 only vectors support multiple layers in a single provider
-        if self.export_provider_type.type_name in ["osm", "osm-generic"]:
-            return list(config.keys())
-        else:
-            return [layer.get("name") for layer in config.get("vector_layers", [])]
+            return {}
+        if self.config:
+            config = clean_config(str(self.config), return_dict=True)
+            # As of EK 1.9.0 only vectors support multiple layers in a single provider
+            if self.export_provider_type.type_name in ["osm", "osm-generic"]:
+                return config
+            elif config.get("vector_layers"):
+                return {layer.get("name"): layer for layer in config.get("vector_layers", [])}
+        # Often layer names are configured using an index number but this number is not very
+        # useful when using the data so fall back to the slug which should be more meaningful.
+        if not self.layer:  # check for NoneType or empty string
+            # TODO: support other service types
+            if self.export_provider_type.type_name in ["arcgis-feature"]:
+                return self.get_service_client().get_layers()
+            else:
+                return {self.slug: {"url": self.url, "name": self.slug}}
+        try:
+            int(self.layer)  # noqa
+            return {
+                self.slug: {"url": self.url, "name": self.slug}
+            }  # self.layer is an integer, so use the slug for better context.
+        except ValueError:
+            return {
+                self.layer: {"url": self.url, "name": self.layer}
+            }  # If we got here, layer is not None or an integer so use that.
 
     def get_use_bbox(self):
         if self.export_provider_type is not None:
@@ -1042,7 +1058,7 @@ def delete(self, *args, **kwargs):
 Group.delete = delete
 
 
-def load_provider_config(config: str) -> dict:
+def load_provider_config(config: Optional[str, dict]) -> dict:
     """
     Function deserializes a yaml object from a given string.
     """
@@ -1050,7 +1066,7 @@ def load_provider_config(config: str) -> dict:
     try:
         if isinstance(config, dict):
             return config
-        configuration = yaml.safe_load(config) or dict()
+        configuration = yaml.safe_load(config) if config else dict()
     except yaml.YAMLError as e:
         logger.error(f"Unable to load provider configuration: {e}")
         raise Exception(e)

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -12,7 +12,7 @@ import traceback
 from pathlib import Path
 from typing import List
 from urllib.parse import urlencode, urljoin
-from zipfile import ZipFile, ZIP_DEFLATED
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import yaml
 from billiard.einfo import ExceptionInfo
@@ -32,56 +32,69 @@ from django.utils import timezone
 from gdal_utils import convert
 from yaml import CLoader
 
-from eventkit_cloud.celery import app, TaskPriority
-from eventkit_cloud.core.helpers import sendnotification, NotificationVerb, NotificationLevel
+from eventkit_cloud.celery import TaskPriority, app
+from eventkit_cloud.core.helpers import (
+    NotificationLevel,
+    NotificationVerb,
+    sendnotification,
+)
 from eventkit_cloud.feature_selection.feature_selection import FeatureSelection
 from eventkit_cloud.jobs.enumerations import GeospatialDataType
-from eventkit_cloud.jobs.models import DataProvider, load_provider_config, clean_config, MapImageSnapshot, ExportFormat
+from eventkit_cloud.jobs.models import (
+    DataProvider,
+    ExportFormat,
+    MapImageSnapshot,
+    clean_config,
+    load_provider_config,
+)
 from eventkit_cloud.tasks import set_cache_value
 from eventkit_cloud.tasks.enumerations import TaskState
 from eventkit_cloud.tasks.exceptions import CancelException, DeleteException
 from eventkit_cloud.tasks.helpers import (
     add_export_run_files_to_zip,
     check_cached_task_failures,
+    download_concurrently,
+    download_data,
+    extract_metadata_files,
+    find_in_zip,
     generate_qgs_style,
+    get_arcgis_templates,
+    get_celery_queue_group,
     get_data_package_manifest,
     get_export_filepath,
-    get_metadata,
     get_export_task_record,
+    get_geometry,
+    get_human_readable_metadata_document,
+    get_metadata,
     get_provider_staging_dir,
     get_run_staging_dir,
     get_style_files,
+    make_file_downloadable,
+    merge_chunks,
     pickle_exception,
     progressive_kill,
-    download_data,
-    download_concurrently,
-    merge_chunks,
-    find_in_zip,
-    get_celery_queue_group,
-    extract_metadata_files,
-    get_geometry,
     update_progress,
-    get_arcgis_templates,
-    make_file_downloadable,
-    get_human_readable_metadata_document,
 )
 from eventkit_cloud.tasks.metadata import metadata_tasks
 from eventkit_cloud.tasks.models import (
-    ExportTaskRecord,
-    ExportTaskException,
     DataProviderTaskRecord,
-    FileProducingTaskResult,
     ExportRun,
+    ExportTaskException,
+    ExportTaskRecord,
+    FileProducingTaskResult,
     RunZipFile,
 )
 from eventkit_cloud.tasks.task_base import EventKitBaseTask
 from eventkit_cloud.tasks.task_process import TaskProcess
-from eventkit_cloud.utils import overpass, pbf, mapproxy, wcs, geopackage, auth_requests
 from eventkit_cloud.tasks.util_tasks import enforce_run_limit, kill_worker
+from eventkit_cloud.utils import auth_requests, geopackage, mapproxy, overpass, pbf, wcs
 from eventkit_cloud.utils.client import EventKitClient
-from eventkit_cloud.utils.helpers import make_dirs
 from eventkit_cloud.utils.generic import retry
-from eventkit_cloud.utils.ogcapi_process import OgcApiProcess, get_format_field_from_config
+from eventkit_cloud.utils.helpers import make_dirs
+from eventkit_cloud.utils.ogcapi_process import (
+    OgcApiProcess,
+    get_format_field_from_config,
+)
 from eventkit_cloud.utils.qgis_utils import convert_qgis_gpkg_to_kml
 from eventkit_cloud.utils.rocket_chat import RocketChat
 from eventkit_cloud.utils.stats.eta_estimator import ETA
@@ -1247,7 +1260,7 @@ def wfs_export_task(
     else:
         out = merge_chunks(
             output_file=gpkg,
-            layer_name=export_task_record.export_provider_task.provider.layers[0],
+            layer_name=list(export_task_record.export_provider_task.provider.layers.keys())[0],
             projection=projection,
             task_uid=task_uid,
             bbox=bbox,
@@ -1370,70 +1383,57 @@ def arcgis_feature_service_export_task(
     bbox=None,
     service_url=None,
     projection=4326,
-    config=str(),
     **kwargs,
 ):
     """
-    Function defining sqlite export for ArcFeatureService service.
+    Function defining geopackage export for ArcFeatureService service.
     """
     result = result or {}
     export_task_record = get_export_task_record(task_uid)
 
     gpkg = get_export_filepath(stage_dir, export_task_record, projection, "gpkg")
 
-    configuration = load_provider_config(config)
+    configuration = load_provider_config(export_task_record.export_provider_task.provider.config)
     if configuration.get("layers"):
         configuration.pop("layers")  # Remove raster layers to prevent download conflict, needs refactor.
-    vector_layer_data = configuration.get("vector_layers", [])
+
     out = None
-    if len(vector_layer_data):
-        layers = {}
-        for layer in vector_layer_data:
-            # TODO: using wrong signature for filepath, however pipeline counts on projection-provider_slug.ext.
-            path = get_export_filepath(stage_dir, export_task_record, f"{layer.get('name')}-{projection}", "gpkg")
-            url = get_arcgis_query_url(layer.get("url"))
-            layers[layer["name"]] = {
-                "task_uid": task_uid,
-                "url": url,
-                "path": path,
-                "base_path": os.path.join(stage_dir, f"{layer.get('name')}-{projection}"),
-                "bbox": bbox,
-                "layer_name": layer.get("name"),
-                "projection": projection,
-                "distinct_field": layer.get("distinct_field"),
-            }
+    layers = {}
+    vector_layer_data = export_task_record.export_provider_task.provider.layers
+    logger.info("Getting arcgis data using vector_layer_data %s", vector_layer_data)
+    for layer_name, layer in vector_layer_data.items():
+        # TODO: using wrong signature for filepath, however pipeline counts on projection-provider_slug.ext.
+        path = get_export_filepath(stage_dir, export_task_record, f"{layer.get('name')}-{projection}", "gpkg")
+        url = get_arcgis_query_url(layer.get("url"))
+        layers[layer["name"]] = {
+            "task_uid": task_uid,
+            "url": url,
+            "path": path,
+            "base_path": os.path.join(stage_dir, f"{layer.get('name')}-{projection}"),
+            "bbox": bbox,
+            "layer_name": layer.get("name"),
+            "projection": projection,
+            "distinct_field": layer.get("distinct_field", "OBJECTID"),
+        }
 
-        try:
-            download_concurrently(layers.values(), feature_data=True, **configuration)
-        except Exception as e:
-            logger.error(f"ArcGIS provider download error: {e}")
-            raise e
-        for layer_name, layer in layers.items():
-            if not os.path.exists(layer["path"]):
-                continue
-            task_process = TaskProcess(task_uid=task_uid)
-            out = convert(
-                driver="gpkg",
-                input_files=layer["path"],
-                output_file=gpkg,
-                boundary=bbox,
-                projection=projection,
-                layer_name=layer_name,
-                access_mode="append",
-                executor=task_process.start_process,
-            )
-
-    else:
-        out = merge_chunks(
+    try:
+        download_concurrently(list(layers.values()), feature_data=True, **configuration)
+    except Exception as e:
+        logger.error(f"ArcGIS provider download error: {e}")
+        raise e
+    for layer_name, layer in layers.items():
+        if not os.path.exists(layer["path"]):
+            continue
+        task_process = TaskProcess(task_uid=task_uid)
+        out = convert(
+            driver="gpkg",
+            input_files=layer["path"],
             output_file=gpkg,
-            layer_name=export_task_record.export_provider_task.provider.layers[0],
+            boundary=bbox,
             projection=projection,
-            task_uid=task_uid,
-            bbox=bbox,
-            stage_dir=stage_dir,
-            base_url=get_arcgis_query_url(service_url),
-            feature_data=True,
-            **configuration,
+            layer_name=layer_name,
+            access_mode="append",
+            executor=task_process.start_process,
         )
 
     if not geopackage.check_content_exists(out):
@@ -1500,7 +1500,7 @@ def vector_file_export_task(
         input_files=gpkg,
         output_file=gpkg,
         projection=projection,
-        layer_name=export_task_record.export_provider_task.provider.layers[0],
+        layer_name=list(export_task_record.export_provider_task.provider.layers.keys())[0],
         boundary=bbox,
         is_raster=False,
         executor=task_process.start_process,
@@ -2081,7 +2081,10 @@ def create_datapack_preview(result=None, task_uid=None, stage_dir=None, **kwargs
     """
     result = result or {}
     try:
-        from eventkit_cloud.utils.image_snapshot import get_wmts_snapshot_image, fit_to_area
+        from eventkit_cloud.utils.image_snapshot import (
+            fit_to_area,
+            get_wmts_snapshot_image,
+        )
 
         check_cached_task_failures(create_datapack_preview.name, task_uid)
 

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import sys
 import uuid
-from unittest.mock import Mock, PropertyMock, patch, MagicMock, ANY
+from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch
 
 import celery
 import yaml
@@ -17,44 +17,49 @@ from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
-from yaml import CLoader, CDumper
+from yaml import CDumper, CLoader
 
 from eventkit_cloud.celery import TaskPriority, app
-from eventkit_cloud.jobs.models import DatamodelPreset, DataProvider, Job, DataProviderType
+from eventkit_cloud.jobs.models import (
+    DatamodelPreset,
+    DataProvider,
+    DataProviderType,
+    Job,
+)
 from eventkit_cloud.tasks.enumerations import TaskState
 from eventkit_cloud.tasks.export_tasks import (
     ExportTask,
+    FormatTask,
+    arcgis_feature_service_export_task,
+    bounds_export_task,
+    cancel_export_provider_task,
+    create_zip_task,
     export_task_error_handler,
+    finalize_export_provider_task,
     finalize_run_task,
+    geopackage_export_task,
+    geotiff_export_task,
+    get_ogcapi_data,
+    gpx_export_task,
+    kill_task,
     kml_export_task,
     mapproxy_export_task,
-    geopackage_export_task,
-    shp_export_task,
-    arcgis_feature_service_export_task,
-    pick_up_run_task,
-    cancel_export_provider_task,
-    kill_task,
-    geotiff_export_task,
-    nitf_export_task,
-    bounds_export_task,
-    parse_result,
-    finalize_export_provider_task,
-    FormatTask,
-    wait_for_providers_task,
-    create_zip_task,
-    pbf_export_task,
-    sqlite_export_task,
-    gpx_export_task,
     mbtiles_export_task,
-    wfs_export_task,
-    vector_file_export_task,
-    raster_file_export_task,
-    osm_data_collection_pipeline,
-    reprojection_task,
+    nitf_export_task,
     ogcapi_process_export_task,
-    get_ogcapi_data,
+    osm_data_collection_pipeline,
+    parse_result,
+    pbf_export_task,
+    pick_up_run_task,
+    raster_file_export_task,
+    reprojection_task,
+    shp_export_task,
+    sqlite_export_task,
+    vector_file_export_task,
+    wait_for_providers_task,
+    wfs_export_task,
+    zip_files,
 )
-from eventkit_cloud.tasks.export_tasks import zip_files
 from eventkit_cloud.tasks.helpers import default_format_time
 from eventkit_cloud.tasks.models import (
     DataProviderTaskRecord,
@@ -804,8 +809,8 @@ class TestExportTasks(ExportTaskBase):
         )
         self.assertEqual(returned_result, expected_result)
 
+    @patch("eventkit_cloud.tasks.models.DataProvider.layers", new_callable=PropertyMock)
     @patch("eventkit_cloud.tasks.export_tasks.os.path.exists")
-    @patch("eventkit_cloud.tasks.export_tasks.merge_chunks")
     @patch("eventkit_cloud.tasks.export_tasks.make_dirs")
     @patch("eventkit_cloud.tasks.export_tasks.get_export_filepath")
     @patch("eventkit_cloud.tasks.export_tasks.geopackage")
@@ -820,8 +825,8 @@ class TestExportTasks(ExportTaskBase):
         mock_geopackage,
         mock_get_export_filepath,
         mock_makedirs,
-        mock_merge_chunks,
         mock_exists,
+        mock_layers,
     ):
         celery_uid = str(uuid.uuid4())
         type(mock_request).id = PropertyMock(return_value=celery_uid)
@@ -840,7 +845,7 @@ class TestExportTasks(ExportTaskBase):
             "https://abc.gov/arcgis/services/x/query?where=objectid=objectid&"
             "outfields=*&f=json&geometry=2.0%2C%202.0%2C%203.0%2C%203.0"
         )
-        mock_merge_chunks.return_value = expected_output_path
+        mock_convert.return_value = expected_output_path
         mock_exists.return_value = True
 
         previous_task_result = {"source": expected_input_url}
@@ -858,6 +863,19 @@ class TestExportTasks(ExportTaskBase):
         mock_geopackage.check_content_exists.return_value = True
         self.task_process.return_value = Mock(exitcode=0)
 
+        # Need to override layers so that we don't make external call.
+        url_1 = "https://abc.gov/arcgis/services/x"
+        url_2 = "https://abc.gov/arcgis/services/y"
+
+        layer_name_1 = "foo"
+        layer_name_2 = "bar"
+        expected_field = "baz"
+
+        mock_layers.return_value = {
+            layer_name_1: {"name": layer_name_1, "url": url_1},
+            layer_name_2: {"name": layer_name_2, "url": url_2},
+        }
+
         # test without trailing slash
         result_a = arcgis_feature_service_export_task.run(
             result=previous_task_result,
@@ -866,17 +884,6 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
             service_url=service_url,
             bbox=bbox,
-        )
-
-        mock_merge_chunks.assert_called_once_with(
-            output_file=expected_output_path,
-            layer_name=expected_provider_slug,
-            projection=projection,
-            task_uid=str(saved_export_task.uid),
-            bbox=bbox,
-            stage_dir=self.stage_dir,
-            base_url=f"{service_url}/{query_string}",
-            feature_data=True,
         )
 
         self.assertEqual(expected_output_path, result_a["result"])
@@ -895,21 +902,12 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(expected_output_path, result_b["result"])
         self.assertEqual(expected_output_path, result_b["source"])
 
-        url_1 = "https://abc.gov/arcgis/services/x"
-        url_2 = "https://abc.gov/arcgis/services/y"
+        vector_layers = {
+            layer_name_1: {"name": layer_name_1, "url": url_1},
+            layer_name_2: {"name": layer_name_2, "url": url_2, "distinct_field": expected_field},
+        }
 
-        layer_name_1 = "foo"
-        layer_name_2 = "bar"
-        expected_field = "baz"
-
-        config = f"""
-        vector_layers:
-            - name: '{layer_name_1}'
-              url: '{url_1}'
-            - name: '{layer_name_2}'
-              url: '{url_2}'
-              distinct_field: '{expected_field}'
-        """
+        mock_layers.return_value = vector_layers
 
         expected_path_1 = f"{layer_name_1}.gpkg"
         expected_path_2 = f"{layer_name_2}.gpkg"
@@ -924,7 +922,7 @@ class TestExportTasks(ExportTaskBase):
                 "bbox": [1, 2, 3, 4],
                 "projection": projection,
                 "layer_name": layer_name_1,
-                "distinct_field": None,
+                "distinct_field": "OBJECTID",
             },
             layer_name_2: {
                 "task_uid": str(saved_export_task.uid),
@@ -941,8 +939,10 @@ class TestExportTasks(ExportTaskBase):
         mock_download_concurrently.return_value = expected_layers
         mock_convert.reset_mock()
 
+        mock_get_export_filepath.reset_mock()
         mock_get_export_filepath.side_effect = [expected_output_path, expected_path_1, expected_path_2]
         mock_convert.return_value = expected_output_path
+        mock_download_concurrently.reset_mock()
 
         # test with multiple layers
         result_c = arcgis_feature_service_export_task.run(
@@ -952,12 +952,11 @@ class TestExportTasks(ExportTaskBase):
             projection=projection,
             service_url=f"{service_url}/",
             bbox=bbox,
-            config=config,
         )
 
         _, args, _ = mock_download_concurrently.mock_calls[0]
-        self.assertEqual(list(args[0]), list(expected_layers.values()))
 
+        self.assertEqual(list(args[0]), list(expected_layers.values()))
         self.assertEqual(mock_convert.call_count, 2)
 
         mock_convert.assert_any_call(

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 import signal
-from unittest.mock import patch, call, Mock, MagicMock
+from unittest.mock import MagicMock, Mock, call, patch
 
 import requests
 import requests_mock
@@ -14,22 +14,22 @@ from django.utils import timezone
 
 from eventkit_cloud.tasks.enumerations import TaskState
 from eventkit_cloud.tasks.helpers import (
-    get_style_files,
+    cd,
+    delete_rabbit_objects,
+    find_in_zip,
+    get_all_rabbitmq_objects,
+    get_arcgis_metadata,
+    get_data_package_manifest,
     get_file_paths,
     get_last_update,
+    get_message_count,
+    get_metadata,
     get_metadata_url,
     get_osm_last_update,
-    cd,
-    get_arcgis_metadata,
-    get_metadata,
-    get_message_count,
-    get_all_rabbitmq_objects,
-    delete_rabbit_objects,
-    get_data_package_manifest,
+    get_style_files,
+    progressive_kill,
     update_progress,
-    find_in_zip,
 )
-from eventkit_cloud.tasks.helpers import progressive_kill
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,11 @@ class TestHelpers(TestCase):
     ):
         run_uid = "1234"
         stage_dir = os.path.join(settings.EXPORT_STAGING_ROOT, str(run_uid))
-        expected_layers = ["layer1", "layer2"]
+        example_layers = {
+            "layer1": {"name": "layer1", "url": "https://some.url/layer1"},
+            "layer2": {"name": "layer2", "url": "https://some.url/layer2"},
+        }
+        expected_layers = [lyr_name for lyr_name, lyr in example_layers.items()]
         expected_type = "vector"
         mock_create_license_file.return_value = expected_license_file = {"/license.txt": "/license.txt"}
         mock_isfile.return_value = True
@@ -162,7 +166,7 @@ class TestHelpers(TestCase):
         mocked_data_provider.service_copyright = expected_copyright = "mocked_copyright"
         mocked_data_provider.config = f"cert_var: {expected_provider_slug}"
         mocked_data_provider.service_description = expected_data_provider_desc = "example_description"
-        mocked_data_provider.layers = expected_layers
+        mocked_data_provider.layers = example_layers
         mocked_data_provider.get_data_type.return_value = expected_type
         mocked_data_provider.level_from = expected_level_from = 0
         mocked_data_provider.level_to = expected_level_to = 12

--- a/eventkit_cloud/tasks/tests/test_task_builders.py
+++ b/eventkit_cloud/tasks/tests/test_task_builders.py
@@ -1,16 +1,29 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, Mock, patch
 
 from django.contrib.auth.models import Group, User
 from django.contrib.gis.geos import GEOSGeometry, Polygon
 from django.db.utils import DatabaseError
 from django.test import TestCase
 
-from eventkit_cloud.jobs.models import ExportFormat, Job, Region, DataProviderTask, DataProvider
-from eventkit_cloud.tasks.export_tasks import osm_data_collection_task, mapproxy_export_task, wcs_export_task
-from eventkit_cloud.tasks.task_builders import TaskChainBuilder, create_export_task_record
+from eventkit_cloud.jobs.models import (
+    DataProvider,
+    DataProviderTask,
+    ExportFormat,
+    Job,
+    Region,
+)
+from eventkit_cloud.tasks.export_tasks import (
+    mapproxy_export_task,
+    osm_data_collection_task,
+    wcs_export_task,
+)
+from eventkit_cloud.tasks.task_builders import (
+    TaskChainBuilder,
+    create_export_task_record,
+)
 from eventkit_cloud.tasks.task_factory import create_run
 
 logger = logging.getLogger(__name__)
@@ -115,7 +128,6 @@ class TestTaskBuilder(TestCase):
 
     @patch("eventkit_cloud.tasks.task_builders.ExportTaskRecord")
     def test_create_export_task_record(self, mock_export_task):
-        from eventkit_cloud.tasks.enumerations import TaskState
 
         task_name = "TaskName"
         export_provider_task_name = "ExportProviderTaskName"
@@ -129,11 +141,8 @@ class TestTaskBuilder(TestCase):
 
         self.assertEqual(task_result, expected_result)
         mock_export_task.objects.get_or_create.assert_called_with(
-            export_provider_task=export_provider_task_name,
-            status=TaskState.PENDING.value,
-            name=task_name,
-            worker=worker,
-            display=False,
+            export_provider_task="ExportProviderTaskName",
+            defaults={"status": "PENDING", "name": "TaskName", "worker": "Worker", "display": False},
         )
 
         expected_result = MagicMock(display=True)
@@ -144,11 +153,8 @@ class TestTaskBuilder(TestCase):
         )
         self.assertEqual(task_result, expected_result)
         mock_export_task.objects.get_or_create.assert_called_with(
-            export_provider_task=export_provider_task_name,
-            status=TaskState.PENDING.value,
-            name=task_name,
-            worker=worker,
-            display=True,
+            export_provider_task="ExportProviderTaskName",
+            defaults={"status": "PENDING", "name": "TaskName", "worker": "Worker", "display": True},
         )
 
         mock_export_task.objects.get_or_create.side_effect = DatabaseError("SomeError")

--- a/eventkit_cloud/utils/generic.py
+++ b/eventkit_cloud/utils/generic.py
@@ -1,8 +1,14 @@
-from functools import wraps
+import copy
+import inspect
+import itertools
 import logging
 import time
+from functools import wraps
 
 from django.conf import settings
+from django.core.cache import cache
+
+from eventkit_cloud.feature_selection.feature_selection import slugify
 
 logger = logging.getLogger()
 
@@ -50,3 +56,29 @@ def retry(f):
         raise exc
 
     return wrapper
+
+
+DEFAULT_TIMEOUT = 60 * 60 * 24  # one day
+
+
+def cacheable(timeout: int = DEFAULT_TIMEOUT, key_fields=[]):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # handle if first arg is self.
+            arg = type(args[0]).__name__ if inspect.isclass(args[0]) else str(slugify(args[0]))
+            arg_string = ".".join([str(slugify(arg)) for arg in args[:1]])
+            keys = (
+                copy.deepcopy(kwargs)
+                if not key_fields
+                else {key_field: kwargs.get(key_field) for key_field in key_fields}
+            )
+            kwarg_string = ".".join([str(slugify(kwarg)) for kwarg in itertools.chain.from_iterable(keys.items())])
+            cache_key = f"{func.__name__}.{arg}.{arg_string}.{kwarg_string}"[:249]
+            logger.debug("Getting or setting the cache_key %s", cache_key)
+            return_value = cache.get_or_set(cache_key, lambda: func(*args, **kwargs), timeout=timeout)
+            return return_value
+
+        return wrapper
+
+    return decorator

--- a/eventkit_cloud/utils/services/arcgis.py
+++ b/eventkit_cloud/utils/services/arcgis.py
@@ -1,9 +1,14 @@
+import copy
 from logging import getLogger
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Union
 
+import requests
 from django.contrib.gis.geos import Polygon
 
+from eventkit_cloud.feature_selection.feature_selection import slugify
+from eventkit_cloud.utils.generic import cacheable
 from eventkit_cloud.utils.services.base import GisClient
+from eventkit_cloud.utils.services.types import LayersDescription
 
 logger = getLogger(__name__)
 
@@ -17,18 +22,75 @@ class ArcGIS(GisClient):
         :param aoi_geojson: (Optional) AOI to check for layer intersection
         """
         super(ArcGIS, self).__init__(*args, **kwargs)
-
+        self.service_description = None
         self.layer = self.layer.lower() if self.layer else None
 
     def download_geometry(self) -> Optional[Polygon]:
         response = self.session.get(self.service_url, params={"f": "json"})
         response.raise_for_status()
         data = response.json()
-        extent = data.get("initialExtent") or data.get("fullExtent") or data.get("extent")
+        extent = data.get("fullExtent") or data.get("extent") or data.get("initialExtent")
         return get_polygon_from_arcgis_extent(extent)
 
     def find_layers(self, root):
         raise NotImplementedError("Method is specific to service type")
+
+    @cacheable(key_fields=["layer_id"])
+    def get_capabilities(
+        self, layer_id: Optional[Union[str, int]] = None, layers: dict = None, get_sublayers: bool = True
+    ):
+        # If there is not a layer_id provided then the service url is used
+        # that implies that it is the general service description for the instantiated client.
+        if not layer_id and self.service_description:
+            return self.service_description
+        url = f"{self.service_url.removesuffix('/')}/{layer_id}" if layer_id is not None else self.service_url
+        try:
+            logger.info("Getting service description from %s", url)
+            result = self.session.get(url, params={"f": "json"})
+            result.raise_for_status()
+            service_description = result.json()
+            layers = copy.deepcopy(layers) or {}
+            sub_layers = {}
+            for layer in service_description.get("layers", {}):
+                # The top level service description will have the definition for all of the layers
+                # We can make a request for all of those layers now, then when we get the sublayers we can just pass
+                # in the "prefetched" version.
+                logger.debug("Getting service layer: %s", layer.get("id"))
+                new_layer = self.get_capabilities(layer_id=layer.get("id"), layers=layers, get_sublayers=False)
+                logger.debug("setting layer id: %s with new layer %s", layer.get("id"), new_layer)
+                layers[layer["id"]] = new_layer
+            # from celery.contrib import rdb;
+            # rdb.set_trace()
+            if get_sublayers:
+                for sub_layer in service_description.get("subLayers", {}):
+                    logger.debug("Getting layer %s sublayer: %s", layer_id, sub_layer.get("id"))
+                    new_sub_layer = layers.get(sub_layer["id"]) or [
+                        self.get_capabilities(layer_id=sub_layer.get("id"), layers=layers)
+                    ]
+                    logger.debug("setting sublayer id: %s with new layer %s", sub_layer.get("id"), new_layer)
+                    sub_layers[sub_layer["id"]] = new_sub_layer
+            service_description["subLayers"] = list(sub_layers.values()) or list(layers.values())
+            service_description["url"] = url  # Not in spec but helpful for calling the layer for data.
+            if not layer_id:
+                self.service_description = service_description
+            return service_description
+        except requests.exceptions.HTTPError:
+            if url:
+                logger.error("Could not get service description for %s", url)
+            raise
+
+    def get_layers(self) -> LayersDescription:
+        cap_doc = self.get_capabilities(layer_id=self.layer)
+
+        if cap_doc and self.layer:
+            return {self.layer: {"name": str(self.layer), "url": str(cap_doc["url"])}}
+        if cap_doc.get("layers"):
+            # TODO: This logic is specific for feature layers,
+            #  this will need to change or be subclassed to separate raster/feature services.
+            return {
+                slugify(layer["name"]): layer for layer in (cap_doc.get("subLayers", [])) if "Feature" in layer["type"]
+            }
+        return {self.layer: {"name": str(self.layer), "url": self.service_url}}
 
 
 class _ArcGISSpatialReference(TypedDict):

--- a/eventkit_cloud/utils/services/base.py
+++ b/eventkit_cloud/utils/services/base.py
@@ -3,15 +3,15 @@ import base64
 import copy
 import json
 import logging
-from typing import Dict
-from typing import Optional
+from typing import Dict, Optional
 
 import requests
-from django.contrib.gis.geos import GEOSGeometry, GeometryCollection, Polygon
+from django.contrib.gis.geos import GeometryCollection, GEOSGeometry, Polygon
 from django.core.cache import cache
 
 from eventkit_cloud.core.helpers import get_or_update_session
 from eventkit_cloud.tasks.helpers import normalize_name
+from eventkit_cloud.utils.generic import cacheable
 from eventkit_cloud.utils.services import DEFAULT_CACHE_TIMEOUT
 from eventkit_cloud.utils.services.check_result import CheckResult, get_status_result
 from eventkit_cloud.utils.services.errors import ProviderCheckError
@@ -199,6 +199,13 @@ class GisClient(abc.ABC):
         query_params = copy.deepcopy(query) or self.query
         service_url = url.rstrip("/\\")
         return self.session.get(url=service_url, params=query_params, timeout=self.timeout)
+
+    @cacheable()
+    def get_capabilities(self):
+        return self.get_response(url=self.service_url, query=self.query)
+
+    def get_layers(self):
+        raise NotImplementedError("Method is specific to service type")
 
     def check_intersection(self, geometry: GEOSGeometry):
         """

--- a/eventkit_cloud/utils/services/interface.py
+++ b/eventkit_cloud/utils/services/interface.py
@@ -4,6 +4,8 @@ from typing import Optional
 import requests
 from django.contrib.gis.geos import Polygon
 
+from eventkit_cloud.utils.services.types import LayersDescription
+
 
 class IGisClient(abc.ABC):
     aoi = None
@@ -43,3 +45,11 @@ class IGisClient(abc.ABC):
     @abc.abstractmethod
     def check_response(self, head_only=False) -> requests.Response:
         pass
+
+    @abc.abstractmethod
+    def get_capabilities(self):
+        raise NotImplementedError("Method is specific to service type")
+
+    @abc.abstractmethod
+    def get_layers(self) -> LayersDescription:
+        raise NotImplementedError("Method is specific to service type")


### PR DESCRIPTION
## Description of Improvement

This PR will allow services which use arcgis-feature to automatically parse the service url to get all of the sublayer info if the service type is arcgis-feature. 

## How to test

Create a provider/product using arcgis-feature service url (can also use mapservice if it has feature layers).   Ensure that the type is set as arcgis-feature.

## Quality Assurance 

The following items have been updated:
 - [x] Linters pass.
 - [x] Unittests pass.
 - [] The docs have been updated for any changes to the settings module.
 - [x] New tests have been added to reproduce the functionality of the above description.
 - [x] Comments have been added to declare intent, or because of some wild comprehension statement.
 - [x] UI enhancements have screenshots attached below.
 - [x] Screenshots, code, or descriptions don't include proprietary information. 
 
:smile:
