### PR TITLE
Add download count and date to provider list

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
@@ -544,7 +544,7 @@ export function DataProvider(props: Props) {
             return `No downloads`;
         }
 
-        if (provider.latest_download == 0) {
+        if (provider.latest_download === 0) {
             return 'Less than a week ago';
         }
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
@@ -622,9 +622,9 @@ export function DataProvider(props: Props) {
                     />
 
                     <div
-                        style={{ display: "flex", justifyContent: "flex-end", position: "relative", columnGap: '80px', alignItems: 'center' }}
+                        style={{ display: "flex", justifyContent: "flex-end", position: "relative", columnGap: '70px', alignItems: 'center' }}
                     >
-                        {size.width > 900 && <div>
+                        {size.width > 900 && <div style={{ width: '60px', justifyContent: 'center', display: 'flex'}}>
                         {(!!provider.download_count) ? <span style={{ fontSize: "0.9em" }}>{provider.download_count}</span> :
                         <span style={{ fontSize: "0.9em" }}>0</span>}
                     </div>}

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/DataProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import {useEffect, useRef, useState} from 'react';
-import {createStyles, Theme, withStyles, withTheme} from '@material-ui/core/styles';
+import { useEffect, useRef, useState } from 'react';
+import { createStyles, Theme, withStyles, withTheme } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -13,18 +13,18 @@ import Star from "@material-ui/icons/Star";
 import StarBorder from "@material-ui/icons/StarBorder";
 import ProviderStatusCheck from './ProviderStatusCheck';
 import BaseDialog from '../Dialog/BaseDialog';
-import {arrayHasValue, formatMegaBytes, getDuration, isZoomLevelInRange, supportsZoomLevels} from '../../utils/generic';
+import { arrayHasValue, formatMegaBytes, getDuration, isZoomLevelInRange, supportsZoomLevels } from '../../utils/generic';
 import {Typography} from "@material-ui/core";
 import ZoomLevelSlider from "./ZoomLevelSlider";
-import {connect, useDispatch} from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import {updateExportInfo} from '../../actions/datacartActions';
 import debounce from 'lodash/debounce';
 import FormatSelector from "./FormatSelector";
-import {Compatibility} from '../../utils/enums';
+import { Compatibility } from '../../utils/enums';
 import IndeterminateCheckBoxIcon from '@material-ui/icons/IndeterminateCheckBox';
 import CheckBoxIcon from "@material-ui/icons/CheckBox";
-import {IncompatibilityInfo} from "./ExportInfo";
-import {MapLayer} from "./CreateExport";
+import { IncompatibilityInfo } from "./ExportInfo";
+import { MapLayer } from "./CreateExport";
 import OlMouseWheelZoom from "../MapTools/OpenLayers/MouseWheelZoom";
 import ZoomUpdater from "./ZoomUpdater";
 import ProviderPreviewMap from "../MapTools/ProviderPreviewMap";
@@ -32,13 +32,13 @@ import PoiQueryDisplay from "../MapTools/PoiQueryDisplay";
 import OlMapClickEvent from "../MapTools/OpenLayers/OlMapClickEvent";
 import SwitchControl from "../common/SwitchControl";
 import Icon from "ol/style/Icon";
-import {DepsHashers, useEffectOnMount} from "../../utils/hooks/hooks";
-import {useAppContext} from "../ApplicationContext";
-import {useJobValidationContext} from "./context/JobValidation";
-import {RegionJustification} from "../StatusDownloadPage/RegionJustification";
-import {renderIf} from "../../utils/renderIf";
+import { DepsHashers, useEffectOnMount, useWindowSize } from "../../utils/hooks/hooks";
+import { useAppContext } from "../ApplicationContext";
+import { useJobValidationContext } from "./context/JobValidation";
+import { RegionJustification } from "../StatusDownloadPage/RegionJustification";
+import { renderIf } from "../../utils/renderIf";
 import ZoomOutAtZoomLevel from "../MapTools/OpenLayers/ZoomOutAtZoomLevel";
-import {updateProviderFavorite} from '../../actions/providerActions'
+import { updateProviderFavorite } from '../../actions/providerActions'
 
 const jss = (theme: Theme & Eventkit.Theme) => createStyles({
     container: {
@@ -173,6 +173,7 @@ export function DataProvider(props: Props) {
     const debouncerRef = useRef(null);
     const estimateDebouncer = (...args) => debouncerRef.current(...args);
     const dispatch = useDispatch();
+    const size = useWindowSize();
 
     const setProviderFavorite = (slug, favorite) => {
         dispatch(updateProviderFavorite(slug, favorite));
@@ -538,6 +539,18 @@ export function DataProvider(props: Props) {
         setDisplayJustification(true);
     }
 
+    function getLastDownloadContent() {
+        if (provider.latest_download == null) {
+            return `No downloads`;
+        }
+
+        if (provider.latest_download == 0) {
+            return 'Less than a week ago';
+        }
+
+        return `${provider.latest_download} week(s) ago`;
+    }
+
     const backgroundColor = (props.alt) ? colors.secondary : colors.white;
 
     function getRef() {
@@ -608,10 +621,19 @@ export function DataProvider(props: Props) {
                         secondary={secondary}
                     />
 
-
+                    <div
+                        style={{ display: "flex", justifyContent: "flex-end", position: "relative", columnGap: '80px', alignItems: 'center' }}
+                    >
+                        {size.width > 900 && <div>
+                        {(!!provider.download_count) ? <span style={{ fontSize: "0.9em" }}>{provider.download_count}</span> :
+                        <span style={{ fontSize: "0.9em" }}>0</span>}
+                    </div>}
+                        {size.width > 900 && <div style={{ width: '150px', display: 'flex', justifyContent: 'center' }}>
+                        <span style={{fontSize: "0.9em"}}>{getLastDownloadContent()}</span>
+                    </div>}
                     <ProviderStatusCheck
                         id="ProviderStatus"
-                        baseStyle={{marginRight: '40px'}}
+                        baseStyle={{marginRight: '30px'}}
                         availability={providerInfo.availability}
                         overArea={overArea}
                         overSize={overSize}
@@ -622,6 +644,7 @@ export function DataProvider(props: Props) {
                         providerInfo={providerInfo}
                         geojson={props.geojson}
                     />
+                    </div>
                     <span className="qa-expandTarget">
                     {isOpen ?
                         <ExpandLess

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.tsx
@@ -22,7 +22,7 @@ import CustomTextField from "../common/CustomTextField";
 import CustomTableRow from "../common/CustomTableRow";
 import BaseDialog from "../Dialog/BaseDialog";
 import AlertWarning from "@material-ui/icons/Warning";
-import { useDebouncedState } from "../../utils/hooks/hooks";
+import { useDebouncedState, useWindowSize } from "../../utils/hooks/hooks";
 import RequestDataSource from "./RequestDataSource";
 import {
     Chip,
@@ -77,7 +77,7 @@ const jss = (theme: Eventkit.Theme & Theme) =>
             marginTop: "30px",
             marginBottom: "30px",
             width: "100%",
-            maxWidth: "700px"
+            maxWidth: "900px"
         },
         sortFilterContainer: {
             alignItems: "stretch",
@@ -385,6 +385,8 @@ export function ExportInfo(props: Props) {
     } as IncompatibilityInfo);
     const [providerDrawerIsOpen, setProviderDrawerIsOpen] = useState(false);
     const [displayDummy, setDisplayDummy] = useState(false);
+
+    const size = useWindowSize();
 
     useEffect(() => {
         updateSelectedFormats();
@@ -1572,14 +1574,16 @@ export function ExportInfo(props: Props) {
                         </div>
                         <div className={classes.sectionBottom}>
                             <div className={`qa-ExportInfo-ListHeader ${classes.listHeading}`}>
-                                <div className="qa-ExportInfo-ListHeaderItem" style={{ flex: "1 1 auto" }}>
-                                    DATA PRODUCTS
+                                <div className="qa-ExportInfo-ListHeaderItem" style={{ flex: "1 1 auto", fontWeight: "bold" }}>
+                                    Data Products
                                 </div>
                                 <div
                                     className="qa-ExportInfo-ListHeaderItem"
-                                    style={{ display: "flex", justifyContent: "flex-end", position: "relative" }}
+                                    style={{ display: "flex", justifyContent: "flex-end", position: "relative", columnGap: '40px' }}
                                 >
-                                    <span>AVAILABILITY</span>
+                                    {size.width > 900 && <span style={{display: "flex", fontWeight: "bold"}}>Download count</span>}
+                                    {size.width > 900 && <span style={{display: "flex", fontWeight: "bold"}}>Last Downloaded</span>}
+                                    <span style={{display: "flex", fontWeight: "bold"}}>Availability</span>
                                     <NavigationRefresh
                                         className={classes.refreshIcon}
                                         onMouseEnter={handlePopoverOpen}

--- a/eventkit_cloud/ui/static/ui/app/utils/hooks/hooks.ts
+++ b/eventkit_cloud/ui/static/ui/app/utils/hooks/hooks.ts
@@ -1,5 +1,38 @@
 import {useCallback, useEffect, useRef, useState} from "react";
 
+export const useWindowSize = () => {
+    // Initialize state with undefined width/height so server and client renders match
+    // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+    const [windowSize, setWindowSize] = useState({
+        width: undefined,
+        height: undefined
+    });
+
+    // Handler to call on window resize
+    const handleResize = () => {
+        // Set window width/height to state
+        setWindowSize({
+            width: window.innerWidth,
+            height: window.innerHeight
+        });
+    };
+
+    useEffect(() => {
+        // only execute all the code below in client side
+        if (typeof window !== "undefined") {
+            // Add event listener
+            window.addEventListener("resize", handleResize);
+
+            // Call handler right away so state gets updated with initial window size
+            handleResize();
+
+            // Remove event listener on cleanup
+            return () => window.removeEventListener("resize", handleResize);
+        }
+    }, []); // Empty array ensures that effect is only run on mount
+    return windowSize;
+};
+
 // Convenience function that acts like componentDidMount.
 // useEffect replaces componentDidMount AND componentDidUpdate
 // sending an empty array to the second param of useEffect causes it to fire only once, on mount.


### PR DESCRIPTION
# Description of Improvement

Adds date and download count to data provider list. Also hides newly added date data if screen is resized below 900px in width.

## How to test

Verify new date and download count text appears in data provider list
Verify date data hides when expected when width is less than 900px

## Quality Assurance

The following items have been updated:

- [x] Linters pass.
- [x] Unittests pass.
- [x] The docs have been updated for any changes to the settings module.
- [x] New tests have been added to reproduce the functionality of the above description.
- [x] Comments have been added to declare intent, or because of some wild comprehension statement.
- [x] UI enhancements have screenshots attached below.
- [x] Screenshots, code, or descriptions don't include proprietary information.

## Screenshots

<img width="1786" alt="Screen Shot 2022-10-17 at 3 47 57 PM" src="https://user-images.githubusercontent.com/3164631/196272963-fd02408c-ddea-4ddf-ab77-122ec148e156.png">


:smile:
