### PR TITLE
Fixing strange start and finish times in exports

### DIFF
--- a/eventkit_cloud/core/models.py
+++ b/eventkit_cloud/core/models.py
@@ -83,9 +83,11 @@ class TimeTrackingModelMixin(models.Model):
 
         if hasattr(self, "status"):
             if self.status and TaskState[self.status] == TaskState.RUNNING:
-                self.started_at = timezone.now()
+                if not self.started_at:
+                    self.started_at = timezone.now()
             if self.status and TaskState[self.status] in TaskState.get_finished_states():
-                self.finished_at = timezone.now()
+                if not self.finished_at:
+                    self.finished_at = timezone.now()
         super(TimeTrackingModelMixin, self).save(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
Adding checks to start and finish times. This is to prevent them from being updated more than once.

# Description of Improvement

Adding None checks for `started_at` and `finished_at` times to prevent them from accidently being updated more than once as the application runs

## How to test

Verify that `test_check_times` within `eventkit_cloud.tasks.tests.test_models` passes.

## Quality Assurance

The following items have been updated:

- [X] Linters pass.
- [X] Unittests pass.
- [X] The docs have been updated for any changes to the settings module.
- [X] New tests have been added to reproduce the functionality of the above description.
- [X] Comments have been added to declare intent, or because of some wild comprehension statement.
- [X] UI enhancements have screenshots attached below.
- [X] Screenshots, code, or descriptions don't include proprietary information.