### PR TITLE
fixes aprx non-default ouput issue in toolbox

### DIFF
--- a/eventkit_cloud/utils/arcgis/templates/create_aprx.py
+++ b/eventkit_cloud/utils/arcgis/templates/create_aprx.py
@@ -497,6 +497,8 @@ class CreateAPRX(object):
 
         if all([parameters[0].altered, not parameters[1].altered, load_metadata(str(parameters[0].value))]):
             parameters[1].value = get_aprx_file_name(str(parameters[0].value))
+        if (parameters[1].valueAsText is not None) and (not os.path.splitext(parameters[1].valueAsText)[0] == ".aprx"):
+            parameters[1].value = os.path.splitext(parameters[1].valueAsText)[0] + ".aprx"
         return
 
     def updateMessages(self, parameters):


### PR DESCRIPTION
## Description of Improvement

Fixes aprx non-default output directory issue in the eventkit toolbox

## How to test

Use the create_aprx toolbox and choose a different location for the output of the aprx file. 

## Quality Assurance 

The following items have been updated:
 - [x] Linters pass.
 - [x] Unittests pass.
 - [x] The docs have been updated for any changes to the settings module.
 - [x] New tests have been added to reproduce the functionality of the above description.
 - [x] Comments have been added to declare intent, or because of some wild comprehension statement.
 - [x] UI enhancements have screenshots attached below.
 - [x] Screenshots, code, or descriptions don't include proprietary information. 

:smile:
