### PR TITLE
Fix oauth token crash when not logged in as oauth user

### DIFF
--- a/eventkit_cloud/auth/tests/test_views.py
+++ b/eventkit_cloud/auth/tests/test_views.py
@@ -33,7 +33,6 @@ class TestAuthViews(TestCase):
 
             request = MagicMock(GET={"code": "1234"})
 
-
             group, created = Group.objects.get_or_create(name="TestDefaultExportExtentGroup")
             with patch("eventkit_cloud.jobs.signals.Group") as mock_group:
                 mock_group.objects.get.return_value = group

--- a/eventkit_cloud/auth/views.py
+++ b/eventkit_cloud/auth/views.py
@@ -125,7 +125,8 @@ def logout(request):
 
 
 def has_valid_access_token(request) -> bool:
-    if getattr(settings, "OAUTH_AUTHORIZATION_URL", None):
+    is_oauth = hasattr(request.user, "oauth")
+    if getattr(settings, "OAUTH_AUTHORIZATION_URL", None) and is_oauth:
         if isinstance(request, str):
             access_token = request
         else:


### PR DESCRIPTION
## Description of Improvement

Checking for a valid access token made incorrect assumption user would always be logged in through oauth (if it was enabled/auth_url is set). This PR adds check to make sure request is coming from oauth user, before checking for valid access token.

## How to test

To reproduce error on master:
1. Set OAUTH_AUTHORIZATION_URL locally, and login using basic authentication (non-oauth)
2. attempt to create a datapack

To test fixes:
1. Set OAUTH_AUTHORIZATION_URL locally, and login using basic auth.
2. attempt to create a datapack
3. ensure all tests pass with OAUTH_AUTHORIZATION_URL set.

## Quality Assurance 

The following items have been updated:
 - [ ] Linters pass.
 - [ ] Unittests pass.
 - [ ] The docs have been updated for any changes to the settings module.
 - [ ] New tests have been added to reproduce the functionality of the above description.
 - [ ] Comments have been added to declare intent, or because of some wild comprehension statement.
 - [ ] UI enhancements have screenshots attached below.
 - [ ] Screenshots, code, or descriptions don't include proprietary information. 
 
## Screenshots

<!-- If this includes a UI enhancement include a screenshot -->

:smile:
