### PR TITLE
PCF Scaling will send tasks to app in wrong space

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -9,7 +9,7 @@ import socket
 import sqlite3
 import time
 import traceback
-from concurrent.futures import ThreadPoolExecutor, wait, Future
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import List, Type, Union, cast
 from urllib.parse import urlencode

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import sys
 import uuid
-from unittest.mock import ANY, MagicMock, Mock, PropertyMock, patch, call
+from unittest.mock import ANY, MagicMock, Mock, PropertyMock, call, patch
 
 import celery
 from billiard.einfo import ExceptionInfo

--- a/eventkit_cloud/utils/auth_requests.py
+++ b/eventkit_cloud/utils/auth_requests.py
@@ -11,9 +11,8 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 
 from django.conf import settings
-from requests_pkcs12 import create_pyopenssl_sslcontext
-
 from mapproxy.client import http as mapproxy_http
+from requests_pkcs12 import create_pyopenssl_sslcontext
 
 logger = logging.getLogger(__name__)
 

--- a/eventkit_cloud/utils/image_snapshot.py
+++ b/eventkit_cloud/utils/image_snapshot.py
@@ -5,12 +5,12 @@ from typing import Union
 from urllib.parse import urlparse
 
 from django.conf import settings
+from mapproxy.grid import tile_grid
 from PIL import Image
 from requests import Response
 from webtest.response import TestResponse
 
 from eventkit_cloud.utils.mapproxy import create_mapproxy_app, get_resolution_for_extent
-from mapproxy.grid import tile_grid
 
 logger = logging.getLogger(__name__)
 

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -8,15 +8,19 @@ from multiprocessing import Process
 from multiprocessing.dummy import DummyProcess
 from typing import Any, Dict, Tuple, TypedDict, Union, cast
 
+import mapproxy
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import GEOSGeometry
 from django.core.cache import cache
 from django.db import connections
 from gdal_utils import convert, convert_bbox
+from mapproxy.config.config import load_config, load_default_config
+from mapproxy.config.loader import ConfigurationError, ProxyConfiguration, validate_references
+from mapproxy.grid import tile_grid
+from mapproxy.wsgiapp import MapProxyApp
 from webtest import TestApp
 
-import mapproxy
 from eventkit_cloud.core.helpers import get_cached_model
 from eventkit_cloud.jobs.helpers import get_valid_regional_justification
 from eventkit_cloud.tasks import get_cache_value
@@ -31,10 +35,6 @@ from eventkit_cloud.utils.geopackage import (
     set_gpkg_contents_bounds,
 )
 from eventkit_cloud.utils.stats.eta_estimator import ETA
-from mapproxy.config.config import load_config, load_default_config
-from mapproxy.config.loader import ConfigurationError, ProxyConfiguration, validate_references
-from mapproxy.grid import tile_grid
-from mapproxy.wsgiapp import MapProxyApp
 
 # Mapproxy uses processes by default, but we can run child processes in demonized process, so we use
 # a dummy process which relies on threads.  This fixes a bunch of deadlock issues which happen when using billiard.

--- a/eventkit_cloud/utils/scaling/pcf.py
+++ b/eventkit_cloud/utils/scaling/pcf.py
@@ -90,7 +90,7 @@ class Pcf(ScaleClient):
     def get_entity_guid(self, name: str, url: str, data: dict) -> tuple[str, str]:
         response = self.session.get(
             url,
-            json=data,
+            params=data,
             headers={
                 "Authorization": f"bearer {self.token}",
                 "Content-Type": "application/json",

--- a/eventkit_cloud/utils/stats/aoi_estimators.py
+++ b/eventkit_cloud/utils/stats/aoi_estimators.py
@@ -4,12 +4,12 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 
 from django.core.exceptions import ObjectDoesNotExist
+from mapproxy import grid as mapproxy_grid
+from mapproxy import srs as mapproxy_srs
 
 import eventkit_cloud.utils.stats.generator as ek_stats
 from eventkit_cloud.jobs.models import DataProvider
 from eventkit_cloud.utils.stats.geomutils import get_area_bbox
-from mapproxy import grid as mapproxy_grid
-from mapproxy import srs as mapproxy_srs
 
 logger = logging.getLogger(__name__)
 

--- a/eventkit_cloud/utils/stats/generator.py
+++ b/eventkit_cloud/utils/stats/generator.py
@@ -14,14 +14,14 @@ from django import db
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.query import QuerySet
+from mapproxy import grid as mapproxy_grid
+from mapproxy import srs as mapproxy_srs
 
 from eventkit_cloud.jobs.models import DataProvider
 from eventkit_cloud.tasks.enumerations import TaskState
 from eventkit_cloud.tasks.models import DataProviderTaskRecord, ExportRun, ExportTaskRecord
 from eventkit_cloud.utils.client import parse_duration
 from eventkit_cloud.utils.stats.geomutils import get_area_bbox, get_bbox_intersect, get_geometry_description
-from mapproxy import grid as mapproxy_grid
-from mapproxy import srs as mapproxy_srs
 
 logger = logging.getLogger(__name__)
 _dbg_geom_cache_misses = 0

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -7,9 +7,9 @@ from unittest.mock import ANY, MagicMock, mock_open, patch
 
 import requests
 from django.test import TransactionTestCase
+from mapproxy.client.http import VerifiedHTTPSConnection, _URLOpenerCache
 
 from eventkit_cloud.utils import auth_requests
-from mapproxy.client.http import VerifiedHTTPSConnection, _URLOpenerCache
 
 logger = logging.getLogger(__name__)
 

--- a/eventkit_cloud/utils/tests/test_mapproxy.py
+++ b/eventkit_cloud/utils/tests/test_mapproxy.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.test import TransactionTestCase
+from mapproxy.config.config import load_default_config
 
 from eventkit_cloud.jobs.models import DataProvider
 from eventkit_cloud.tasks.enumerations import TaskState
@@ -24,7 +25,6 @@ from eventkit_cloud.utils.mapproxy import (
     get_width,
     mapproxy_config_keys_index,
 )
-from mapproxy.config.config import load_default_config
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description of Improvement

It appears the GET request for PCF was using the wrong format.
Actual change is `pcf.py`; the other changes in this PR are from `black` formatting

## How to test

Check the PCF servers with API calls

## Quality Assurance

The following items have been updated:

- [X] Linters pass.
- [X] Unittests pass.
- [X] The docs have been updated for any changes to the settings module.
- [X] New tests have been added to reproduce the functionality of the above description.
- [X] Comments have been added to declare intent, or because of some wild comprehension statement.
- [X] UI enhancements have screenshots attached below.
- [X] Screenshots, code, or descriptions don't include proprietary information.