### PR TITLE
Fix provider list filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ else
 endif
 
 black:
-	docker-compose run --rm eventkit black --config /var/lib/eventkit/config/pyproject.toml --check --diff eventkit_cloud
+	docker-compose run --rm eventkit black --config /var/lib/eventkit/pyproject.toml --check --diff eventkit_cloud
 
 black-format:
 	docker-compose run --rm eventkit black --config /var/lib/eventkit/config/pyproject.toml eventkit_cloud

--- a/conda/convert_requirements_to_conda.py
+++ b/conda/convert_requirements_to_conda.py
@@ -1,5 +1,5 @@
-from os import path
 import re
+from os import path
 
 
 def convert_requirements_to_conda():

--- a/conda/download_packages.py
+++ b/conda/download_packages.py
@@ -1,6 +1,7 @@
-import requests
-import subprocess
 import os
+import subprocess
+
+import requests
 
 
 def download_packages(output_dir='.'):

--- a/conda/output_config_yaml.py
+++ b/conda/output_config_yaml.py
@@ -1,9 +1,9 @@
+import os
 import re
 import subprocess
 import sys
 
 import yaml
-import os
 
 
 def dump_conda_config_yaml(output_dir='.', requirements_file=None):

--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -943,7 +943,7 @@ def filtered_basic_data_provider_serializer(
 ):
 
     if not data_providers:
-        return [{}]
+        return []
 
     if not isinstance(data_providers, (list, QuerySet)):  # type: ignore
         data_providers = [data_providers]

--- a/eventkit_cloud/api/tests/test_serializers.py
+++ b/eventkit_cloud/api/tests/test_serializers.py
@@ -37,7 +37,7 @@ class TestSerializers(TestCase):
         ]
         self.assertEqual(filtered_basic_data_provider_serializer(self.data_provider, many=True), expected_result)
         self.assertEqual(filtered_basic_data_provider_serializer(self.data_provider), expected_result[0])
-        self.assertEqual(filtered_basic_data_provider_serializer([]), [{}])
+        self.assertEqual(filtered_basic_data_provider_serializer([]), [])
         with self.assertRaises(Exception):
             filtered_basic_data_provider_serializer([Mock(), Mock()])
 

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -969,11 +969,7 @@ class DataProviderViewSet(EventkitViewSet):
             providers, filtered_providers = attribute_class_filter(queryset, self.request.user)
             data = serializer(providers, many=True, context={"request": request})
             filtered_data = filtered_serializer(filtered_providers, many=True, context={"request": request})
-            if isinstance(data, list):
-                data += filtered_data
-            else:
-                filtered_data.update(data)
-                data = filtered_data
+            data = data + filtered_data
 
             if cache.add(cache_key, data, timeout=DEFAULT_TIMEOUT):
                 DataProvider.update_cache_key_list(cache_key)

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import getpass
-import os
-import json
 import argparse
+import getpass
+import json
+import os
 import time
 
 from eventkit_cloud.utils.client import EventKitClient

--- a/scripts/ci_utils.py
+++ b/scripts/ci_utils.py
@@ -2,7 +2,8 @@ import json
 import logging
 import os
 import subprocess
-from concurrent.futures import ThreadPoolExecutor, wait, ALL_COMPLETED
+from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
+
 import requests
 import yaml
 

--- a/scripts/debug_celery.py
+++ b/scripts/debug_celery.py
@@ -8,7 +8,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "eventkit_cloud.settings.prod")
 django.setup()
 
 from eventkit_cloud.celery import app
-from eventkit_cloud.tasks.scheduled_tasks import scale_celery_task, scale_by_runs
+from eventkit_cloud.tasks.scheduled_tasks import scale_by_runs, scale_celery_task
 
 if __name__ == '__main__':
     scale_celery_task(30000)

--- a/scripts/get_metrics.py
+++ b/scripts/get_metrics.py
@@ -1,5 +1,6 @@
+from datetime import datetime, timedelta
+
 from eventkit_cloud.tasks.models import ExportRun
-from datetime import timedelta, datetime
 
 
 def meters_to_sq_km(meters):

--- a/scripts/github.py
+++ b/scripts/github.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 import requests
-
 from ci_utils import run_subprocess
 
 

--- a/scripts/spatialite_test.py
+++ b/scripts/spatialite_test.py
@@ -8,9 +8,8 @@
 """
 
 import os
-from string import Template
-
 import sqlite3
+from string import Template
 
 
 def run(*script_args):

--- a/scripts/thematic_test.py
+++ b/scripts/thematic_test.py
@@ -9,9 +9,8 @@
 import logging
 import os
 import shutil
-from string import Template
-
 import sqlite3
+from string import Template
 
 from eventkit_cloud.jobs.models import Job
 

--- a/scripts/update_providers.py
+++ b/scripts/update_providers.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 import os
-import sys
+
 
 def update_providers(file_path, skip_missing=False):
     print(f"Loading provider file {file_path}")
@@ -54,8 +54,8 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "eventkit_cloud.settings.prod")
     import django
     django.setup()
-    from eventkit_cloud.jobs.models import DataProvider, DataProviderType
     from eventkit_cloud.core.models import AttributeClass
+    from eventkit_cloud.jobs.models import DataProvider, DataProviderType
 
     parser = argparse.ArgumentParser(description='Load Fixtures for Data Providers.')
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 
 def read(*rnames):


### PR DESCRIPTION
## Description of Improvement

Updates the data provider api to return an empty list instead of an empty list with an empty object in the default case. This was causing an issue when attempting to filter by provider names during the create datapack process.

## How to test

Steps to reproduce:
1. Go to first step of create datapack.
2. Attempt to search/filter a data provider
3. White screen

After fixes:
All tests should pass
Above case should work

## Quality Assurance 

The following items have been updated:
 - [x] Linters pass.
 - [x] Unittests pass.
 - [x] The docs have been updated for any changes to the settings module.
 - [x] New tests have been added to reproduce the functionality of the above description.
 - [x] Comments have been added to declare intent, or because of some wild comprehension statement.
 - [x] UI enhancements have screenshots attached below.
 - [x] Screenshots, code, or descriptions don't include proprietary information. 
 
## Screenshots

:smile:
