### PR TITLE
Allow cancellation of getProviders request

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/actions/providerActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/providerActions.js
@@ -30,7 +30,7 @@ export function getProviders(selectedArea, selectedTopics) {
             data: params,
             onSuccess: (response) => ({ providers: response.data }),
             cancellable: true,
-            getCancelSource: (state) => (state.providers.cancelToken),
+            getCancelSource: (state) => (state.providers.cancelController),
         };
     }
 
@@ -44,7 +44,7 @@ export function getProviders(selectedArea, selectedTopics) {
         method: 'GET',
         onSuccess: (response) => ({ providers: response.data }),
         cancellable: true,
-        getCancelSource: (state) => (state.providers.cancelToken),
+        getCancelSource: (state) => (state.providers.cancelController),
     };
 }
 

--- a/eventkit_cloud/ui/static/ui/app/actions/providerActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/providerActions.js
@@ -29,6 +29,8 @@ export function getProviders(selectedArea, selectedTopics) {
             method: 'POST',
             data: params,
             onSuccess: (response) => ({ providers: response.data }),
+            cancellable: true,
+            getCancelSource: (state) => (state.providers.cancelToken),
         };
     }
 
@@ -41,6 +43,8 @@ export function getProviders(selectedArea, selectedTopics) {
         url: '/api/providers',
         method: 'GET',
         onSuccess: (response) => ({ providers: response.data }),
+        cancellable: true,
+        getCancelSource: (state) => (state.providers.cancelToken),
     };
 }
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -680,11 +680,7 @@ export function ExportInfo(props: Props) {
         } else {
             // or remove the value from the unchecked checkbox from the array
             index = selectedProviders.map(x => x.name).indexOf(e.target.name);
-            for (const provider of providers) {
-                if (provider.name === e.target.name) {
-                    selectedProviders.splice(index, 1);
-                }
-            }
+            selectedProviders.splice(index, 1);
         }
         // update the state with the new array of options
         updateExportInfoCallback({
@@ -1531,7 +1527,7 @@ export function ExportInfo(props: Props) {
                                     itemContent={index => dataProviders[index]}
                                     className="qa-ExportInfo-List"
                                 /> : <span style={{display: 'flex', justifyContent: 'center', width: '100%', height: 50, fontSize: '16px'}}>
-                                    No providers found. Check applied filters and server status.</span>}
+                                    No providers found</span>}
 
                             <div className={classes.stickyRow}>
                                 <div className={classes.stickyRowItems}

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -1523,14 +1523,15 @@ export function ExportInfo(props: Props) {
                                 <div style={{display: 'flex', justifyContent: 'center', width: '100%', height: 500}}>
                                     <CircularProgress disableShrink={true} size={50}/>
                                 </div> :
-                                <Virtuoso
+                                dataProviders.length > 0 ? <Virtuoso
                                     style={{width: '100%', height: 500}}
                                     id="ProviderList"
-                                    totalCount={getCurrentProviders().length}
+                                    totalCount={dataProviders.length}
                                     initialItemCount={10}
                                     itemContent={index => dataProviders[index]}
                                     className="qa-ExportInfo-List"
-                                />}
+                                /> : <span style={{display: 'flex', justifyContent: 'center', width: '100%', height: 50, fontSize: '16px'}}>
+                                    No providers found. Check applied filters and server status.</span>}
 
                             <div className={classes.stickyRow}>
                                 <div className={classes.stickyRowItems}

--- a/eventkit_cloud/ui/static/ui/app/index.tsx
+++ b/eventkit_cloud/ui/static/ui/app/index.tsx
@@ -14,7 +14,7 @@ import PageLoading from './components/common/PageLoading';
 axios.interceptors.response.use(function (response) {
     return response;
 }, function (error) {
-    if (error.response.status === 401 || error.response.status === 403) {
+    if (error?.response?.status === 401 || error?.response?.status === 403) {
         window.location.href = '/login';
     } else {
         return Promise.reject(error);

--- a/eventkit_cloud/ui/static/ui/app/reducers/providerReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/providerReducer.js
@@ -11,17 +11,18 @@ export function getProvidersReducer(state = initialStateProviders, action) {
             return {
                 fetching: true,
                 objects: [],
+                cancelToken: action.cancelSource,
             };
         case types.PROVIDERS_RECEIVED:
             return {
                 fetching: false,
                 objects: action.providers,
+                cancelToken: undefined,
             };
         case types.GETTING_PROVIDERS_ERROR:
             return {
                 ...state,
-                fetching: false,
-                objects: action.providers,
+                fetching: !!state.cancelToken,
             };
         case types.PATCHED_PROVIDER_FAVORITE:
             return {

--- a/eventkit_cloud/ui/static/ui/app/reducers/providerReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/providerReducer.js
@@ -11,18 +11,19 @@ export function getProvidersReducer(state = initialStateProviders, action) {
             return {
                 fetching: true,
                 objects: [],
-                cancelToken: action.cancelSource,
+                cancelController: action.cancelSource,
             };
         case types.PROVIDERS_RECEIVED:
             return {
                 fetching: false,
                 objects: action.providers,
-                cancelToken: undefined,
+                cancelController: undefined,
             };
         case types.GETTING_PROVIDERS_ERROR:
             return {
                 ...state,
-                fetching: !!state.cancelToken,
+                fetching: false,
+                cancelController: undefined,
             };
         case types.PATCHED_PROVIDER_FAVORITE:
             return {

--- a/eventkit_cloud/ui/static/ui/app/store/middlewares.ts
+++ b/eventkit_cloud/ui/static/ui/app/store/middlewares.ts
@@ -87,11 +87,10 @@ export const simpleApiCall = ({ dispatch, getState }) => next => (action) => {
             dispatch({ ...payload, type: successType, ...onSuccess(response) });
         }
     }).catch(error => {
-        if (axios.isAxiosError(error)) {
-            dispatch({ ...payload, type: failureType, ...onError(error) });
-        } else {
+        if (axios.isCancel(error)) {
             console.warn(error.message);
-            //dispatch({ ...payload, type: failureType, ...onError(error) });
+        } else {
+            dispatch({ ...payload, type: failureType, ...onError(error) });
         }
     });
 };

--- a/eventkit_cloud/ui/static/ui/app/tests/reducers/providerReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/reducers/providerReducer.spec.js
@@ -37,7 +37,7 @@ describe('getProvidersReducer', () => {
             },
             { type: types.GETTING_PROVIDERS_ERROR, providers: [] },
         )).toEqual({
-            fetching: false, objects: [],
+            fetching: false, objects: ['one', 'two', 'three'],
         });
     });
 

--- a/eventkit_cloud/ui/static/ui/app/tests/reducers/providerReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/reducers/providerReducer.spec.js
@@ -35,7 +35,7 @@ describe('getProvidersReducer', () => {
                 fetching: true,
                 objects: ['one', 'two', 'three'],
             },
-            { type: types.GETTING_PROVIDERS_ERROR, providers: [] },
+            { type: types.GETTING_PROVIDERS_ERROR },
         )).toEqual({
             fetching: false, objects: ['one', 'two', 'three'],
         });

--- a/eventkit_cloud/ui/static/ui/app/tests/store/middleware.spec.ts
+++ b/eventkit_cloud/ui/static/ui/app/tests/store/middleware.spec.ts
@@ -83,16 +83,16 @@ describe('middleware', () => {
         });
 
         it('should cancel on-going request if source is returned and not auto', () => {
-            const cancel = sinon.stub();
+            const abort = sinon.stub();
             const action = {
                 types: ['one', 'two', 'three'],
                 requiresAuth: false,
                 shouldCallApi: () => true,
-                getCancelSource: () => ({ cancel }),
+                getCancelSource: () => ({ abort }),
                 auto: false,
             };
             middleware.simpleApiCall({dispatch, getState})(next)(action);
-            expect(action.getCancelSource().cancel.calledOnce).toBe(true);
+            expect(action.getCancelSource().abort.calledOnce).toBe(true);
         });
 
         it('should create a cancelSource and dispatch it with the first type', () => {


### PR DESCRIPTION
# Description of Improvement

Sets up getProviders action/request to be cancellable. Cancels any existing providers request if another is made before server responds success/fail to the initial request. Also fixes some errors around handling cancelled requested in axios interceptor.

## How to test

Introduce a delay into providers request on server (easiest way is time.sleep() in data provider view)
Navigate between dashboard and create workflow within delay window.
Verify initial request appearing as 'cancelled' in developer tools

## Quality Assurance

The following items have been updated:

- [x] Linters pass.
- [x] Unittests pass.
- [x] The docs have been updated for any changes to the settings module.
- [x] New tests have been added to reproduce the functionality of the above description.
- [x] Comments have been added to declare intent, or because of some wild comprehension statement.
- [x] UI enhancements have screenshots attached below.
- [x] Screenshots, code, or descriptions don't include proprietary information.

## Screenshots

:smile:
