### PR TITLE
Multiple osm requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ ifeq ($(detected_OS),Linux)
 	sudo chmod -R g+rw .
 endif
 
+bf: initial black-format initial
+
+if: initial isort-format initial
+
 # Only run this command if you want to completely rebuild your conda dependencies.
 conda-install:
 	cd conda && docker-compose build --no-cache

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -98,7 +98,10 @@ EMAIL_HOST_PASSWORD='email-password'
 
 To use your own instance of an Overpass API add:
 
-- `OVERPASS_API_URL='my-overpass-site.com/api/interpreter'`
+`OVERPASS_API_URL='my-overpass-site.com/api/interpreter'`
+
+Max size of overpass request in sqkm.
+`OSM_MAX_REQUEST_SIZE=40000`
 
 If an Overpass API endpoint requires a client certificate, you can provide it as an environment variable in PEM format:
 

--- a/eventkit_cloud/settings/prod.py
+++ b/eventkit_cloud/settings/prod.py
@@ -72,7 +72,9 @@ EXPORT_MEDIA_ROOT = os.getenv("EXPORT_MEDIA_ROOT", EXPORT_STAGING_ROOT)
 MEDIA_ROOT = os.path.abspath(EXPORT_MEDIA_ROOT)
 
 # url to overpass api endpoint
-OVERPASS_API_URL = os.getenv("OVERPASS_API_URL", "http://overpass-api.de/api/interpreter")  # Deprecated
+OVERPASS_API_URL = os.getenv("OVERPASS_API_URL", "http://overpass-api.de/api/interpreter")
+OSM_MAX_REQUEST_SIZE = os.getenv("OSM_MAX_REQUEST_SIZE", 40000)
+
 GEOCODING_API_URL = os.getenv("GEOCODING_API_URL", "http://api.geonames.org/searchJSON")
 GEOCODING_API_TYPE = os.getenv("GEOCODING_API_TYPE", "GEONAMES")
 REVERSE_GEOCODING_API_URL = os.getenv("REVERSE_GEOCODING_API_URL", None)

--- a/eventkit_cloud/tasks/exceptions.py
+++ b/eventkit_cloud/tasks/exceptions.py
@@ -1,7 +1,7 @@
 class CancelException(Exception):
     """Used to indicate when a user calls for cancellation."""
 
-    def __init__(self, message=None, task_name=None, user_name="system", filename=None, *args, **kwargs):
+    def __init__(self, message: str = None, task_name=None, user_name="system", filename=None, *args, **kwargs):
         """
 
         :param message: A non-default message
@@ -17,7 +17,7 @@ class CancelException(Exception):
 class DeleteException(Exception):
     """Used to indicate when a user calls for cancellation."""
 
-    def __init__(self, message=None, task_name=None, user_name=None, filename=None, *args, **kwargs):
+    def __init__(self, message: str = None, task_name=None, user_name=None, filename=None, *args, **kwargs):
         """
 
         :param message: A non-default message
@@ -33,7 +33,7 @@ class DeleteException(Exception):
 class FailedException(Exception):
     """Used to indicate when a task has failed too many times."""
 
-    def __init__(self, message=None, task_name=None, *args, **kwargs):
+    def __init__(self, message: str = None, task_name=None, *args, **kwargs):
         """
         :param message: A non-default message
         :param task_uid: Task_uid to look up user and task name.
@@ -42,3 +42,37 @@ class FailedException(Exception):
         if not self.message:
             self.message = f"{task_name} has failed too many times and will not be retried."
         super(FailedException, self).__init__(self.message, *args, **kwargs)
+
+
+class AreaLimitExceededError(Exception):
+    """Used to indicate an area is too large."""
+
+    def __init__(self, message: str = None, bbox: list[float] = None, *args, **kwargs):
+        """
+        :param message: A non-default message
+        :param task_uid: Task_uid to look up user and task name.
+        """
+        self.message = message  # without this you may get DeprecationWarning
+        self.bbox = bbox
+        if not self.message:
+            self.message = f"The requested boundary {self.bbox} was too large."
+
+        super(AreaLimitExceededError, self).__init__(self.message, *args, **kwargs)
+
+
+class TooManyRequestsError(Exception):
+    """Used to indicate an area is too large."""
+
+    def __init__(self, message: str = None, service_name=None, *args, **kwargs):
+        """
+        :param message: A non-default message
+        :param task_uid: Task_uid to look up user and task name.
+        """
+        self.message = message  # without this you may get DeprecationWarning
+        if not self.message:
+            if service_name:
+                self.message = f"Too many requests were made to the {service_name} service."
+            else:
+                self.message = "Too many requests were made to the service."
+
+        super(TooManyRequestsError, self).__init__(self.message, *args, **kwargs)

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -1262,14 +1262,14 @@ def find_in_zip(
 
 
 def extract_metadata_files(
-    zip_filepath: str, destination: str, extensions: list = [".md", ".txt", ".doc", ".docx", ".csv", ".xls", ".xlsx"]
+    zip_filepath: str, destination: str, extensions: list = None
 ):
     """
     Function extract metadata files from archives.
     The function will look for any files that match the extensions that were provided,
     and will extract those files into a metadata directory.
     """
-
+    metadata_extensions = extensions or [".md", ".txt", ".doc", ".docx", ".csv", ".xls", ".xlsx"]
     zip_file = ZipFile(zip_filepath)
     files_in_zip = zip_file.namelist()
 
@@ -1279,7 +1279,7 @@ def extract_metadata_files(
     for filepath in files_in_zip:
         file_path = Path(filepath)
 
-        if file_path.suffix in extensions:
+        if file_path.suffix in metadata_extensions:
             zip_file.extract(filepath, path=metadata_dir)
 
     return str(metadata_dir)
@@ -1462,3 +1462,14 @@ def get_file_paths(directory):
             for f in filenames:
                 paths[os.path.abspath(os.path.join(dirpath, f))] = os.path.join(dirpath, f)
     return paths
+
+
+def split_bbox(bbox: list[float]) -> list[list[float]]:
+    bboxes: list[list[float]] = []
+    mid_x = ((bbox[2] - bbox[0]) / 2) + bbox[0]
+    mid_y = ((bbox[3] - bbox[1]) / 2) + bbox[1]
+    bboxes.append([bbox[0], bbox[1], mid_x, mid_y])
+    bboxes.append([bbox[0], mid_y, mid_x, bbox[3]])
+    bboxes.append([mid_x, mid_y, bbox[2], bbox[3]])
+    bboxes.append([mid_x, bbox[1], bbox[2], mid_y])
+    return bboxes

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import sys
 import uuid
-from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch
+from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch, call
 
 import celery
 from billiard.einfo import ExceptionInfo
@@ -575,7 +575,26 @@ class TestExportTasks(ExportTaskBase):
             config=example_config,
         )
         mock_connect.assert_called_once()
-        mock_overpass.Overpass.assert_called_once()
+        mock_overpass.Overpass.assert_has_calls([call(bbox=[0.0, -1, 1, 0.0], stage_dir='/stage', slug=None, url=None,
+                                                      job_name='no_job_name_specified', task_uid='1234',
+                                                      raw_data_filename='no_job_name_specified_1_query.osm',
+                                                      config={'overpass_query': 'some_query; out;'}),
+                                                 call().run_query(user_details=None, subtask_percentage=65, eta=None),
+                                                 call(bbox=[-1, 0.0, 0.0, 1], stage_dir='/stage', slug=None, url=None,
+                                                      job_name='no_job_name_specified', task_uid='1234',
+                                                      raw_data_filename='no_job_name_specified_2_query.osm',
+                                                      config={'overpass_query': 'some_query; out;'}),
+                                                 call().run_query(user_details=None, subtask_percentage=65, eta=None),
+                                                 call(bbox=[-1, -1, 0.0, 0.0], stage_dir='/stage', slug=None, url=None,
+                                                      job_name='no_job_name_specified', task_uid='1234',
+                                                      raw_data_filename='no_job_name_specified_3_query.osm',
+                                                      config={'overpass_query': 'some_query; out;'}),
+                                                 call().run_query(user_details=None, subtask_percentage=65, eta=None),
+                                                 call(bbox=[-1, -1, 0.0, 0.0], stage_dir='/stage', slug=None, url=None,
+                                                      job_name='no_job_name_specified', task_uid='1234',
+                                                      raw_data_filename='no_job_name_specified_4_query.osm',
+                                                      config={'overpass_query': 'some_query; out;'}),
+                                                 call().run_query(user_details=None, subtask_percentage=65, eta=None)])
         mock_pbf.OSMToPBF.assert_called_once()
         mock_feature_selection.example.assert_called_once()
         mock_cancel_provider_task.assert_not_called()

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -28,6 +28,7 @@ from eventkit_cloud.tasks.helpers import (
     get_osm_last_update,
     get_style_files,
     progressive_kill,
+    split_bbox,
     update_progress,
 )
 
@@ -428,3 +429,24 @@ class TestHelpers(TestCase):
             zip_filepath=zip_filepath, stage_dir="example/dir", archive_extension="zip", matched_files=[], extract=False
         )
         self.assertEqual(found_files, [f"/vsizip/{zip_filepath}/inner/inner_inner/inner_inner_inner/test_geojson.json"])
+
+    def test_split_bbox(self):
+        bbox = [-1, -1, 1, 1]
+        expected_result = [[-1, -1, 0, 0], [-1, 0, 0, 1], [0, 0, 1, 1], [0, -1, 1, 0]]
+        self.assertCountEqual(expected_result, split_bbox(bbox))
+
+        bbox = [-2, -2, 0, 0]
+        expected_result = [[-2, -2, -1.0, -1.0], [-2, -1.0, -1.0, 0], [-1.0, -1.0, 0, 0], [-1.0, -2, 0, -1.0]]
+        self.assertCountEqual(expected_result, split_bbox(bbox))
+
+        bbox = [0, -2, 2, 0]
+        expected_result = [[0, -2, 1.0, -1.0], [0, -1.0, 1.0, 0], [1.0, -1.0, 2, 0], [1.0, -2, 2, -1.0]]
+        self.assertCountEqual(expected_result, split_bbox(bbox))
+
+        bbox = [0, 0, 2, 2]
+        expected_result = [[0, 0, 1.0, 1.0], [0, 1.0, 1.0, 2], [1.0, 1.0, 2, 2], [1.0, 0, 2, 1.0]]
+        self.assertCountEqual(expected_result, split_bbox(bbox))
+
+        bbox = [-2, 0, 0, 2]
+        expected_result = [[-2, 0, -1.0, 1.0], [-2, 1.0, -1.0, 2], [-1.0, 1.0, 0, 2], [-1.0, 0, 0, 1.0]]
+        self.assertCountEqual(expected_result, split_bbox(bbox))

--- a/eventkit_cloud/utils/generic.py
+++ b/eventkit_cloud/utils/generic.py
@@ -23,8 +23,8 @@ TIME_DELAY_BASE = 2  # Used for exponential delays (i.e. 5^y) at 6 would be abou
 def retry(f):
     @wraps(f)
     def wrapper(*args, **kwds):
-
-        attempts = MAX_DB_CONNECTION_RETRIES
+        allowed_exceptions = kwds.pop("allowed_exceptions", None)  # TODO use a library that handles this stuff better.
+        attempts = kwds.pop("max_repeat", None) or MAX_DB_CONNECTION_RETRIES
         exc = None
         while attempts:
             try:
@@ -34,6 +34,8 @@ def retry(f):
                     raise Exception("The process failed to return any data, please contact an administrator.")
                 return return_value
             except Exception as e:
+                if allowed_exceptions and e in allowed_exceptions:
+                    raise e
                 logger.error("The function {0} threw an error.".format(getattr(f, "__name__")))
                 logger.error(str(e))
                 exc = e

--- a/eventkit_cloud/utils/pbf.py
+++ b/eventkit_cloud/utils/pbf.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 from string import Template
+from typing import Optional
 
 from eventkit_cloud.tasks.task_process import TaskProcess
 
@@ -17,22 +18,25 @@ class OSMToPBF(object):
     Convert OSM to PBF.
     """
 
-    def __init__(self, osm=None, pbffile=None, debug=False, task_uid=None):
+    def __init__(
+        self, osm_files: Optional[list[str]] = None, pbffile: str = None, debug: bool = False, task_uid: str = None
+    ):
         """
         Initialize the OSMToPBF utility.
 
         Args:
-            osm: the raw osm file to convert
+            osm_files: the raw osm file to convert
             pbffile: the location of the pbf output file
         """
-        self.osm = osm
-        if not os.path.exists(self.osm):
+
+        if not osm_files or any(not os.path.exists(osm) for osm in osm_files):
             raise IOError("Cannot find raw OSM data for this task.")
         self.pbffile = pbffile
         if not self.pbffile:
             # create pbf path from osm path.
-            root = self.osm.split(".")[0]
+            root = osm_files[0].split(".")[0]
             self.pbffile = root + ".pbf"
+        self.osm: str = " ".join(osm_files)
         self.debug = debug
         self.cmd = Template("osmconvert $osm --out-pbf >$pbf")
         self.task_uid = task_uid
@@ -80,5 +84,5 @@ if __name__ == "__main__":
     debug = False
     if config.get("debug"):
         debug = True
-    o2p = OSMToPBF(osm=osm, pbffile=pbf, debug=debug)
+    o2p = OSMToPBF(osm_files=[osm], pbffile=pbf, debug=debug)
     o2p.convert()

--- a/eventkit_cloud/utils/tests/test_pbf.py
+++ b/eventkit_cloud/utils/tests/test_pbf.py
@@ -24,7 +24,7 @@ class TestOSMToPBF(TransactionTestCase):
         convert_cmd = "osmconvert {0} --out-pbf >{1}".format(osm, pbffile)
         exists.return_value = True
         self.task_process.return_value = Mock(exitcode=0)
-        o2p = OSMToPBF(osm=osm, pbffile=pbffile, task_uid=self.task_uid)
+        o2p = OSMToPBF(osm_files=[osm], pbffile=pbffile, task_uid=self.task_uid)
         out = o2p.convert()
         self.task_process.assert_called_once_with(task_uid=self.task_uid)
         exists.assert_called_once_with(osm)


### PR DESCRIPTION
# Description of Improvement

Allows larger areas for OSM by requests smaller requests or repeating failed requests with smaller areas, and then joining the results on the server. 

## How to test

Set OSM_MAX_REQUEST_SIZE to something small (e.g. 5) and then request an area of about 10 km within the app.  Several requests should appear in the logs and the entire area should be downloaded. 

## Quality Assurance

The following items have been updated:

- [x] Linters pass.
- [x] Unittests pass.
- [x] The docs have been updated for any changes to the settings module.
- [x] New tests have been added to reproduce the functionality of the above description.
- [x] Comments have been added to declare intent, or because of some wild comprehension statement.
- [x] UI enhancements have screenshots attached below.
- [x] Screenshots, code, or descriptions don't include proprietary information.

## Screenshots

An example of Puerto Rico in a single datapack. 
![image](https://user-images.githubusercontent.com/6437951/192261996-4367f965-6094-4e8d-a904-3d3fc69003a5.png)

:smile:
