### PR TITLE
fixes issue with licenses showing up multiple times

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,7 @@ cache:
     - alias front_diff="git diff --quiet --exit-code remotes/origin/$CI_DEFAULT_BRANCH -- eventkit_cloud/ui/static/ui/**/* config/**/* package.json .gitlab-ci.yml"
 
 .front:
-  image: "${CI_REGISTRY_PATH}eventkit/eventkit-webpack:${VERSION}-0"
+  image: "${CI_REGISTRY_PATH}eventkit/eventkit-webpack:${VERSION}-1"
   before_script:
     - !reference [ .front_rules, before_script ]
     - front_diff || cp -rf config/ui/. ./
@@ -64,7 +64,7 @@ cache:
   extends: .back_rules
   cache: []
   image:
-    name: "${CI_REGISTRY_PATH}eventkit/eventkit-base:${VERSION}-1"
+    name: "${CI_REGISTRY_PATH}eventkit/eventkit-base:${VERSION}-2"
     entrypoint: [ "" ]
   variables:
     CURL_CA_BUNDLE: "./conda/cacert.pem"

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -837,7 +837,7 @@ class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
             .filter(Q(user=self.request.user) | Q(user=None))
         )
         providers, filtered_provider = attribute_class_filter(provider_queryset, self.request.user)
-        return License.objects.filter(data_providers__in=providers)
+        return License.objects.filter(data_providers__in=providers).distinct()
 
     @action(methods=["get"], detail=True, renderer_classes=[PlainTextRenderer])
     def download(self, request, slug=None, *args, **kwargs):

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -428,19 +428,21 @@ def osm_data_collection_pipeline(
     )
 
     task_process = TaskProcess()
-    convert(
-        boundary=selection,
-        input_files=[in_dataset],
-        output_file=gpkg_filepath,
-        layers=["land_polygons"],
-        driver="gpkg",
-        is_raster=False,
-        access_mode="append",
-        projection=projection,
-        layer_creation_options=["GEOMETRY_NAME=geom"],  # Needed for current styles (see note below).
-        executor=task_process.start_process,
-    )
-
+    try:
+        convert(
+            boundary=selection,
+            input_files=[in_dataset],
+            output_file=gpkg_filepath,
+            layers=["land_polygons"],
+            driver="gpkg",
+            is_raster=False,
+            access_mode="append",
+            projection=projection,
+            layer_creation_options=["GEOMETRY_NAME=geom"],  # Needed for current styles (see note below).
+            executor=task_process.start_process,
+        )
+    except Exception:
+        logger.error("Could not load land data.")
     # TODO:  The arcgis templates as of version 1.9.0 rely on both OGC_FID and FID field existing.
     #  Just add the fid field if missing for now.
     with sqlite3.connect(gpkg_filepath) as conn:


### PR DESCRIPTION
# Description of Improvement

Fixes duplicate licenses.

## How to test

Create two or three licenses and assign them to multiple providers.  They should only appear once in the licenses api and on the account page.

## Quality Assurance

The following items have been updated:

- [x] Linters pass.
- [x] Unittests pass.
- [x] The docs have been updated for any changes to the settings module.
- [x] New tests have been added to reproduce the functionality of the above description.
- [x] Comments have been added to declare intent, or because of some wild comprehension statement.
- [x] UI enhancements have screenshots attached below.
- [x] Screenshots, code, or descriptions don't include proprietary information.

## Screenshots

<!-- If this includes a UI enhancement include a screenshot -->

:smile:
