### PR TITLE
Refactor dashboard to functional components

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/About/InfoGrid.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/About/InfoGrid.tsx
@@ -1,5 +1,5 @@
-import GridList from '@material-ui/core/GridList';
-import GridTile from '@material-ui/core/GridListTile';
+import ImageList from '@material-ui/core/ImageList';
+import ImageListItem from '@material-ui/core/ImageListItem';
 
 export interface Props {
     title: any;
@@ -26,17 +26,17 @@ export const InfoGrid = (props: Props) => {
     return (
         <div>
             <h3 style={styles.title}><strong>{props.title}</strong></h3>
-            <GridList cellHeight="auto" spacing={12}>
+            <ImageList cellHeight="auto" spacing={12}>
                 {props.items.map(item => (
-                    <GridTile
+                    <ImageListItem
                         key={item.title}
                         style={styles.item}
                     >
                         <strong>{item.title}:&nbsp;</strong>
                         <span>{item.body}</span>
-                    </GridTile>
+                    </ImageListItem>
                 ))}
-            </GridList>
+            </ImageList>
         </div>
     );
 };

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardPage.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardPage.tsx
@@ -1,7 +1,8 @@
-import {useEffect, useRef, useState} from 'react';
+import * as React from "react";
+import { useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import debounce from 'lodash/debounce';
-import { withTheme } from '@material-ui/core/styles';
+import { Theme, withTheme } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import Help from '@material-ui/icons/Help';
 import Paper from '@material-ui/core/Paper';
@@ -21,7 +22,7 @@ import { updateDataCartPermissions } from '../../actions/datacartActions';
 import { joyride } from '../../joyride.config';
 import history from '../../utils/history';
 import EventkitJoyride from "../common/JoyrideWrapper";
-import * as React from "react";
+import {Breakpoint} from "@material-ui/core/styles/createBreakpoints";
 
 export const CUSTOM_BREAKPOINTS = {
     xl: 1920,
@@ -50,7 +51,7 @@ interface Props {
     getNotifications: (options?: object) => void;
     updatePermission: Eventkit.Store.UpdatePermissions;
     updateDataCartPermissions: () => void;
-    theme: Eventkit.Theme;
+    theme: Eventkit.Theme & Theme;
     userData: any;
 }
 
@@ -149,6 +150,9 @@ export const DashboardPage = (props: Props) => {
     };
 
     const refresh = ({isAuto = false} = {}) => {
+        props.getNotifications({
+            pageSize: getNotificationsColumns({getMax: true}) * getNotificationsRows() * 3,
+        });
         refreshMyDataPacks({isAuto});
         refreshFeatured({isAuto});
         refreshRecentlyViewed({isAuto});
@@ -234,9 +238,7 @@ export const DashboardPage = (props: Props) => {
     useEffect(() => {
         // Anything in here is fired on component mount.
         props.getProviders();
-        props.getNotifications({
-            pageSize: getNotificationsColumns({getMax: true}) * getNotificationsRows() * 3,
-        });
+
         refresh();
         autoRefreshIntervalId = window.setInterval(autoRefresh, autoRefreshInterval);
         const dashSteps = joyride.DashboardPage;
@@ -347,8 +349,8 @@ export const DashboardPage = (props: Props) => {
                 {iconElementRight}
             </PageHeader>
             <div className='dashboard' style={styles.dashboard}>
-                {isLoading() ?
-                    <PageLoading background="transparent"/>
+                {loadingPage ?
+                    <PageLoading background={"transparent"}/>
                     : null
                 }
                 <CustomScrollbar
@@ -383,8 +385,7 @@ export const DashboardPage = (props: Props) => {
                     {loadingPage ?
                         null
                         :
-                        <div style={styles.content}>
-                            {/* Notifications */}
+                        <div id={"dashboardContent"} style={styles.content}>
                             <DashboardSection
                                 className="qa-DashboardSection-Notifications"
                                 title="Notifications"
@@ -402,17 +403,18 @@ export const DashboardPage = (props: Props) => {
                                     </Paper>
                                 }
                                 rowMajor={false}
+                                width={width as Breakpoint}
                             >
                                 {props.notificationsData.notificationsSorted.map(notification => (
                                     <NotificationGridItem
                                         key={`Notification-${notification.id}`}
                                         notification={notification}
                                         history={props.history}
+                                        width={width as Breakpoint}
                                     />
                                 ))}
                             </DashboardSection>
 
-                            {/* Recently Viewed */}
                             <DashboardSection
                                 className="qa-DashboardSection-RecentlyViewed"
                                 title="Recently Viewed"
@@ -434,10 +436,12 @@ export const DashboardPage = (props: Props) => {
                                         </Link>
                                     </Paper>
                                 }
+                                width={width as Breakpoint}
                             >
                                 {props.viewedIds.map((id, index) => {
                                     return (
                                         <DataPackGridItem
+                                            data-testid={"viewed"}
                                             className="qa-DashboardSection-RecentlyViewedGrid-Item"
                                             runId={id}
                                             userData={props.userData}
@@ -453,7 +457,6 @@ export const DashboardPage = (props: Props) => {
                                 })}
                             </DashboardSection>
 
-                            {/* Featured */}
                             {props.featuredIds.length === 0 ?
                                 null
                                 :
@@ -465,9 +468,11 @@ export const DashboardPage = (props: Props) => {
                                     gridPadding={getGridPadding()}
                                     cellHeight={width !== 'xs' ? 335 : 435}
                                     onViewAll={handleFeaturedViewAll}
+                                    width={width as Breakpoint}
                                 >
                                     {props.featuredIds.map((id, index) => (
                                         <DataPackFeaturedItem
+                                            data-testid={"featured"}
                                             className="qa-DashboardSection-FeaturedGrid-WideItem"
                                             runId={id}
                                             key={`FeaturedDataPack-${id}`}
@@ -479,7 +484,6 @@ export const DashboardPage = (props: Props) => {
                                 </DashboardSection>
                             }
 
-                            {/* My DataPacks */}
                             <DashboardSection
                                 className="qa-DashboardSection-MyDataPacks"
                                 title="My DataPacks"
@@ -502,9 +506,11 @@ export const DashboardPage = (props: Props) => {
                                         </Link>
                                     </Paper>
                                 }
+                                width={width as Breakpoint}
                             >
                                 {props.ownIds.map((id, index) => (
                                     <DataPackGridItem
+                                        data-testid={"pack"}
                                         className="qa-DashboardSection-MyDataPacksGrid-Item"
                                         runId={id}
                                         userData={props.userData}
@@ -555,4 +561,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withTheme<any>(connect(mapStateToProps, mapDispatchToProps)(DashboardPage));
+export default withTheme(connect(mapStateToProps, mapDispatchToProps)(DashboardPage));

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardPage.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardPage.tsx
@@ -1,27 +1,27 @@
-import { Component } from 'react';
-import {connect} from 'react-redux';
+import {useEffect, useRef, useState} from 'react';
+import { connect } from 'react-redux';
 import debounce from 'lodash/debounce';
-import {withTheme} from '@material-ui/core/styles';
-import {Link} from 'react-router-dom';
-import Joyride, {StoreHelpers} from 'react-joyride';
+import { withTheme } from '@material-ui/core/styles';
+import { Link } from 'react-router-dom';
 import Help from '@material-ui/icons/Help';
 import Paper from '@material-ui/core/Paper';
 import ButtonBase from '@material-ui/core/ButtonBase';
 import PageHeader from '../common/PageHeader';
 import PageLoading from '../common/PageLoading';
-import {deleteRun, getFeaturedRuns, getRuns} from '../../actions/datapackActions';
-import {getViewedJobs} from '../../actions/userActivityActions';
-import {getNotifications} from '../../actions/notificationsActions';
+import { deleteRun, getFeaturedRuns, getRuns } from '../../actions/datapackActions';
+import { getViewedJobs } from '../../actions/userActivityActions';
+import { getNotifications } from '../../actions/notificationsActions';
 import CustomScrollbar from '../common/CustomScrollbar';
-import {getProviders} from '../../actions/providerActions';
+import { getProviders } from '../../actions/providerActions';
 import DashboardSection from './DashboardSection';
 import DataPackGridItem from '../DataPackPage/DataPackGridItem';
 import DataPackFeaturedItem from './DataPackFeaturedItem';
 import NotificationGridItem from '../Notification/NotificationGridItem';
-import {updateDataCartPermissions} from '../../actions/datacartActions';
-import {joyride} from '../../joyride.config';
+import { updateDataCartPermissions } from '../../actions/datacartActions';
+import { joyride } from '../../joyride.config';
 import history from '../../utils/history';
 import EventkitJoyride from "../common/JoyrideWrapper";
+import * as React from "react";
 
 export const CUSTOM_BREAKPOINTS = {
     xl: 1920,
@@ -54,143 +54,42 @@ interface Props {
     userData: any;
 }
 
-interface State {
-    loadingPage: boolean;
-    steps: object[];
-    isRunning: boolean;
-    width: string;
-}
+export const DashboardPage = (props: Props) => {
+    let autoRefreshIntervalId: number | undefined = undefined;
+    let autoRefreshInterval: number = 10000;
+    let onResize: () => void;
+    let joyrideRef = useRef(null);
+    let helpersRef = useRef(null);
 
-export class DashboardPage extends Component<Props, State> {
-    private autoRefreshIntervalId: number | undefined = undefined;
-    private autoRefreshInterval: number = 10000;
-    private onResize: () => void;
-    private joyride;
-    private helpers: StoreHelpers;
-
-    constructor(props) {
-        super(props);
-        this.getWidth = this.getWidth.bind(this);
-        this.setScreenSize = this.setScreenSize.bind(this);
-        this.getGridPadding = this.getGridPadding.bind(this);
-        this.getGridColumns = this.getGridColumns.bind(this);
-        this.getGridWideColumns = this.getGridWideColumns.bind(this);
-        this.getNotificationsColumns = this.getNotificationsColumns.bind(this);
-        this.getNotificationsRows = this.getNotificationsRows.bind(this);
-        this.refreshMyDataPacks = this.refreshMyDataPacks.bind(this);
-        this.refreshFeatured = this.refreshFeatured.bind(this);
-        this.refreshRecentlyViewed = this.refreshRecentlyViewed.bind(this);
-        this.refresh = this.refresh.bind(this);
-        this.autoRefresh = this.autoRefresh.bind(this);
-        this.handleNotificationsViewAll = this.handleNotificationsViewAll.bind(this);
-        this.handleFeaturedViewAll = this.handleFeaturedViewAll.bind(this);
-        this.handleMyDataPacksViewAll = this.handleMyDataPacksViewAll.bind(this);
-        this.isLoading = this.isLoading.bind(this);
-        this.handleWalkthroughClick = this.handleWalkthroughClick.bind(this);
-        this.callback = this.callback.bind(this);
-        this.state = {
-            loadingPage: this.isLoading(),
-            steps: [],
-            isRunning: false,
-            width: this.getWidth(),
-        };
-        this.onResize = debounce(this.setScreenSize, 166);
-    }
-
-    componentDidMount() {
-        this.props.getProviders();
-        this.props.getNotifications({
-            pageSize: this.getNotificationsColumns({getMax: true}) * this.getNotificationsRows() * 3,
-        });
-        this.refresh();
-        this.autoRefreshIntervalId = window.setInterval(this.autoRefresh, this.autoRefreshInterval);
-        const steps = joyride.DashboardPage;
-        this.joyrideAddSteps(steps);
-        window.addEventListener('resize', this.onResize);
-    }
-
-    shouldComponentUpdate(p, s) {
-        const status = p.notificationsStatus;
-        const oldStatus = this.props.notificationsStatus;
-
-        // if the status object has changed we need to inspect
-        if (status !== oldStatus) {
-            // if there is a error change we need to update
-            if (status.error !== oldStatus.error) {
-                return true;
-            }
-            // if a fetch has completed AND the data has changed we need to update
-            if (status.fetched && p.notificationsData !== this.props.notificationsData) {
-                return true;
-            }
-            // any other status change can be ignored
-            return false;
-        }
-
-        if (p.runsFetched !== this.props.runsFetched ||
-            p.featuredRunsFetched !== this.props.featuredRunsFetched ||
-            p.viewedRunsFetched !== this.props.viewedRunsFetched
-        ) {
-            return this.state.loadingPage;
-        }
-        // if the status is not the update we can default to true
-        return true;
-    }
-
-    componentDidUpdate(prevProps) {
-        // Only show page loading once, before all sections have initially loaded.
-        const {loadingPage} = this.state;
-        if (loadingPage && !this.isLoading()) {
-            this.setState({loadingPage: false});
-        }
-
-        // Deleted datapack.
-        if (this.props.runDeletion.deleted && !prevProps.runDeletion.deleted) {
-            this.refresh();
-        }
-
-        // Updated permissions.
-        if (this.props.updatePermission.updated && !prevProps.updatePermission.updated) {
-            this.refresh();
-        }
-    }
-
-    componentWillUnmount() {
-        window.clearInterval(this.autoRefreshIntervalId);
-        this.autoRefreshIntervalId = undefined;
-        window.removeEventListener('resize', this.onResize);
-    }
-
-    private getWidth() {
-        const width = window.innerWidth;
+    const getWidth = () => {
+        const windowWidth = window.innerWidth;
         let value = 'xs';
-        if (width >= CUSTOM_BREAKPOINTS.xl) {
+        if (windowWidth >= CUSTOM_BREAKPOINTS.xl) {
             value = 'xl';
-        } else if (width >= CUSTOM_BREAKPOINTS.lg) {
+        } else if (windowWidth >= CUSTOM_BREAKPOINTS.lg) {
             value = 'lg';
-        } else if (width >= CUSTOM_BREAKPOINTS.md) {
+        } else if (windowWidth >= CUSTOM_BREAKPOINTS.md) {
             value = 'md';
-        } else if (width >= CUSTOM_BREAKPOINTS.sm) {
+        } else if (windowWidth >= CUSTOM_BREAKPOINTS.sm) {
             value = 'sm';
         }
 
         return value;
-    }
+    };
 
-    private setScreenSize() {
-        const width = this.getWidth();
+    const setScreenSize = () => {
+        const nWidth = getWidth();
 
-        if (width !== this.state.width) {
-            this.setState({width});
+        if (nWidth !== width) {
+            setWidth(nWidth);
         }
-    }
+    };
 
-    private getGridPadding() {
-        return this.state.width !== 'xs' ? 6 : 2;
-    }
+    const getGridPadding = () => {
+        return width !== 'xs' ? 6 : 2;
+    };
 
-    private getGridColumns({getMax = false} = {}) {
-        const {width} = this.state;
+    const getGridColumns = ({getMax = false} = {}) => {
         if (width === 'xl' || getMax) {
             return 6;
         } else if (width === 'lg') {
@@ -202,89 +101,87 @@ export class DashboardPage extends Component<Props, State> {
         }
 
         return 2;
-    }
+    };
 
-    private getGridWideColumns({getMax = false} = {}) {
-        if (this.state.width === 'lg' || this.state.width === 'xl' || getMax) {
+    const getGridWideColumns = ({getMax = false} = {}) => {
+        if (width === 'lg' || width === 'xl' || getMax) {
             return 2;
         }
 
         return 1;
-    }
+    };
 
-    private getNotificationsColumns({getMax = false} = {}) {
-        if (this.state.width === 'lg' || this.state.width === 'xl' || getMax) {
+    const getNotificationsColumns = ({getMax = false} = {}) => {
+        if (width === 'lg' || width === 'xl' || getMax) {
             return 3;
-        } else if (this.state.width === 'md') {
+        } else if (width === 'md') {
             return 2;
         }
 
         return 1;
-    }
+    };
 
-    private getNotificationsRows() {
+    const getNotificationsRows = () => {
         return 3;
-    }
+    };
 
-    private refreshMyDataPacks({isAuto = false} = {}) {
-        this.props.getRuns({
-            pageSize: this.getGridColumns({getMax: true}) * 3,
+    const refreshMyDataPacks = ({isAuto = false} = {}) => {
+        props.getRuns({
+            pageSize: getGridColumns({getMax: true}) * 3,
             ordering: '-created_at',
-            ownerFilter: this.props.userData.user.username,
+            ownerFilter: props.userData.user.username,
             isAuto,
         });
-    }
+    };
 
-    private refreshFeatured({isAuto = false} = {}) {
-        this.props.getFeaturedRuns({
-            pageSize: this.getGridWideColumns({getMax: true}) * 3,
+    const refreshFeatured = ({isAuto = false} = {}) => {
+        props.getFeaturedRuns({
+            pageSize: getGridWideColumns({getMax: true}) * 3,
             isAuto,
         });
-    }
+    };
 
-    private refreshRecentlyViewed({isAuto = false} = {}) {
-        this.props.getViewedJobs({
-            pageSize: this.getGridColumns({getMax: true}) * 3,
+    const refreshRecentlyViewed = ({isAuto = false} = {}) => {
+        props.getViewedJobs({
+            pageSize: getGridColumns({getMax: true}) * 3,
             isAuto,
         });
-    }
+    };
 
-    private refresh({isAuto = false} = {}) {
-        this.refreshMyDataPacks({isAuto});
-        this.refreshFeatured({isAuto});
-        this.refreshRecentlyViewed({isAuto});
-    }
+    const refresh = ({isAuto = false} = {}) => {
+        refreshMyDataPacks({isAuto});
+        refreshFeatured({isAuto});
+        refreshRecentlyViewed({isAuto});
+    };
 
-    private autoRefresh() {
-        this.refresh({isAuto: true});
-    }
+    const autoRefresh = () => {
+        refresh({isAuto: true});
+    };
 
-    private handleNotificationsViewAll() {
+    const handleNotificationsViewAll = () => {
         history.push('/notifications');
-    }
+    };
 
-    private handleFeaturedViewAll() {
+    const handleFeaturedViewAll = () => {
         history.push('/exports');
-    }
+    };
 
-    private handleMyDataPacksViewAll() {
-        history.push(`/exports?collection=${this.props.userData.user.username}`);
-    }
+    const handleMyDataPacksViewAll = () => {
+        history.push(`/exports?collection=${props.userData.user.username}`);
+    };
 
-    private isLoading() {
+    const isLoading = () => {
         return (
-            this.props.notificationsStatus === null ||
-            this.props.runsFetched === null ||
-            this.props.featuredRunsFetched === null ||
-            this.props.viewedRunsFetched === null ||
-            this.props.runDeletion.deleting ||
-            this.props.updatePermission.updating
+            props.notificationsStatus === null ||
+            props.runsFetched === null ||
+            props.featuredRunsFetched === null ||
+            props.viewedRunsFetched === null ||
+            props.runDeletion.deleting ||
+            props.updatePermission.updating
         );
-    }
+    };
 
-    private joyrideAddSteps(steps) {
-        let newSteps = steps;
-
+    const joyrideAddSteps = (newSteps) => {
         if (!Array.isArray(newSteps)) {
             newSteps = [newSteps];
         }
@@ -293,321 +190,341 @@ export class DashboardPage extends Component<Props, State> {
             return;
         }
 
-        this.setState(currentState => {
-            const nextState = {...currentState};
-            nextState.steps = nextState.steps.concat(newSteps);
-            return nextState;
-        });
-    }
+        setSteps(steps.concat(newSteps));
+    };
 
-    private callback(data) {
+    const callback = (data) => {
         const {action, step, type} = data;
+
+        if (!action) {
+            return;
+        }
+
         if (action === 'close' || action === 'skip' || type === 'tour:end') {
-            this.setState({isRunning: false});
-            this?.helpers?.reset(true);
+            helpersRef?.current?.reset(true);
+            joyrideRef?.current?.reset(true);
+            setIsRunning(false);
             window.location.hash = '';
         }
+    };
 
-        if (step && step.scrollToId) {
-            window.location.hash = step.scrollToId;
-        }
-    }
-
-    private handleWalkthroughClick() {
-        if (this.state.isRunning) {
-            this.setState({isRunning: false});
-            this?.helpers.reset(true);
+    const handleWalkthroughClick = () => {
+        if (isRunning) {
+            setIsRunning(false);
+            joyrideRef?.current?.reset(true);
         } else {
-            const [...steps] = joyride.DashboardPage;
-            this.setState({isRunning: true, steps: []});
-            if (this.props.featuredIds.length === 0) {
-                const ix = steps.findIndex(s => s.selector === '.qa-DashboardSection-Featured');
-                if (ix > -1) {
-                    steps.splice(ix, 1);
-                }
-            }
-            this.joyrideAddSteps(steps);
+            setIsRunning(true);
         }
+    };
+
+    const [loadingPage, setLoadingPage] = useState(isLoading());
+    const [steps, setSteps] = useState([]);
+    const [isRunning, setIsRunning] = useState(false);
+    const [width, setWidth] = useState(getWidth());
+    onResize = debounce(setScreenSize, 166);
+
+    if (loadingPage && !isLoading()) {
+        setLoadingPage(false);
     }
 
-    render() {
-        const {colors, images} = this.props.theme.eventkit;
+    useEffect( () => {
+        refresh();
+    }, [props.runDeletion.deleted, props.updatePermission.updated]);
 
-        const mainAppBarHeight = 95;
-        const pageAppBarHeight = 35;
-        const styles = {
-            root: {
-                position: 'relative' as 'relative',
-                height: `calc(100vh - ${mainAppBarHeight}px)`,
-                width: '100%',
-                backgroundImage: `url(${images.topo_dark})`,
-            },
-            customScrollbar: {
-                height: `calc(100vh - ${mainAppBarHeight + pageAppBarHeight}px)`,
-            },
-            loadingOverlay: {
-                position: 'absolute' as 'absolute',
-                height: '100%',
-                width: '100%',
-                background: colors.backdrop,
-                zIndex: '100',
-            },
-            loadingPage: {
-                position: 'absolute',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-            },
-            content: {
-                marginBottom: '12px',
-                maxWidth: '1920px',
-                margin: 'auto',
-            },
-            noData: {
-                margin: `0 ${10 + (this.getGridPadding() / 2)}px`,
-                padding: '22px',
-                fontSize: '18px',
-                color: colors.grey,
-            },
-            link: {
-                color: colors.primary,
-            },
-            tourButton: {
-                color: colors.primary,
-                cursor: 'pointer',
-                display: 'inline-block',
-                marginLeft: '10px',
-                fontSize: '14px',
-                height: '30px',
-                lineHeight: '30px',
-            },
-            tourIcon: {
-                color: colors.primary,
-                cursor: 'pointer',
-                height: '18px',
-                width: '18px',
-                verticalAlign: 'middle',
-                marginRight: '5px',
-                marginBottom: '5px',
-            },
-            banner: {
-                position: 'relative' as 'relative',
-                width: '100%',
-                height: '35px'
-            },
-            dashboard: {
-                height: 'calc(100vh - 226px)',
-                position: 'absolute' as 'absolute',
-                width: '100%'
+    useEffect(() => {
+        // Anything in here is fired on component mount.
+        props.getProviders();
+        props.getNotifications({
+            pageSize: getNotificationsColumns({getMax: true}) * getNotificationsRows() * 3,
+        });
+        refresh();
+        autoRefreshIntervalId = window.setInterval(autoRefresh, autoRefreshInterval);
+        const dashSteps = joyride.DashboardPage;
+        if (props.featuredIds.length === 0) {
+            const ix = dashSteps.findIndex(s => s.selector === '.qa-DashboardSection-Featured');
+            if (ix > -1) {
+                dashSteps.splice(ix, 1);
             }
-        };
+        }
+        joyrideAddSteps(dashSteps);
+        window.addEventListener('resize', onResize);
+        return () => {
+            // Anything in here is fired on component unmount.
+            window.clearInterval(autoRefreshIntervalId);
+            autoRefreshIntervalId = undefined;
+            window.removeEventListener('resize', onResize);
+        }
+    }, [])
 
-        const iconElementRight = (
-            <ButtonBase
-                onClick={this.handleWalkthroughClick}
-                style={styles.tourButton}
+    const {colors, images} = props.theme.eventkit;
+
+    const mainAppBarHeight = 95;
+    const pageAppBarHeight = 35;
+    const styles = {
+        root: {
+            position: 'relative' as 'relative',
+            height: `calc(100vh - ${mainAppBarHeight}px)`,
+            width: '100%',
+            backgroundImage: `url(${images.topo_dark})`,
+        },
+        customScrollbar: {
+            height: `calc(100vh - ${mainAppBarHeight + pageAppBarHeight}px)`,
+        },
+        loadingOverlay: {
+            position: 'absolute' as 'absolute',
+            height: '100%',
+            width: '100%',
+            background: colors.backdrop,
+            zIndex: '100',
+        },
+        loadingPage: {
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+        },
+        content: {
+            marginBottom: '12px',
+            maxWidth: '1920px',
+            margin: 'auto',
+        },
+        noData: {
+            margin: `0 ${10 + (getGridPadding() / 2)}px`,
+            padding: '22px',
+            fontSize: '18px',
+            color: colors.grey,
+        },
+        link: {
+            color: colors.primary,
+        },
+        tourButton: {
+            color: colors.primary,
+            cursor: 'pointer',
+            display: 'inline-block',
+            marginLeft: '10px',
+            fontSize: '14px',
+            height: '30px',
+            lineHeight: '30px',
+        },
+        tourIcon: {
+            color: colors.primary,
+            cursor: 'pointer',
+            height: '18px',
+            width: '18px',
+            verticalAlign: 'middle',
+            marginRight: '5px',
+            marginBottom: '5px',
+        },
+        banner: {
+            position: 'relative' as 'relative',
+            width: '100%',
+            height: '35px'
+        },
+        dashboard: {
+            height: 'calc(100vh - 226px)',
+            position: 'absolute' as 'absolute',
+            width: '100%'
+        }
+    };
+
+    const iconElementRight = (
+        <ButtonBase
+            onClick={handleWalkthroughClick}
+            style={styles.tourButton}
+        >
+            <Help style={styles.tourIcon}/>
+            Page Tour
+        </ButtonBase>
+    );
+
+    return (
+        <div style={styles.root}>
+            <PageHeader
+                id="Dashboard"
+                className="qa-Dashboard-PageHeader"
+                title="Dashboard"
             >
-                <Help style={styles.tourIcon}/>
-                Page Tour
-            </ButtonBase>
-        );
-
-        return (
-            <div style={styles.root}>
-                <PageHeader
-                    id="Dashboard"
-                    className="qa-Dashboard-PageHeader"
-                    title="Dashboard"
+                {iconElementRight}
+            </PageHeader>
+            <div className='dashboard' style={styles.dashboard}>
+                {isLoading() ?
+                    <PageLoading background="transparent"/>
+                    : null
+                }
+                <CustomScrollbar
+                    style={styles.customScrollbar}
                 >
-                    {iconElementRight}
-                </PageHeader>
-                <div className='dashboard' style={styles.dashboard}>
-                    {this.isLoading() ?
-                        <PageLoading background="transparent"/>
-                        : null
-                    }
-                    <CustomScrollbar
-                        style={styles.customScrollbar}
-                    >
-                        <EventkitJoyride
-                            callback={this.callback}
-                            ref={instance => {
-                                this.joyride = instance;
-                            }}
+                    <EventkitJoyride
+                        name={"Dashboard Page"}
+                        callback={callback}
+                        getRef={(_ref) => (joyrideRef = _ref)}
+                        getHelpers={(helpers: any) => {
+                            helpersRef = helpers;
+                        }}
+                        // @ts-ignore
+                        steps={steps}
+                        continuous
+                        showSkipButton
+                        showProgress
+                        locale={{
                             // @ts-ignore
-                            steps={this.state.steps}
-                            getHelpers={(helpers: any) => {this.helpers = helpers}}
-                            autoStart
-                            continuous
-                            showSkipButton
-                            showProgress
-                            locale={{
-                                // @ts-ignore
-                                back: (<span>Back</span>),
-                                // @ts-ignore
-                                close: (<span>Close</span>),
-                                // @ts-ignore
-                                last: (<span>Done</span>),
-                                // @ts-ignore
-                                next: (<span>Next</span>),
-                                // @ts-ignore
-                                skip: (<span>Skip</span>),
-                            }}
-                            run={this.state.isRunning}
-                            // styles={{
-                            //     options: {
-                            //         overlayColor: colors.primary,
-                            //         backgroundColor: colors.primary,
-                            //         primaryColor: colors.white,
-                            //     },
-                            // }}
-                        />
-                        {this.state.loadingPage ?
-                            null
-                            :
-                            <div style={styles.content}>
-                                {/* Notifications */}
-                                <DashboardSection
-                                    className="qa-DashboardSection-Notifications"
-                                    title="Notifications"
-                                    name="Notifications"
-                                    columns={this.getNotificationsColumns()}
-                                    rows={this.getNotificationsRows()}
-                                    gridPadding={this.getGridPadding()}
-                                    onViewAll={this.handleNotificationsViewAll}
-                                    noDataElement={
-                                        <Paper
-                                            className="qa-DashboardSection-Notifications-NoData"
-                                            style={styles.noData}
-                                        >
-                                            <span>{"You don't have any notifications."}</span>
-                                        </Paper>
-                                    }
-                                    rowMajor={false}
-                                >
-                                    {this.props.notificationsData.notificationsSorted.map(notification => (
-                                        <NotificationGridItem
-                                            key={`Notification-${notification.id}`}
-                                            notification={notification}
-                                            history={this.props.history}
-                                        />
-                                    ))}
-                                </DashboardSection>
-
-                                {/* Recently Viewed */}
-                                <DashboardSection
-                                    className="qa-DashboardSection-RecentlyViewed"
-                                    title="Recently Viewed"
-                                    name="RecentlyViewed"
-                                    columns={this.getGridColumns()}
-                                    gridPadding={this.getGridPadding()}
-                                    noDataElement={
-                                        <Paper
-                                            className="qa-DashboardSection-RecentlyViewed-NoData"
-                                            style={styles.noData}
-                                        >
-                                            <span>{"You don't have any recently viewed DataPacks."}&nbsp;</span>
-                                            <Link
-                                                to="/exports"
-                                                href="/exports"
-                                                style={styles.link}
-                                            >
-                                                View DataPack Library
-                                            </Link>
-                                        </Paper>
-                                    }
-                                >
-                                    {this.props.viewedIds.map((id, index) => {
-                                        return (
-                                            <DataPackGridItem
-                                                className="qa-DashboardSection-RecentlyViewedGrid-Item"
-                                                runId={id}
-                                                userData={this.props.userData}
-                                                key={`RecentlyViewedDataPack-${id}`}
-                                                onRunDelete={this.props.deleteRun}
-                                                onRunShare={this.props.updateDataCartPermissions}
-                                                providers={this.props.providers}
-                                                gridName="RecentlyViewed"
-                                                index={index}
-                                                showFeaturedFlag={false}
-                                            />
-                                        );
-                                    })}
-                                </DashboardSection>
-
-                                {/* Featured */}
-                                {this.props.featuredIds.length === 0 ?
-                                    null
-                                    :
-                                    <DashboardSection
-                                        className="qa-DashboardSection-Featured"
-                                        title="Featured"
-                                        name="Featured"
-                                        columns={this.getGridWideColumns()}
-                                        gridPadding={this.getGridPadding()}
-                                        cellHeight={this.state.width !== 'xs' ? 335 : 435}
-                                        onViewAll={this.handleFeaturedViewAll}
+                            back: (<span>Back</span>),
+                            // @ts-ignore
+                            close: (<span>Close</span>),
+                            // @ts-ignore
+                            last: (<span>Done</span>),
+                            // @ts-ignore
+                            next: (<span>Next</span>),
+                            // @ts-ignore
+                            skip: (<span>Skip</span>),
+                        }}
+                        run={isRunning}
+                    />
+                    {loadingPage ?
+                        null
+                        :
+                        <div style={styles.content}>
+                            {/* Notifications */}
+                            <DashboardSection
+                                className="qa-DashboardSection-Notifications"
+                                title="Notifications"
+                                name="Notifications"
+                                columns={getNotificationsColumns()}
+                                rows={getNotificationsRows()}
+                                gridPadding={getGridPadding()}
+                                onViewAll={handleNotificationsViewAll}
+                                noDataElement={
+                                    <Paper
+                                        className="qa-DashboardSection-Notifications-NoData"
+                                        style={styles.noData}
                                     >
-                                        {this.props.featuredIds.map((id, index) => (
-                                            <DataPackFeaturedItem
-                                                className="qa-DashboardSection-FeaturedGrid-WideItem"
-                                                runId={id}
-                                                key={`FeaturedDataPack-${id}`}
-                                                gridName="Featured"
-                                                index={index}
-                                                height={this.state.width !== 'xs' ? '335px' : '435px'}
-                                            />
-                                        ))}
-                                    </DashboardSection>
+                                        <span>{"You don't have any notifications."}</span>
+                                    </Paper>
                                 }
+                                rowMajor={false}
+                            >
+                                {props.notificationsData.notificationsSorted.map(notification => (
+                                    <NotificationGridItem
+                                        key={`Notification-${notification.id}`}
+                                        notification={notification}
+                                        history={props.history}
+                                    />
+                                ))}
+                            </DashboardSection>
 
-                                {/* My DataPacks */}
-                                <DashboardSection
-                                    className="qa-DashboardSection-MyDataPacks"
-                                    title="My DataPacks"
-                                    name="MyDataPacks"
-                                    columns={this.getGridColumns()}
-                                    gridPadding={this.getGridPadding()}
-                                    onViewAll={this.handleMyDataPacksViewAll}
-                                    noDataElement={
-                                        <Paper
-                                            className="qa-DashboardSection-MyDataPacks-NoData"
-                                            style={styles.noData}
+                            {/* Recently Viewed */}
+                            <DashboardSection
+                                className="qa-DashboardSection-RecentlyViewed"
+                                title="Recently Viewed"
+                                name="RecentlyViewed"
+                                columns={getGridColumns()}
+                                gridPadding={getGridPadding()}
+                                noDataElement={
+                                    <Paper
+                                        className="qa-DashboardSection-RecentlyViewed-NoData"
+                                        style={styles.noData}
+                                    >
+                                        <span>{"You don't have any recently viewed DataPacks."}&nbsp;</span>
+                                        <Link
+                                            to="/exports"
+                                            href="/exports"
+                                            style={styles.link}
                                         >
-                                            <span>{"You don't have any DataPacks."}&nbsp;</span>
-                                            <Link
-                                                to="/create"
-                                                href="/create"
-                                                style={styles.link}
-                                            >
-                                                Create DataPack
-                                            </Link>
-                                        </Paper>
-                                    }
-                                >
-                                    {this.props.ownIds.map((id, index) => (
+                                            View DataPack Library
+                                        </Link>
+                                    </Paper>
+                                }
+                            >
+                                {props.viewedIds.map((id, index) => {
+                                    return (
                                         <DataPackGridItem
-                                            className="qa-DashboardSection-MyDataPacksGrid-Item"
+                                            className="qa-DashboardSection-RecentlyViewedGrid-Item"
                                             runId={id}
-                                            userData={this.props.userData}
-                                            key={`MyDataPacksDataPack-${id}`}
-                                            onRunDelete={this.props.deleteRun}
-                                            onRunShare={this.props.updateDataCartPermissions}
-                                            providers={this.props.providers}
-                                            gridName="MyDataPacks"
+                                            userData={props.userData}
+                                            key={`RecentlyViewedDataPack-${id}`}
+                                            onRunDelete={props.deleteRun}
+                                            onRunShare={props.updateDataCartPermissions}
+                                            providers={props.providers}
+                                            gridName="RecentlyViewed"
                                             index={index}
                                             showFeaturedFlag={false}
                                         />
+                                    );
+                                })}
+                            </DashboardSection>
+
+                            {/* Featured */}
+                            {props.featuredIds.length === 0 ?
+                                null
+                                :
+                                <DashboardSection
+                                    className="qa-DashboardSection-Featured"
+                                    title="Featured"
+                                    name="Featured"
+                                    columns={getGridWideColumns()}
+                                    gridPadding={getGridPadding()}
+                                    cellHeight={width !== 'xs' ? 335 : 435}
+                                    onViewAll={handleFeaturedViewAll}
+                                >
+                                    {props.featuredIds.map((id, index) => (
+                                        <DataPackFeaturedItem
+                                            className="qa-DashboardSection-FeaturedGrid-WideItem"
+                                            runId={id}
+                                            key={`FeaturedDataPack-${id}`}
+                                            gridName="Featured"
+                                            index={index}
+                                            height={width !== 'xs' ? '335px' : '435px'}
+                                        />
                                     ))}
                                 </DashboardSection>
-                            </div>
-                        }
-                    </CustomScrollbar>
-                </div>
+                            }
+
+                            {/* My DataPacks */}
+                            <DashboardSection
+                                className="qa-DashboardSection-MyDataPacks"
+                                title="My DataPacks"
+                                name="MyDataPacks"
+                                columns={getGridColumns()}
+                                gridPadding={getGridPadding()}
+                                onViewAll={handleMyDataPacksViewAll}
+                                noDataElement={
+                                    <Paper
+                                        className="qa-DashboardSection-MyDataPacks-NoData"
+                                        style={styles.noData}
+                                    >
+                                        <span>{"You don't have any DataPacks."}&nbsp;</span>
+                                        <Link
+                                            to="/create"
+                                            href="/create"
+                                            style={styles.link}
+                                        >
+                                            Create DataPack
+                                        </Link>
+                                    </Paper>
+                                }
+                            >
+                                {props.ownIds.map((id, index) => (
+                                    <DataPackGridItem
+                                        className="qa-DashboardSection-MyDataPacksGrid-Item"
+                                        runId={id}
+                                        userData={props.userData}
+                                        key={`MyDataPacksDataPack-${id}`}
+                                        onRunDelete={props.deleteRun}
+                                        onRunShare={props.updateDataCartPermissions}
+                                        providers={props.providers}
+                                        gridName="MyDataPacks"
+                                        index={index}
+                                        showFeaturedFlag={false}
+                                    />
+                                ))}
+                            </DashboardSection>
+                        </div>
+                    }
+                </CustomScrollbar>
             </div>
-        );
-    }
-}
+        </div>
+    );
+};
 
 function mapStateToProps(state) {
     return {

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { withStyles, withTheme, createStyles, Theme } from '@material-ui/core/styles';
-import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
+import { isWidthUp } from '@material-ui/core/withWidth';
 import ImageList from '@material-ui/core/ImageList';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
@@ -284,4 +284,4 @@ export const DashboardSection = (props: Props) => {
     );
 };
 
-export default withWidth()(withTheme(withStyles(jss)(DashboardSection)));
+export default withTheme(withStyles(jss)(DashboardSection));

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { withStyles, withTheme, createStyles, Theme } from '@material-ui/core/styles';
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import SwipeableViews from 'react-swipeable-views';
@@ -181,11 +181,11 @@ export const DashboardSection = (props: Props) => {
                         }
 
                         content = childrenColumns.map((childrenColumn, columnIndex) => (
-                            <GridList
+                            <ImageList
                                 key={`DashboardSection-${props.name}-Page${pageIndex}-Column${columnIndex}`}
                                 className="qa-DashboardSection-Page-Column"
-                                cellHeight={props.cellHeight || 'auto'}
-                                spacing={gridPadding}
+                                rowHeight={props.cellHeight || 'auto'}
+                                gap={gridPadding}
                                 cols={1}
                             >
                                 {childrenColumn.map((child, index) => (
@@ -196,21 +196,21 @@ export const DashboardSection = (props: Props) => {
                                         {child}
                                     </div>
                                 ))}
-                            </GridList>
+                            </ImageList>
                         ));
                     }
 
                     return (
-                        <GridList
+                        <ImageList
                             key={`DashboardSection-${props.name}-Page${pageIndex}`}
                             className="qa-DashboardSection-Page"
-                            cellHeight={props.cellHeight || 'auto'}
+                            rowHeight={props.cellHeight || 'auto'}
                             style={styles.gridList}
-                            spacing={gridPadding}
+                            gap={gridPadding}
                             cols={props.columns}
                         >
                             {content}
-                        </GridList>
+                        </ImageList>
                     );
                 })}
             </SwipeableViews>

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
@@ -6,6 +6,7 @@ import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import SwipeableViews from 'react-swipeable-views';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
+import { useState } from "react";
 
 const jss = (theme: Theme & Eventkit.Theme) => createStyles({
     tabsRoot: {
@@ -60,248 +61,224 @@ export interface State {
     pageIndex: number;
 }
 
-export class DashboardSection extends React.Component<Props, State> {
-    static defaultProps = {
-        style: {},
-        onViewAll: undefined,
-        noDataElement: undefined,
-        cellHeight: undefined,
-        gridPadding: 2,
-        rows: 1,
-        rowMajor: true,
-        children: undefined,
-        classes: {},
-    };
+export const DashboardSection = (props: Props) => {
+    let maxPages: number = 3;
+    const [pageIndex, setPageIndex] = useState(0);
 
-    private maxPages: number;
-
-    constructor(props: Props) {
-        super(props);
-        this.handlePageChange = this.handlePageChange.bind(this);
-        this.getPages = this.getPages.bind(this);
-        this.state = {
-            pageIndex: 0,
-        };
-        this.maxPages = 3;
-    }
-
-    private getPages() {
-        const itemsPerPage = this.props.columns * this.props.rows;
+    const getPages = () => {
+        const itemsPerPage = props.columns * props.rows;
         // Group children into pages, each of length maxPages.
-        const children = React.Children.toArray(this.props.children);
+        const children = React.Children.toArray(props.children);
         const pages = [];
         for (let i = 0; i < children.length; i += itemsPerPage) {
             pages.push(children.slice(i, i + itemsPerPage));
-            if (pages.length === this.maxPages) {
+            if (pages.length === maxPages) {
                 break;
             }
         }
 
         return pages;
-    }
+    };
 
-    handlePageChange(_, pageIndex: number) {
-        this.setState({
-            pageIndex,
-        });
-    }
+    const handlePageChange = (_, pageIndex: number) => {
+        setPageIndex(pageIndex);
+    };
 
-    render() {
-        const { colors } = this.props.theme.eventkit;
-        const { classes } = this.props;
-        const md = isWidthUp('md', this.props.width);
+    const { colors } = props.theme.eventkit;
+    const { classes } = props;
+    const md = isWidthUp('md', props.width);
 
-        const spacing = md ? 10 : 2;
-        const scrollbarWidth = 6;
-        const halfGridPadding = this.props.gridPadding / 2;
-        const styles = {
-            root: {
-                marginBottom: '35px',
-                ...this.props.style,
-            },
-            sectionHeader: {
-                margin: '12px 0 13px',
-                paddingLeft: md ? `${spacing + halfGridPadding}px` : '12px',
-                paddingRight: md ? `${spacing + halfGridPadding + scrollbarWidth}px` : '12px',
-                fontSize: md ? '22px' : '18px',
-                fontWeight: 'bold' as 'bold',
-                letterSpacing: '0.6px',
-                textTransform: 'uppercase' as 'uppercase',
-                display: 'flex',
-                alignItems: 'center',
-                color: colors.white,
-            },
-            sectionHeaderLeft: {
-                flex: '1',
-            },
-            sectionHeaderRight: {
-                display: 'flex',
-                alignItems: 'center',
-            },
-            swipeableViews: {
-                width: '100%',
-            },
-            gridList: {
-                border: '1px',
-                width: '100%',
-                height: 'auto',
-                margin: '0',
-                paddingLeft: `${spacing}px`,
-                paddingRight: md ? `${spacing + scrollbarWidth}px` : `${spacing}px`,
-            },
-            viewAll: {
-                color: colors.primary,
-                textTransform: 'uppercase' as 'uppercase',
-                fontSize: md ? '14px' : '12px',
-                cursor: 'pointer',
-                marginLeft: '18px',
-            },
-        };
+    const spacing = md ? 10 : 2;
+    const scrollbarWidth = 6;
+    const halfGridPadding = props.gridPadding / 2;
+    const styles = {
+        root: {
+            marginBottom: '35px',
+            ...props.style,
+        },
+        sectionHeader: {
+            margin: '12px 0 13px',
+            paddingLeft: md ? `${spacing + halfGridPadding}px` : '12px',
+            paddingRight: md ? `${spacing + halfGridPadding + scrollbarWidth}px` : '12px',
+            fontSize: md ? '22px' : '18px',
+            fontWeight: 'bold' as 'bold',
+            letterSpacing: '0.6px',
+            textTransform: 'uppercase' as 'uppercase',
+            display: 'flex',
+            alignItems: 'center',
+            color: colors.white,
+        },
+        sectionHeaderLeft: {
+            flex: '1',
+        },
+        sectionHeaderRight: {
+            display: 'flex',
+            alignItems: 'center',
+        },
+        swipeableViews: {
+            width: '100%',
+        },
+        gridList: {
+            border: '1px',
+            width: '100%',
+            height: 'auto',
+            margin: '0',
+            paddingLeft: `${spacing}px`,
+            paddingRight: md ? `${spacing + scrollbarWidth}px` : `${spacing}px`,
+        },
+        viewAll: {
+            color: colors.primary,
+            textTransform: 'uppercase' as 'uppercase',
+            fontSize: md ? '14px' : '12px',
+            cursor: 'pointer',
+            marginLeft: '18px',
+        },
+    };
 
-        const childrenPages = this.getPages();
+    const childrenPages = getPages();
 
-        let view = null;
-        if (childrenPages.length > 0) {
-            // swipe here
-            view = (
-                <SwipeableViews
-                    style={styles.swipeableViews}
-                    index={this.state.pageIndex}
-                    onChangeIndex={this.handlePageChange}
-                >
-                    {childrenPages.map((childrenPage, pageIndex) => {
-                        let content;
-                        if (this.props.rowMajor) {
-                            content = childrenPage.map((child, index) => (
-                                <div
-                                    key={`DashboardSection-${this.props.name}-Page${pageIndex}-Item${index}`}
-                                    className="qa-DashboardSection-Page-Item"
-                                >
-                                    {child}
-                                </div>
-                            ));
-                        } else {
-                            // For column-major layouts, create an inner single-column GridList for each column, so
-                            // that items each column gets filled completely before adding to the next one.
-                            const childrenColumns = [];
-                            let column = [];
+    let view = null;
+    if (childrenPages.length > 0) {
+        // swipe here
+        view = (
+            <SwipeableViews
+                style={styles.swipeableViews}
+                index={pageIndex}
+                onChangeIndex={handlePageChange}
+            >
+                {childrenPages.map((childrenPage, pageIndex) => {
+                    let content;
+                    if (props.rowMajor) {
+                        content = childrenPage.map((child, index) => (
+                            <div
+                                key={`DashboardSection-${props.name}-Page${pageIndex}-Item${index}`}
+                                className="qa-DashboardSection-Page-Item"
+                            >
+                                {child}
+                            </div>
+                        ));
+                    } else {
+                        // For column-major layouts, create an inner single-column GridList for each column, so
+                        // that items each column gets filled completely before adding to the next one.
+                        const childrenColumns = [];
+                        let column = [];
 
-                            childrenPage.forEach((child) => {
-                                column.push(child);
-                                if (column.length >= this.props.rows) {
-                                    // Filled the column. Onto the next one.
-                                    childrenColumns.push(column);
-                                    column = [];
-                                }
-                            });
-
-                            // Partial column at the end.
-                            if (column.length > 0) {
+                        childrenPage.forEach((child) => {
+                            column.push(child);
+                            if (column.length >= props.rows) {
+                                // Filled the column. Onto the next one.
                                 childrenColumns.push(column);
+                                column = [];
                             }
+                        });
 
-                            content = childrenColumns.map((childrenColumn, columnIndex) => (
-                                <GridList
-                                    key={`DashboardSection-${this.props.name}-Page${pageIndex}-Column${columnIndex}`}
-                                    className="qa-DashboardSection-Page-Column"
-                                    cellHeight={this.props.cellHeight || 'auto'}
-                                    spacing={this.props.gridPadding}
-                                    cols={1}
-                                >
-                                    {childrenColumn.map((child, index) => (
-                                        <div
-                                            key={`DashboardSection-${this.props.name}-Page${pageIndex}-Column${columnIndex}-Item${index}`}
-                                            className="qa-DashboardSection-Page-Item"
-                                        >
-                                            {child}
-                                        </div>
-                                    ))}
-                                </GridList>
-                            ));
+                        // Partial column at the end.
+                        if (column.length > 0) {
+                            childrenColumns.push(column);
                         }
 
-                        return (
+                        content = childrenColumns.map((childrenColumn, columnIndex) => (
                             <GridList
-                                key={`DashboardSection-${this.props.name}-Page${pageIndex}`}
-                                className="qa-DashboardSection-Page"
-                                cellHeight={this.props.cellHeight || 'auto'}
-                                style={styles.gridList}
-                                spacing={this.props.gridPadding}
-                                cols={this.props.columns}
+                                key={`DashboardSection-${props.name}-Page${pageIndex}-Column${columnIndex}`}
+                                className="qa-DashboardSection-Page-Column"
+                                cellHeight={props.cellHeight || 'auto'}
+                                spacing={props.gridPadding}
+                                cols={1}
                             >
-                                {content}
+                                {childrenColumn.map((child, index) => (
+                                    <div
+                                        key={`DashboardSection-${props.name}-Page${pageIndex}-Column${columnIndex}-Item${index}`}
+                                        className="qa-DashboardSection-Page-Item"
+                                    >
+                                        {child}
+                                    </div>
+                                ))}
                             </GridList>
-                        );
-                    })}
-                </SwipeableViews>
-            );
-        } else if (this.props.noDataElement) {
-            view = this.props.noDataElement;
-        }
+                        ));
+                    }
 
-        return (
+                    return (
+                        <GridList
+                            key={`DashboardSection-${props.name}-Page${pageIndex}`}
+                            className="qa-DashboardSection-Page"
+                            cellHeight={props.cellHeight || 'auto'}
+                            style={styles.gridList}
+                            spacing={props.gridPadding}
+                            cols={props.columns}
+                        >
+                            {content}
+                        </GridList>
+                    );
+                })}
+            </SwipeableViews>
+        );
+    } else if (props.noDataElement) {
+        view = props.noDataElement;
+    }
+
+    return (
+        <div
+            style={styles.root}
+            id={`DashboardSection${props.title}`}
+            className={`qa-DashboardSection-${props.title}`}
+        >
             <div
-                style={styles.root}
-                id={`DashboardSection${this.props.title}`}
-                className={`qa-DashboardSection-${this.props.title}`}
+                className="qa-DashboardSection-Header"
+                style={styles.sectionHeader}
             >
                 <div
-                    className="qa-DashboardSection-Header"
-                    style={styles.sectionHeader}
+                    className="qa-DashboardSection-Header-Title"
+                    style={styles.sectionHeaderLeft}
                 >
-                    <div
-                        className="qa-DashboardSection-Header-Title"
-                        style={styles.sectionHeaderLeft}
-                    >
-                        {this.props.title}
-                    </div>
-                    {(childrenPages.length > 0) ?
-                        <div style={styles.sectionHeaderRight}>
-                            <Tabs
-                                onChange={this.handlePageChange}
-                                value={this.state.pageIndex}
-                                classes={{
-                                    root: classes.tabsRoot,
-                                    indicator: classes.tabsIndicator,
-                                }}
+                    {props.title}
+                </div>
+                {(childrenPages.length > 0) ?
+                    <div style={styles.sectionHeaderRight}>
+                        <Tabs
+                            onChange={handlePageChange}
+                            value={pageIndex}
+                            classes={{
+                                root: classes.tabsRoot,
+                                indicator: classes.tabsIndicator,
+                            }}
+                            data-testid={"tabsList"}
+                        >
+                            {[...Array(maxPages)].map((nothing, pageIndex) => (
+                                <Tab
+                                    key={`DashboardSection-${props.name}-Tab${pageIndex}`}
+                                    className="qa-DashboardSection-Tab"
+                                    value={pageIndex}
+                                    classes={{
+                                        root: classes.tabRoot,
+                                        selected: classes.tabSelected,
+                                        disabled: classes.tabDisabled,
+                                    }}
+                                    disabled={!(pageIndex < childrenPages.length)}
+                                />
+                            ))}
+                        </Tabs>
+                        {props.onViewAll ?
+                            <span
+                                role="button"
+                                tabIndex={0}
+                                className="qa-DashboardSection-ViewAll"
+                                style={styles.viewAll}
+                                onClick={props.onViewAll}
+                                onKeyPress={props.onViewAll}
                             >
-                                {[...Array(this.maxPages)].map((nothing, pageIndex) => (
-                                    <Tab
-                                        key={`DashboardSection-${this.props.name}-Tab${pageIndex}`}
-                                        className="qa-DashboardSection-Tab"
-                                        value={pageIndex}
-                                        classes={{
-                                            root: classes.tabRoot,
-                                            selected: classes.tabSelected,
-                                            disabled: classes.tabDisabled,
-                                        }}
-                                        disabled={!(pageIndex < childrenPages.length)}
-                                    />
-                                ))}
-                            </Tabs>
-                            {this.props.onViewAll ?
-                                <span
-                                    role="button"
-                                    tabIndex={0}
-                                    className="qa-DashboardSection-ViewAll"
-                                    style={styles.viewAll}
-                                    onClick={this.props.onViewAll}
-                                    onKeyPress={this.props.onViewAll}
-                                >
                                     View All
                                 </span>
-                                :
-                                null
-                            }
-                        </div>
-                        :
-                        null
-                    }
-                </div>
-                {view}
+                            :
+                            null
+                        }
+                    </div>
+                    :
+                    null
+                }
             </div>
-        );
-    }
-}
+            {view}
+        </div>
+    );
+};
 
 export default withWidth()(withTheme(withStyles(jss)(DashboardSection)));

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.tsx
@@ -64,9 +64,12 @@ export interface State {
 export const DashboardSection = (props: Props) => {
     let maxPages: number = 3;
     const [pageIndex, setPageIndex] = useState(0);
+    const rows = props.rows ?? 1;
+    const rowMajor = props.rowMajor ?? true;
+    const gridPadding = props.gridPadding ?? 2;
 
     const getPages = () => {
-        const itemsPerPage = props.columns * props.rows;
+        const itemsPerPage = props.columns * rows;
         // Group children into pages, each of length maxPages.
         const children = React.Children.toArray(props.children);
         const pages = [];
@@ -90,7 +93,7 @@ export const DashboardSection = (props: Props) => {
 
     const spacing = md ? 10 : 2;
     const scrollbarWidth = 6;
-    const halfGridPadding = props.gridPadding / 2;
+    const halfGridPadding = gridPadding / 2;
     const styles = {
         root: {
             marginBottom: '35px',
@@ -148,7 +151,7 @@ export const DashboardSection = (props: Props) => {
             >
                 {childrenPages.map((childrenPage, pageIndex) => {
                     let content;
-                    if (props.rowMajor) {
+                    if (rowMajor) {
                         content = childrenPage.map((child, index) => (
                             <div
                                 key={`DashboardSection-${props.name}-Page${pageIndex}-Item${index}`}
@@ -165,7 +168,7 @@ export const DashboardSection = (props: Props) => {
 
                         childrenPage.forEach((child) => {
                             column.push(child);
-                            if (column.length >= props.rows) {
+                            if (column.length >= rows) {
                                 // Filled the column. Onto the next one.
                                 childrenColumns.push(column);
                                 column = [];
@@ -182,7 +185,7 @@ export const DashboardSection = (props: Props) => {
                                 key={`DashboardSection-${props.name}-Page${pageIndex}-Column${columnIndex}`}
                                 className="qa-DashboardSection-Page-Column"
                                 cellHeight={props.cellHeight || 'auto'}
-                                spacing={props.gridPadding}
+                                spacing={gridPadding}
                                 cols={1}
                             >
                                 {childrenColumn.map((child, index) => (
@@ -203,7 +206,7 @@ export const DashboardSection = (props: Props) => {
                             className="qa-DashboardSection-Page"
                             cellHeight={props.cellHeight || 'auto'}
                             style={styles.gridList}
-                            spacing={props.gridPadding}
+                            spacing={gridPadding}
                             cols={props.columns}
                         >
                             {content}

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DataPackFeaturedItem.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DataPackFeaturedItem.tsx
@@ -1,8 +1,5 @@
-import * as PropTypes from 'prop-types';
-import { Component } from 'react';
 import { connect } from 'react-redux';
 import { withTheme, Theme, withStyles, createStyles, StyledComponentProps } from '@material-ui/core/styles';
-import withWidth from '@material-ui/core/withWidth';
 import { Link } from 'react-router-dom';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
@@ -10,8 +7,10 @@ import CardContent from '@material-ui/core/CardContent';
 import moment from 'moment';
 import { makeFullRunSelector } from '../../selectors/runSelector';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
-import {MapView} from "../common/MapView";
-import {MapLayer} from "../CreateDataPack/CreateExport";
+import { MapView } from "../common/MapView";
+import { MapLayer } from "../CreateDataPack/CreateExport";
+import { useAppContext } from "../ApplicationContext";
+import * as React from "react";
 
 const jss = (theme: Eventkit.Theme & Theme) => createStyles({
     card: {
@@ -140,99 +139,91 @@ interface StateProps {
 
 export type Props = StyledComponentProps & OwnProps & StateProps;
 
-export class DataPackFeaturedItem extends Component<Props, {}> {
-    static contextTypes = {
-        config: PropTypes.object,
+export const DataPackFeaturedItem = (props: Props) => {
+    const { BASEMAP_COPYRIGHT, BASEMAP_URL } = useAppContext();
+
+    const  getMapId = () => {
+            let mapId = '';
+            if (props.gridName !== undefined) {
+                mapId += `${props.gridName}_`;
+            }
+            mapId += `${props.run.uid}_`;
+            if (props.index !== undefined) {
+                mapId += `${props.index}_`;
+            }
+            mapId += 'map';
+
+            return mapId;
     };
 
-    constructor(props: Props) {
-        super(props);
-        this.getMapId = this.getMapId.bind(this);
-    }
+    const { classes } = props;
+    const selectedBasemap = { mapUrl: BASEMAP_URL } as MapLayer;
 
-    private getMapId() {
-        let mapId = '';
-        if (this.props.gridName !== undefined) {
-            mapId += `${this.props.gridName}_`;
-        }
-        mapId += `${this.props.run.uid}_`;
-        if (this.props.index !== undefined) {
-            mapId += `${this.props.index}_`;
-        }
-        mapId += 'map';
-
-        return mapId;
-    }
-
-    render() {
-        const { classes } = this.props;
-        const selectedBasemap = { mapUrl: this.context.config.BASEMAP_URL } as MapLayer;
-
-        return (
-            <Card
-                className={classes.card}
-                style={{ height: this.props.height }}
-                key={this.props.run.uid}
-            >
-                <div className={classes.content} style={{ height: this.props.height }}>
-                    <div className={classes.map}>
-                        <MapView
-                            id={this.getMapId()}
-                            selectedBaseMap={selectedBasemap}
-                            copyright={this.context.config.BASEMAP_COPYRIGHT}
-                            geojson={this.props.run.job.extent}
-                            minZoom={2}
-                            maxZoom={20}
-                        />
-                    </div>
-                    <div className={classes.info}>
-                        <CardHeader
-                            className={classes.cardHeader}
-                            title={
-                                <div>
-                                    <div className={classes.cardTitle}>
-                                        <Link
-                                            to={`/status/${this.props.run.job.uid}`}
-                                            href={`/status/${this.props.run.job.uid}`}
-                                            className={classes.titleLink}
-                                        >
-                                            {this.props.run.job.name}
-                                        </Link>
-                                    </div>
-                                </div>
-                            }
-                            subheader={
-                                <div className={classes.cardSubtitle}>
-                                    <div
-                                        className="qa-DataPackFeaturedItem-Subtitle-Event"
-                                        style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                                    >
-                                        {`Event: ${this.props.run.job.event}`}
-                                    </div>
-                                    <span className="qa-DataPackFeaturedItem-Subtitle-Added">
-                                        {`Added: ${moment(this.props.run.created_at).format('M/D/YY')}`}
-                                    </span>
-                                    <br />
-                                    <span className="qa-DataPackFeaturedItem-Subtitle-Expires">
-                                        {`Expires: ${moment(this.props.run.expiration).format('M/D/YY')}`}
-                                    </span>
-                                    <br />
-                                </div>
-                            }
-                        />
-                        <CardContent
-                            className={classes.cardTextContainer}
-                        >
-                            <span className={classes.cardText}>
-                                {this.props.run.job.description}
-                            </span>
-                        </CardContent>
-                    </div>
+    console.log(`Props: ${props.run}`);
+    return (
+        <Card
+            className={classes.card}
+            style={{ height: props.height }}
+            key={props.run.uid}
+        >
+            <div className={classes.content} style={{ height: props.height }}>
+                <div className={classes.map}>
+                    <MapView
+                        id={getMapId()}
+                        selectedBaseMap={selectedBasemap}
+                        copyright={BASEMAP_COPYRIGHT}
+                        geojson={props.run.job.extent}
+                        minZoom={2}
+                        maxZoom={20}
+                    />
                 </div>
-            </Card>
-        );
-    }
-}
+                <div className={classes.info}>
+                    <CardHeader
+                        className={classes.cardHeader}
+                        title={
+                            <div>
+                                <div className={classes.cardTitle}>
+                                    <Link
+                                        to={`/status/${props.run.job.uid}`}
+                                        href={`/status/${props.run.job.uid}`}
+                                        className={classes.titleLink}
+                                    >
+                                        {props.run.job.name}
+                                    </Link>
+                                </div>
+                            </div>
+                        }
+                        subheader={
+                            <div className={classes.cardSubtitle}>
+                                <div
+                                    className="qa-DataPackFeaturedItem-Subtitle-Event"
+                                    style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                                >
+                                    {`Event: ${props.run.job.event}`}
+                                </div>
+                                <span className="qa-DataPackFeaturedItem-Subtitle-Added">
+                                        {`Added: ${moment(props.run.created_at).format('M/D/YY')}`}
+                                    </span>
+                                <br />
+                                <span className="qa-DataPackFeaturedItem-Subtitle-Expires">
+                                        {`Expires: ${moment(props.run.expiration).format('M/D/YY')}`}
+                                    </span>
+                                <br />
+                            </div>
+                        }
+                    />
+                    <CardContent
+                        className={classes.cardTextContainer}
+                    >
+                            <span className={classes.cardText}>
+                                {props.run.job.description}
+                            </span>
+                    </CardContent>
+                </div>
+            </div>
+        </Card>
+    );
+};
 
 const makeMapStateToProps = () => {
     const getFullRun = makeFullRunSelector();
@@ -244,7 +235,4 @@ const makeMapStateToProps = () => {
     return mapStateToProps;
 };
 
-export default withWidth()(
-    withTheme(
-        withStyles(jss)(
-            connect(makeMapStateToProps)(DataPackFeaturedItem))));
+export default withTheme(withStyles(jss)(connect(makeMapStateToProps)(DataPackFeaturedItem)));

--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DataPackFeaturedItem.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DataPackFeaturedItem.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { connect } from 'react-redux';
 import { withTheme, Theme, withStyles, createStyles, StyledComponentProps } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
@@ -6,11 +7,9 @@ import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
 import moment from 'moment';
 import { makeFullRunSelector } from '../../selectors/runSelector';
-import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import { MapView } from "../common/MapView";
 import { MapLayer } from "../CreateDataPack/CreateExport";
 import { useAppContext } from "../ApplicationContext";
-import * as React from "react";
 
 const jss = (theme: Eventkit.Theme & Theme) => createStyles({
     card: {
@@ -130,7 +129,6 @@ interface OwnProps {
     index: number;
     height?: string;
     theme: Eventkit.Theme & Theme;
-    width: Breakpoint;
 }
 
 interface StateProps {
@@ -159,7 +157,6 @@ export const DataPackFeaturedItem = (props: Props) => {
     const { classes } = props;
     const selectedBasemap = { mapUrl: BASEMAP_URL } as MapLayer;
 
-    console.log(`Props: ${props.run}`);
     return (
         <Card
             className={classes.card}

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGrid.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGrid.tsx
@@ -1,5 +1,5 @@
 import withWidth, {isWidthUp} from '@material-ui/core/withWidth';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import DataPackGridItem from './DataPackGridItem';
 import CustomScrollbar from '../common/CustomScrollbar';
 import LoadButtons from '../common/LoadButtons';
@@ -67,11 +67,11 @@ export function DataPackGrid(props: Props) {
             style={{height: 'calc(100vh - 236px)', width: '100%'}}
         >
             <div style={styles.root} className="qa-div-root">
-                <GridList
+                <ImageList
                     className="qa-DataPackGrid-GridList"
-                    cellHeight="auto"
+                    rowHeight="auto"
                     style={styles.gridList}
-                    spacing={isWidthUp('md', props.width) ? 7 : 2}
+                    gap={isWidthUp('md', props.width) ? 7 : 2}
                     cols={getColumns()}
                 >
                     {props.runIds.map((id, index) => (
@@ -88,7 +88,7 @@ export function DataPackGrid(props: Props) {
                             showFeaturedFlag
                         />
                     ))}
-                </GridList>
+                </ImageList>
             </div>
             <LoadButtons
                 range={props.range}

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackList.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackList.tsx
@@ -5,7 +5,7 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import NavigationArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import NavigationArrowDropUp from '@material-ui/icons/ArrowDropUp';
 import DataPackListItem from './DataPackListItem';
@@ -155,11 +155,11 @@ export class DataPackList extends Component<Props, {}> {
                     style={{ height: 'calc(100vh - 236px)', width: '100%' }}
                 >
                     <div style={styles.root} className="qa-DataPackList-root">
-                        <GridList
+                        <ImageList
                             className="qa-DataPackList-GridList"
-                            cellHeight="auto"
+                            rowHeight="auto"
                             cols={1}
-                            spacing={0}
+                            gap={0}
                             style={{ width: '100%', minWidth: '360px' }}
                         >
                             {this.props.runIds.map(id => (
@@ -173,7 +173,7 @@ export class DataPackList extends Component<Props, {}> {
                                 />
                             ))}
                             {load}
-                        </GridList>
+                        </ImageList>
                     </div>
                 </ScrollBarRefWrap>
             );

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.tsx
@@ -3,7 +3,7 @@ import { Component, useEffect, useState } from 'react';
 import {connect} from 'react-redux';
 import {withTheme, Theme} from '@material-ui/core/styles';
 import withWidth, {isWidthUp} from '@material-ui/core/withWidth';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import Dot from '@material-ui/icons/FiberManualRecord';
 import axios from 'axios';
 import Map from 'ol/Map';
@@ -1018,11 +1018,11 @@ export class MapView extends Component<Props, State> {
             <div style={{height: 'calc(100vh - 236px)'}}>
                 <ScrollBarRefWrap style={styles.list} setScrollbar={this.props.setScrollbar}>
                     <div style={styles.root}>
-                        <GridList
+                        <ImageList
                             className="qa-MapView-GridList"
-                            cellHeight="auto"
+                            rowHeight="auto"
                             cols={1}
-                            spacing={0}
+                            gap={0}
                             style={{width: '100%'}}
                         >
                             {this.props.runIds.map(id => (
@@ -1037,7 +1037,7 @@ export class MapView extends Component<Props, State> {
                                     providers={this.props.providers}
                                 />
                             ))}
-                        </GridList>
+                        </ImageList>
                     </div>
                     {load}
                 </ScrollBarRefWrap>

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationGridItem.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationGridItem.js
@@ -10,7 +10,6 @@ import { getNotificationViewPath } from '../../utils/notificationUtils';
 import NotificationMessage from './NotificationMessage';
 import NotificationIcon from './NotificationIcon';
 import NotificationMenu from './NotificationMenu';
-import * as React from "react";
 
 export class NotificationGridItem extends Component {
     constructor(props) {
@@ -70,8 +69,11 @@ export class NotificationGridItem extends Component {
         };
 
         return (
-            <div className="qa-NotificationGridItem" style={this.props.style}
-                 data-testid={"notification"}>
+            <div
+                className="qa-NotificationGridItem"
+                style={this.props.style}
+                data-testid="notification"
+            >
                 <Paper style={styles.root}>
                     <NotificationIcon notification={this.props.notification} />
                     <NotificationMessage

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationGridItem.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationGridItem.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { withTheme } from '@material-ui/core/styles';
-import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
+import { isWidthUp } from '@material-ui/core/withWidth';
 import moment from 'moment';
 import Paper from '@material-ui/core/Paper';
 import { markNotificationsAsRead, markNotificationsAsUnread, removeNotifications } from '../../actions/notificationsActions';
@@ -10,6 +10,7 @@ import { getNotificationViewPath } from '../../utils/notificationUtils';
 import NotificationMessage from './NotificationMessage';
 import NotificationIcon from './NotificationIcon';
 import NotificationMenu from './NotificationMenu';
+import * as React from "react";
 
 export class NotificationGridItem extends Component {
     constructor(props) {
@@ -69,7 +70,8 @@ export class NotificationGridItem extends Component {
         };
 
         return (
-            <div className="qa-NotificationGridItem" style={this.props.style}>
+            <div className="qa-NotificationGridItem" style={this.props.style}
+                 data-testid={"notification"}>
                 <Paper style={styles.root}>
                     <NotificationIcon notification={this.props.notification} />
                     <NotificationMessage
@@ -128,4 +130,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default withWidth()(withTheme(connect(null, mapDispatchToProps)(NotificationGridItem)));
+export default withTheme(connect(null, mapDispatchToProps)(NotificationGridItem));

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsDropdown.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsDropdown.js
@@ -5,7 +5,7 @@ import { withTheme } from '@material-ui/core/styles';
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import Paper from '@material-ui/core/Paper';
 import NotificationGridItem from './NotificationGridItem';
 import { markAllNotificationsAsRead } from '../../actions/notificationsActions';
@@ -116,11 +116,11 @@ export class NotificationsDropdown extends Component {
             );
         } else if (notifications.length > 0) {
             body = (
-                <GridList
+                <ImageList
                     className="qa-NotificationsDropdown-Grid"
-                    cellHeight="auto"
+                    rowHeight="auto"
                     style={styles.gridList}
-                    spacing={0}
+                    gap={0}
                     cols={1}
                 >
                     {notifications.map((notification, index) => (
@@ -135,7 +135,7 @@ export class NotificationsDropdown extends Component {
                             onView={this.props.onNavigate}
                         />
                     ))}
-                </GridList>
+                </ImageList>
             );
         }
 

--- a/eventkit_cloud/ui/static/ui/app/components/NotificationsPage/NotificationsPage.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/NotificationsPage/NotificationsPage.tsx
@@ -3,7 +3,7 @@ import { Component } from 'react';
 import {connect} from 'react-redux';
 import {Theme, withTheme} from '@material-ui/core/styles';
 import withWidth, {isWidthUp} from '@material-ui/core/withWidth';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import Paper from '@material-ui/core/Paper';
 import PageHeader from '../common/PageHeader';
 import PageLoading from '../common/PageLoading';
@@ -203,11 +203,11 @@ export class NotificationsPage extends Component<Props, State> {
                                                     />
                                                 )
                                                 : (
-                                                    <GridList
+                                                    <ImageList
                                                         className="qa-NotificationsPage-Content-Notifications-Grid"
-                                                        cellHeight="auto"
+                                                        rowHeight="auto"
                                                         style={styles.gridList}
-                                                        spacing={2}
+                                                        gap={2}
                                                         cols={1}
                                                     >
                                                         {notifications.map(notification => (
@@ -217,7 +217,7 @@ export class NotificationsPage extends Component<Props, State> {
                                                                 history={this.props.history}
                                                             />
                                                         ))}
-                                                    </GridList>
+                                                    </ImageList>
                                                 )
                                             }
                                             <LoadButtons

--- a/eventkit_cloud/ui/static/ui/app/components/PermissionsBanner.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/PermissionsBanner.tsx
@@ -59,7 +59,7 @@ function PermissionsBanner(props: Props) {
     return (
         <>
             <Paper elevation={0} className={classes.paper}>
-                <Grid container spacing={8} justify="space-between">
+                <Grid container spacing={8} justifyContent="space-between">
                     <Grid item xs={10}>
                         <div className={(!isOpen) ? classes.nonExpandedText : classes.expandedText}>
                             Some sources may have been limited based on your permissions. If you believe this is an

--- a/eventkit_cloud/ui/static/ui/app/index.tsx
+++ b/eventkit_cloud/ui/static/ui/app/index.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import { MuiThemeProvider, createTheme } from '@material-ui/core/styles';
 import Loadable from 'react-loadable';
 import { Route } from 'react-router';
 import { ConnectedRouter } from 'connected-react-router';
@@ -21,7 +21,7 @@ axios.interceptors.response.use(function (response) {
     }
 });
 
-const theme = createMuiTheme(ekTheme);
+const theme = createTheme(ekTheme);
 
 const Loading = (args) => {
     if (args.pastDelay) {

--- a/eventkit_cloud/ui/static/ui/app/styles/eventkit_theme.js
+++ b/eventkit_cloud/ui/static/ui/app/styles/eventkit_theme.js
@@ -147,7 +147,7 @@ export const theme = {
                 },
                 color: colors.grey,
             },
-            selected: {
+            '&$selected': {
                 color: colors.primary,
                 backgroundColor: colors.selected_primary,
             },

--- a/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DashboardPage.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DashboardPage.spec.tsx
@@ -338,16 +338,12 @@ describe('DashboardPage component', () => {
         afterEach(() => {
             jest.useRealTimers();
         });
-        it('renders Notifications section', async () => {
-            await waitFor(() => {
-                expect(screen.queryByText("Notifications")).not.toBeNull();
-            });
+        it('renders Notifications section', () => {
+            expect(screen.getByText("Notifications"));
         });
 
-        it('renders Recently Viewed section', async () => {
-            await waitFor(() => {
-                expect(screen.queryByText("Recently Viewed")).not.toBeNull();
-            });
+        it('renders Recently Viewed section',  () => {
+            expect(screen.getByText("Recently Viewed"));
         });
 
         it('renders Featured section', () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DashboardPage.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DashboardPage.spec.tsx
@@ -1,17 +1,24 @@
-import { shallow } from 'enzyme';
+import * as React from "react";
 import * as sinon from 'sinon';
-import PageLoading from '../../components/common/PageLoading';
+import { screen, fireEvent, within, waitFor } from '@testing-library/react';
+import "@testing-library/jest-dom/extend-expect";
+import * as TestUtils from '../test-utils';
+
+jest.doMock("../../components/DataPackPage/DataPackGridItem", () => {
+    return (props) => (<div className="gridItem" data-testid={props['data-testid']}>{props.children}</div>);
+});
+
+jest.doMock("../../components/DashboardPage/DataPackFeaturedItem", () => {
+    return (props) => (<div className="gridItem" data-testid={props['data-testid']}>{props.children}</div>);
+});
+
 import { DashboardPage } from '../../components/DashboardPage/DashboardPage';
-import DataPackShareDialog from '../../components/DataPackShareDialog/DataPackShareDialog';
-import DashboardSection from '../../components/DashboardPage/DashboardSection';
-import NotificationGridItem from '../../components/Notification/NotificationGridItem';
-import DataPackGridItem from '../../components/DataPackPage/DataPackGridItem';
-import DataPackFeaturedItem from '../../components/DashboardPage/DataPackFeaturedItem';
 import history from '../../utils/history';
+
 
 const mockNotifications = {
     1: {
-        id: '1',
+        id: 1,
         verb: 'run_started',
         actor: {
             details: {
@@ -24,7 +31,7 @@ const mockNotifications = {
         unread: false,
     },
     2: {
-        id: '2',
+        id: 2,
         verb: 'run_completed',
         actor: {
             details: {
@@ -65,9 +72,114 @@ const mockRuns = [
     },
 ];
 
+const user = {
+    data: {
+        user: {
+            username: 'admin'
+        }
+    },
+    meta: {
+        autoLogoutAt: null,
+        autoLogoutWarningAt: null,
+    },
+    status: {
+        patched: false,
+        patching: false,
+        error: null,
+        isLoading: false,
+    },
+};
+
+const mockExports = {
+    data: {
+        runs: {
+            '6870234f-d876-467c-a332-65fdf0399a0d': {
+                uid: '6870234f-d876-467c-a332-65fdf0399a0d',
+                created_at: '2017-03-10T15:52:35.637331Z',
+                job: '7643f806-1484-4446-b498-7ddaa65d011a',
+                expiration: '2017-03-24T15:52:35.637258Z',
+                extent: {type: 'FeatureCollection', features: []}
+            }
+        },
+        jobs: {
+            '7643f806-1484-4446-b498-7ddaa65d011a': {
+                uid: '7643f806-1484-4446-b498-7ddaa65d011a',
+                name: 'Test1',
+                event: 'Test1 event',
+                description: 'Test1 description',
+                extent: {type: 'FeatureCollection', features: []}
+            }
+        }
+    },
+    viewedInfo: {
+        ids: mockRuns.map(run => run.uid)
+    },
+    featuredInfo: {
+        ids: mockRuns.map(run => run.uid)
+    },
+    ownInfo: {
+        ids: mockRuns.map(run => run.uid)
+    }
+};
+
+
 describe('DashboardPage component', () => {
-    let wrapper;
-    let instance;
+    const getInitialState = (defaultState) => (
+        {
+            ...defaultState,
+            aoiInfo: {
+                geojson: {},
+            },
+            exportInfo: {
+                exportName: '',
+                datapackDescription: '',
+                projectName: '',
+                providers: [],
+                providerInfo: {
+                    'osm': {
+                        availability: {
+                            status: 'STAT'
+                        },
+                    }
+                },
+                exportOptions: {
+                    '123': {
+                        minZoom: 0,
+                        maxZoom: 2,
+                    }
+                },
+                projections: [],
+            },
+            user,
+            topics: [],
+            exports: mockExports,
+            notifications: {
+                data: {
+                    notifications: mockNotifications,
+                    notificationsSorted: [],
+                },
+                status: {
+                    fetching: null,
+                    fetched: null,
+                    deleting: null,
+                    deleted: null,
+                    error: null,
+                    cancelSource: null,
+                },
+                unreadCount: {
+                    status: {
+                        fetching: null,
+                        fetched: null,
+                        error: null,
+                        cancelSource: null,
+                    },
+                    data: {
+                        unreadCount: 0,
+                    },
+                },
+            }
+        }
+    );
 
     function defaultProps() {
         return {
@@ -116,25 +228,12 @@ describe('DashboardPage component', () => {
             getProviders: sinon.spy(),
             getNotifications: sinon.spy(),
             ...(global as any).eventkit_test_props,
-        };
-    }
-
-    function setup(propsOverride = {}) {
-        const props = {
-            ...defaultProps(),
-            ...propsOverride,
-        };
-        wrapper = shallow(<DashboardPage {...props} />);
-        instance = wrapper.instance();
-
-        instance.joyride = {
-            reset: sinon.spy(),
+            history,
         };
     }
 
     function loadEmptyData() {
-        wrapper.setProps({
-            ...instance.props,
+        return {
             ownIds: [],
             runsFetched: true,
             featuredIds: [],
@@ -158,13 +257,11 @@ describe('DashboardPage component', () => {
                 fetched: true,
                 groups: {},
             },
-        });
+        };
     }
 
-    function loadData() {
-        wrapper.setProps({
-
-            ...instance.props,
+    function loadedProps() {
+        return {
             ownIds: mockRuns.map(run => run.uid),
             runsFetched: true,
             featuredIds: mockRuns.map(run => run.uid),
@@ -190,242 +287,125 @@ describe('DashboardPage component', () => {
                 fetching: false,
                 fetched: true,
             },
-        });
+            runDeletion: {
+                deleting: false
+            },
+            updatePermission: {
+                updating: false
+            }
+        };
     }
 
-    beforeEach(setup);
-
-    it('joyrideAddSteps should set state for steps in tour', () => {
-        const steps = [
-            {
-                text: 'im the step',
-            },
-        ];
-        const stateStub = sinon.stub(instance, 'setState');
-        instance.joyrideAddSteps(steps);
-        expect(stateStub.calledOnce).toBe(true);
-        expect(stateStub.calledWith({ steps }));
-        stateStub.restore();
-    });
-
-    it('callback function stops tour if close is clicked', () => {
-        const callbackData = {
-            action: 'close',
-            index: 2,
-            step: {
-                position: 'bottom',
-                selector: '.select',
-                style: {},
-                text: 'Click here to Navigate to Create a DataPack.',
-                title: 'Create DataPack',
-            },
-            type: 'step:before',
-        };
-        const stateSpy = sinon.stub(DashboardPage.prototype, 'setState');
-        instance.callback(callbackData);
-        expect(stateSpy.calledWith({ isRunning: false }));
-        stateSpy.restore();
-    });
-
-    it('callback sets location hash if step has a scrollToId', () => {
-        const callbackData = {
-            action: 'next',
-            index: 3,
-            step: {
-                scrollToId: 'test-id',
-                position: 'bottom',
-                selector: '.select',
-                style: {},
-                text: 'Click here to Navigate to Create a DataPack.',
-                title: 'Create DataPack',
-            },
-            type: 'step:before',
-        };
-        expect(window.location.hash).toEqual('');
-        instance.callback(callbackData);
-        expect(window.location.hash).toEqual('#test-id');
-    });
-
     describe('when it mounts', () => {
-        let refreshSpy;
-
         beforeEach(() => {
-            refreshSpy = sinon.spy(DashboardPage.prototype, 'refresh');
             jest.useFakeTimers();
-            setup();
-            instance.componentDidMount();
         });
-
         afterEach(() => {
-            refreshSpy.restore();
+            jest.useRealTimers();
         });
-
         it('requests providers', () => {
-            expect(instance.props.getProviders.callCount).toBe(2);
+            const props = {
+                ...defaultProps(),
+            };
+            TestUtils.renderComponent(<DashboardPage {...props} />);
+            expect(props.getProviders.callCount).toBe(1);
         });
 
         it('requests notifications', () => {
-            expect(instance.props.getNotifications.callCount).toBe(2);
-        });
-
-        it('refreshes the page periodically', () => {
-            expect(instance.autoRefreshIntervalId).not.toBe(null);
-            expect(refreshSpy.callCount).toBe(2);
-            jest.runOnlyPendingTimers();
-            expect(refreshSpy.callCount).toBe(4);
-            jest.runOnlyPendingTimers();
-            expect(refreshSpy.callCount).toBe(6);
-            jest.runOnlyPendingTimers();
-            expect(refreshSpy.callCount).toBe(8);
-        });
-
-        describe('then it unmounts', () => {
-            beforeEach(() => {
-                instance.componentWillUnmount();
-            });
-
-            it('stops auto refreshing', () => {
-                expect(instance.autoRefreshIntervalId).toBe(undefined);
-                expect(refreshSpy.callCount).toBe(2);
-                jest.runOnlyPendingTimers();
-                expect(refreshSpy.callCount).toBe(3);
-            });
-        });
-    });
-
-    describe('initial state', () => {
-        it('renders loading spinner', () => {
-            expect(wrapper.find(PageLoading)).toHaveLength(1);
-        });
-
-        it('does not render any dashboard sections', () => {
-            expect(wrapper.find(DashboardSection)).toHaveLength(0);
-        });
-
-        it('does not render share dialog', () => {
-            expect(wrapper.find(DataPackShareDialog)).toHaveLength(0);
+            const props = {
+                ...defaultProps(),
+            };
+            TestUtils.renderComponent(<DashboardPage {...props} />);
+            expect(props.getNotifications.callCount).toBe(2);
         });
     });
 
     describe('when data has loaded', () => {
         beforeEach(() => {
-            loadData();
+            jest.useFakeTimers();
+            const props = {
+                ...defaultProps(),
+                ...loadedProps(),
+            };
+            const defaultState = TestUtils.getDefaultTestState();
+            const initialState = getInitialState(defaultState);
+            TestUtils.renderComponent(<DashboardPage {...props} />, {
+                includeToastContainer: false,
+                initialState,
+            });
+            jest.runOnlyPendingTimers();
+        });
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+        it('renders Notifications section', async () => {
+            await waitFor(() => {
+                expect(screen.queryByText("Notifications")).not.toBeNull();
+            });
         });
 
-        it('does not render loading spinner', () => {
-            expect(wrapper.find(PageLoading)).toHaveLength(0);
-        });
-
-        it('renders Notifications section', () => {
-            expect(wrapper.find('.qa-DashboardSection-Notifications')).toHaveLength(1);
-        });
-
-        it('renders Recently Viewed section', () => {
-            expect(wrapper.find('.qa-DashboardSection-RecentlyViewed')).toHaveLength(1);
+        it('renders Recently Viewed section', async () => {
+            await waitFor(() => {
+                expect(screen.queryByText("Recently Viewed")).not.toBeNull();
+            });
         });
 
         it('renders Featured section', () => {
-            expect(wrapper.find('.qa-DashboardSection-Featured')).toHaveLength(1);
+            expect(screen.getByText("Featured"));
         });
 
         it('renders My DataPacks section', () => {
-            expect(wrapper.find('.qa-DashboardSection-MyDataPacks')).toHaveLength(1);
+            expect(screen.getByText("My DataPacks"));
         });
 
         it('renders notifications', () => {
-            const notificationItems = wrapper.find('.qa-DashboardSection-Notifications').children().find(NotificationGridItem);
-            const notificationsSorted = instance.props.notificationsData.notificationsSorted;
-            expect(notificationItems).not.toHaveLength(0);
-            expect(notificationItems).toHaveLength(notificationsSorted.length);
-            notificationsSorted.forEach((notification, i) => {
-                expect(notificationItems.at(i).props().notification).toBe(notificationsSorted[i]);
-            });
+            const notifications = screen.getAllByTestId("notification");
+            expect(notifications).not.toHaveLength(0);
+            expect(notifications).toHaveLength(Object.keys(mockNotifications).length);
         });
 
         it('renders recently viewed datapacks', () => {
-            const recentlyViewedItems = wrapper.find('.qa-DashboardSection-RecentlyViewed').children().find(DataPackGridItem);
-            const viewedJobs = instance.props.viewedIds;
-            expect(recentlyViewedItems).not.toHaveLength(0);
-            expect(recentlyViewedItems).toHaveLength(viewedJobs.length);
-            viewedJobs.forEach((id, i) => {
-                expect(recentlyViewedItems.at(i).props().runId).toBe(id);
-            });
+            const viewedItems = screen.getAllByTestId("viewed");
+            expect(viewedItems).not.toHaveLength(0);
+            expect(viewedItems).toHaveLength(mockRuns.length);
         });
 
         it('renders featured datapacks', () => {
-            const featuredItems = wrapper.find('.qa-DashboardSection-Featured').children().find(DataPackFeaturedItem);
-            const featuredRuns = instance.props.featuredIds;
+            const featuredItems = screen.getAllByTestId("featured");
             expect(featuredItems).not.toHaveLength(0);
-            expect(featuredItems).toHaveLength(featuredRuns.length);
-            featuredRuns.forEach((id, i) => {
-                expect(featuredItems.at(i).props().runId).toBe(id);
-            });
+            expect(featuredItems).toHaveLength(mockRuns.length);
         });
 
         it('renders my datapacks', () => {
-            const myDataPacksItems = wrapper.find('.qa-DashboardSection-MyDataPacks').children().find(DataPackGridItem);
-            const runs = instance.props.ownIds;
+            const myDataPacksItems = screen.getAllByTestId("pack");
             expect(myDataPacksItems).not.toHaveLength(0);
-            expect(myDataPacksItems).toHaveLength(runs.length);
-            runs.forEach((id, i) => {
-                expect(myDataPacksItems.at(i).props().runId).toBe(id);
-            });
-        });
-
-        it('does not render Notifications "no data" element', () => {
-            const notificationsSection = wrapper.find('.qa-DashboardSection-Notifications').shallow();
-            expect(notificationsSection.find('.qa-DashboardSection-Notifications-NoData')).toHaveLength(0);
-        });
-
-        it('does not render Recently Viewed "no data" element', () => {
-            const recentlyViewedSection = wrapper.find('.qa-DashboardSection-RecentlyViewed').shallow();
-            expect(recentlyViewedSection.find('.qa-DashboardSection-RecentlyViewed-NoData')).toHaveLength(0);
-        });
-
-        it('does not render My DataPacks "no data" element', () => {
-            const myDataPacksSection = wrapper.find('.qa-DashboardSection-MyDataPacks').shallow();
-            expect(myDataPacksSection.find('.qa-DashboardSection-MyDataPacks-NoData')).toHaveLength(0);
+            expect(myDataPacksItems).toHaveLength(mockRuns.length);
         });
     });
 
     describe('when empty data has loaded', () => {
         beforeEach(() => {
-            loadEmptyData();
-        });
-
-        it('should not be loading', () => {
-            expect(instance.isLoading()).toBe(false);
-        });
-
-        it('does not render loading spinner', () => {
-            expect(wrapper.find(PageLoading)).toHaveLength(0);
+            const props = {
+                ...defaultProps(),
+                ...loadEmptyData(),
+            };
+            TestUtils.renderComponent(<DashboardPage {...props} />);
         });
 
         it('renders Notifications section', () => {
-            expect(wrapper.find('.qa-DashboardSection-Notifications')).toHaveLength(1);
+            expect(screen.getByText("Notifications"));
         });
 
         it('renders Recently Viewed section', () => {
-            expect(wrapper.find('.qa-DashboardSection-RecentlyViewed')).toHaveLength(1);
+            expect(screen.getByText("Recently Viewed"));
         });
 
         it('does not render Featured section', () => {
-            expect(wrapper.find('.qa-DashboardSection-Featured')).toHaveLength(0);
+            expect(screen.queryByText("Featured")).toBeNull();
         });
 
         it('renders My DataPacks section', () => {
-            expect(wrapper.find('.qa-DashboardSection-MyDataPacks')).toHaveLength(1);
-        });
-    });
-
-    describe('when automatically refreshing', () => {
-        beforeEach(() => {
-            loadData();
-            instance.autoRefresh();
-        });
-
-        it('does not render loading spinner', () => {
-            expect(wrapper.find(PageLoading)).toHaveLength(0);
+            expect(screen.getByText("My DataPacks"));
         });
     });
 
@@ -434,7 +414,11 @@ describe('DashboardPage component', () => {
 
         beforeEach(() => {
             browserHistoryPushStub = sinon.stub(history, 'push');
-            instance.handleNotificationsViewAll();
+            const props = {
+                ...defaultProps(),
+                ...loadedProps(),
+            };
+            TestUtils.renderComponent(<DashboardPage {...props} />);
         });
 
         afterEach(() => {
@@ -442,6 +426,9 @@ describe('DashboardPage component', () => {
         });
 
         it('navigates to "/notifications"', () => {
+            const nEle = screen.getByText("Notifications");
+            const vAll = within(nEle.parentElement).getByText("View All");
+            fireEvent.click(vAll);
             expect(browserHistoryPushStub.callCount).toBe(1);
             expect(browserHistoryPushStub.calledWith('/notifications')).toBe(true);
         });
@@ -451,8 +438,13 @@ describe('DashboardPage component', () => {
         let browserHistoryPushStub;
 
         beforeEach(() => {
+            jest.useFakeTimers();
             browserHistoryPushStub = sinon.stub(history, 'push');
-            instance.handleFeaturedViewAll();
+            const props = {
+                ...defaultProps(),
+                ...loadedProps(),
+            };
+            TestUtils.renderComponent(<DashboardPage {...props} />);
         });
 
         afterEach(() => {
@@ -460,6 +452,9 @@ describe('DashboardPage component', () => {
         });
 
         it('navigates to "/exports"', () => {
+            const nEle = screen.getByText("Featured");
+            const vAll = within(nEle.parentElement).getByText("View All");
+            fireEvent.click(vAll);
             expect(browserHistoryPushStub.callCount).toBe(1);
             expect(browserHistoryPushStub.calledWith('/exports')).toBe(true);
         });
@@ -469,8 +464,13 @@ describe('DashboardPage component', () => {
         let browserHistoryPushStub;
 
         beforeEach(() => {
+            jest.useFakeTimers();
             browserHistoryPushStub = sinon.stub(history, 'push');
-            instance.handleMyDataPacksViewAll();
+            const props = {
+                ...defaultProps(),
+                ...loadedProps(),
+            };
+            TestUtils.renderComponent(<DashboardPage {...props} />);
         });
 
         afterEach(() => {
@@ -478,69 +478,11 @@ describe('DashboardPage component', () => {
         });
 
         it('navigates to "/exports?collection=myDataPacks"', () => {
+            const nEle = screen.getByText("My DataPacks");
+            const vAll = within(nEle.parentElement).getByText("View All");
+            fireEvent.click(vAll);
             expect(browserHistoryPushStub.callCount).toBe(1);
             expect(browserHistoryPushStub.calledWith('/exports?collection=admin')).toBe(true);
-        });
-    });
-
-    describe('when a datapack is being deleted', () => {
-        let setupA;
-
-        beforeEach(() => {
-            setupA = () => {
-                loadData();
-                instance.refresh = sinon.spy();
-                wrapper.setProps({
-                    runDeletion: {
-                        deleting: true,
-                        deleted: false,
-                    },
-                });
-            };
-            setupA();
-        });
-
-        it('renders loading spinner', () => {
-            expect(wrapper.find(PageLoading)).toHaveLength(1);
-        });
-
-        describe('then it is successfully deleted', () => {
-            beforeEach(() => {
-                setupA();
-                wrapper.setProps({
-                    runDeletion: {
-                        deleting: false,
-                        deleted: true,
-                    },
-                });
-            });
-
-            it('does not render loading spinner', () => {
-                expect(wrapper.find(PageLoading)).toHaveLength(0);
-            });
-
-            it('refreshes the page', () => {
-                expect(instance.refresh.callCount).toBe(1);
-            });
-        });
-    });
-
-    describe('when permissions are updated', () => {
-        beforeEach(() => {
-            instance.refresh = sinon.spy();
-            wrapper.setProps({
-                updatePermission: {
-                    updated: true,
-                },
-            });
-        });
-
-        it('refreshes page', () => {
-            expect(instance.refresh.callCount).toBe(1);
-        });
-
-        it('renders loading spinner', () => {
-            expect(wrapper.find(PageLoading)).toHaveLength(1);
         });
     });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DashboardSection.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DashboardSection.spec.tsx
@@ -1,14 +1,10 @@
-import { shallow } from 'enzyme';
 import * as sinon from 'sinon';
-import Tab from '@material-ui/core/Tab';
-import Tabs from '@material-ui/core/Tabs';
-import SwipeableViews from 'react-swipeable-views';
+import { screen, fireEvent } from '@testing-library/react';
+import "@testing-library/jest-dom/extend-expect";
+import * as TestUtils from '../test-utils';
 import { DashboardSection } from '../../components/DashboardPage/DashboardSection';
 
 describe('DashboardSection component', () => {
-    let wrapper;
-    let instance;
-
     function defaultProps() {
         return {
             title: 'Test',
@@ -16,21 +12,16 @@ describe('DashboardSection component', () => {
             columns: 3,
             providers: [],
             noDataElement: <div className="qa-DashboardSection-NoDataElement" />,
+            classes: {},
+            theme: {
+                eventkit: {
+                    images: {},
+                    colors: {}
+                }
+            },
             ...(global as any).eventkit_test_props,
+            width: {},
         };
-    }
-
-    function setup(propsOverride = {}, options = { children: [] }) {
-        const props = {
-            ...defaultProps(),
-            ...propsOverride,
-        };
-        wrapper = shallow((
-            <DashboardSection {...props}>
-                {options.children}
-            </DashboardSection>
-        ));
-        instance = wrapper.instance();
     }
 
     function generateChildren(count) {
@@ -42,157 +33,125 @@ describe('DashboardSection component', () => {
         return children;
     }
 
-    beforeEach(setup);
-
     it('renders header title', () => {
-        expect(wrapper.find('.qa-DashboardSection-Header-Title').hostNodes().text()).toBe(instance.props.title);
+        const props = {
+            ...defaultProps(),
+        };
+        TestUtils.renderComponent(<DashboardSection {...props} />);
+        expect(screen.getByText(props.title));
     });
 
     it('limits the number of pages to maxPages', () => {
-        setup({
+        const props = {
+            ...defaultProps(),
             columns: 1,
             rows: 1,
-        }, {
-            children: generateChildren(10),
-        });
-        expect(wrapper.find('.qa-DashboardSection-Page-Item')).toHaveLength(3);
-    });
-
-    it('constructs the correct number of pages, each with the correct number of children', () => {
-        setup({
-            columns: 3,
-            rows: 2,
-        }, {
-            children: generateChildren(8),
-        });
-        expect(instance.maxPages).toBe(3);
-        const pages = instance.getPages();
-        expect(pages).toHaveLength(2);
-        expect(pages[0]).toHaveLength(6);
-        expect(pages[1]).toHaveLength(2);
+        };
+        const children = generateChildren(10);
+        TestUtils.renderComponent(
+            <DashboardSection {...props}>
+                {children}
+            </DashboardSection>
+        );
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs).toHaveLength(3);
     });
 
     it('updates the page index on a page change', () => {
-        expect(wrapper.state().pageIndex).not.toBe(1);
-        instance.handlePageChange({}, 1);
-        expect(wrapper.state().pageIndex).toBe(1);
+        const props = {
+            ...defaultProps(),
+            columns: 3,
+            rows: 2,
+        };
+        const children = generateChildren(8);
+        TestUtils.renderComponent(
+            <DashboardSection {...props}>
+                {children}
+            </DashboardSection>
+        );
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs).toHaveLength(3);
+        expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+        fireEvent.click(tabs[1]);
+        expect(tabs[1]).toHaveAttribute("aria-selected", "true");
     });
 
     describe('no children', () => {
         it('renders "no data" element', () => {
-            expect(wrapper.find('.qa-DashboardSection-NoDataElement')).toHaveLength(1);
+            const props = {
+                ...defaultProps(),
+            };
+            const component = TestUtils.renderComponent(<DashboardSection {...props} />, { includeToastContainer: false });
+            expect(component.container.children).toHaveLength(1);
         });
     });
 
     describe('3 columns, 3 children (1 page)', () => {
         beforeEach(() => {
-            setup({
+            const props = {
+                ...defaultProps(),
                 columns: 3,
-            }, {
-                children: generateChildren(3),
-            });
-        });
-
-        it('renders a single page', () => {
-            expect(wrapper.find('.qa-DashboardSection-Page')).toHaveLength(1);
-        });
-
-        it('constructs a single page of items', () => {
-            expect(instance.getPages().length).toBe(1);
-        });
-
-        it('renders a tab group', () => {
-            expect(wrapper.find(Tabs)).toHaveLength(1);
+            };
+            const children = generateChildren(3);
+            TestUtils.renderComponent(
+                <DashboardSection {...props}>
+                    {children}
+                </DashboardSection>
+            );
         });
 
         it('renders 3 tab buttons (maxPages = 3)', () => {
-            expect(wrapper.find(Tab)).toHaveLength(3);
+            const tabs = screen.getAllByRole('tab');
+            expect(tabs).toHaveLength(3);
         });
 
         it('enables the first tab button', () => {
-            const tabButton = wrapper.find(Tab).at(0);
-            expect(tabButton.props().disabled).not.toBe(true);
-        });
-
-        it('disables the second tab button', () => {
-            const tabButton = wrapper.find(Tab).at(1);
-            expect(tabButton.props().disabled).toBe(true);
-        });
-
-        it('disables the third tab button', () => {
-            const tabButton = wrapper.find(Tab).at(2);
-            expect(tabButton.props().disabled).toBe(true);
-        });
-
-        it('renders SwipeableViews component', () => {
-            expect(wrapper.find(SwipeableViews)).toHaveLength(1);
-        });
-
-        it('syncs page index with SwipeableViews component', () => {
-            const swipeableViews = wrapper.find(SwipeableViews);
-            expect(swipeableViews.props().index).toBe(instance.state.pageIndex);
-            expect(swipeableViews.props().onChangeIndex).toBe(instance.handlePageChange);
-        });
-
-        it('renders children', () => {
-            expect(wrapper.find('.qa-DashboardSection-Child')).toHaveLength(3);
+            const tabs = screen.getAllByRole('tab');
+            expect(tabs).toHaveLength(3);
+            expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+            expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+            expect(tabs[2]).toHaveAttribute("aria-selected", "false");
         });
     });
 
-    describe('when rowMajor is true', () => {
-        beforeEach(() => {
-            setup({
-                rowMajor: true,
-                columns: 3,
-                rows: 3,
-            }, {
-                children: generateChildren(9),
-            });
-        });
-
-        it('renders children in a row-major grid', () => {
-            expect(wrapper.find('.qa-DashboardSection-Page-Column')).toHaveLength(0);
-        });
-    });
-
-    describe('when rowMajor is false', () => {
-        beforeEach(() => {
-            setup({
-                rowMajor: false,
-                columns: 3,
-                rows: 3,
-            }, {
-                children: generateChildren(9),
-            });
-        });
-
-        it('renders children in a column-major grid', () => {
-            expect(wrapper.find('.qa-DashboardSection-Page-Column')).toHaveLength(3);
-        });
-    });
-
-    describe('when onViewAll handler is not passed in', () => {
-        it('does not render "View All" button', () => {
-            expect(wrapper.find('.qa-DashboardSection-ViewAll')).toHaveLength(0);
+    describe('when onViewAll handler is not passed in',  () => {
+        it('does not render "View All" button',  () => {
+            const props = {
+                ...defaultProps(),
+            };
+            const children = generateChildren(3);
+            TestUtils.renderComponent(
+                <DashboardSection {...props}>
+                    {children}
+                </DashboardSection>
+            );
+            expect(screen.queryByText('View All')).toBeNull();
         });
     });
 
     describe('when onViewAll handler is passed in', () => {
+        const props = {
+            ...defaultProps(),
+            onViewAll: sinon.spy(),
+        };
         beforeEach(() => {
-            setup({
-                onViewAll: sinon.spy(),
-            }, {
-                children: generateChildren(1),
-            });
+            const children = generateChildren(1);
+            TestUtils.renderComponent(
+                <DashboardSection {...props}>
+                    {children}
+                </DashboardSection>
+            );
         });
 
         it('renders "View All" button', () => {
-            expect(wrapper.find('.qa-DashboardSection-ViewAll')).toHaveLength(1);
+            expect(screen.getByText('View All'));
         });
 
         it('calls onViewAll() when "View All" button is clicked', () => {
-            wrapper.find('.qa-DashboardSection-ViewAll').simulate('click');
-            expect(instance.props.onViewAll.callCount).toBe(1);
+            const all = screen.getByText('View All');
+            expect(all);
+            fireEvent.click(all);
+            expect(props.onViewAll.callCount).toBe(1);
         });
     });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DataPackFeaturedItem.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DashboardPage/DataPackFeaturedItem.spec.tsx
@@ -1,15 +1,11 @@
-import { Link } from 'react-router-dom';
-import * as sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { screen } from '@testing-library/react';
+import "@testing-library/jest-dom/extend-expect";
+import * as TestUtils from '../test-utils';
 import moment from 'moment';
-import CardHeader from '@material-ui/core/CardHeader';
-import CardContent from '@material-ui/core/CardContent';
-import { DataPackFeaturedItem } from '../../components/DashboardPage/DataPackFeaturedItem';
+
+import DataPackFeaturedItem  from '../../components/DashboardPage/DataPackFeaturedItem';
 
 describe('DataPackFeaturedItem component', () => {
-    let wrapper;
-    let instance;
-
     function defaultProps() {
         return {
             run: {
@@ -26,63 +22,88 @@ describe('DataPackFeaturedItem component', () => {
             },
             gridName: 'test',
             index: 0,
-            classes: {},
             ...(global as any).eventkit_test_props,
+            width: {},
+            height: 'xl',
+            runId: '6870234f-d876-467c-a332-65fdf0399a0d'
         };
     }
 
-    function setup(propsOverride = {}) {
-        const props = {
-            ...defaultProps(),
-            ...propsOverride,
-        };
-        wrapper = shallow(<DataPackFeaturedItem {...props} />, {
-            context: { config: { BASEMAP_URL: 'some url' } },
-        });
-        instance = wrapper.instance();
+    function getInitialState(defaultState) {
+        return {
+            ...defaultState,
+            exports: {
+                data: {
+                    runs: {
+                        '6870234f-d876-467c-a332-65fdf0399a0d': {
+                            uid: '6870234f-d876-467c-a332-65fdf0399a0d',
+                            created_at: '2017-03-10T15:52:35.637331Z',
+                            job: '7643f806-1484-4446-b498-7ddaa65d011a',
+                            expiration: '2017-03-24T15:52:35.637258Z',
+                            extent: {type: 'FeatureCollection', features: []}
+                        }
+                    },
+                    jobs: {
+                        '7643f806-1484-4446-b498-7ddaa65d011a': {
+                            uid: '7643f806-1484-4446-b498-7ddaa65d011a',
+                            name: 'Test1',
+                            event: 'Test1 event',
+                            description: 'Test1 description',
+                            extent: {type: 'FeatureCollection', features: []}
+                        }
+                    }
+                }
+            }
+        }
     }
-
-    function wrapShallow(element) {
-        return shallow(<div>{element}</div>).childAt(0);
-    }
-
-    beforeEach(setup);
 
     it('renders card title with correct text and props', () => {
-        const title = wrapShallow(wrapper.find(CardHeader).props().title);
-        const titleLink = title.find(Link);
-        const props = titleLink.props() as any;
-        expect(props.to).toBe(`/status/${instance.props.run.job.uid}`);
-        expect(props.href).toBe(`/status/${instance.props.run.job.uid}`);
-        expect(titleLink.childAt(0).text()).toBe(instance.props.run.job.name);
+        const props = {
+            ...defaultProps(),
+        };
+        const defaultState = TestUtils.getDefaultTestState();
+        const initialState = getInitialState(defaultState);
+        TestUtils.renderComponent(<DataPackFeaturedItem {...props} />, {
+            appContextConfig: {
+                BASEMAP_URL: 'some url',
+            },
+            initialState
+        });
+        const titleComp = screen.getByText(props.run.job.name);
+        const link = titleComp.closest('a');
+        expect(titleComp).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', `/status/${props.run.job.uid}`);
     });
 
     it('renders card subtitle with correct text', () => {
-        const subtitle = wrapShallow(wrapper.find(CardHeader).props().subheader);
-        expect(subtitle.find('.qa-DataPackFeaturedItem-Subtitle-Event').text()).toBe(
-            `Event: ${instance.props.run.job.event}`,
-        );
-        expect(subtitle.find('.qa-DataPackFeaturedItem-Subtitle-Added').text()).toBe(
-            `Added: ${moment(instance.props.run.created_at).format('M/D/YY')}`,
-        );
-        expect(subtitle.find('.qa-DataPackFeaturedItem-Subtitle-Expires').text()).toBe(
-            `Expires: ${moment(instance.props.run.expiration).format('M/D/YY')}`,
-        );
+        const props = {
+            ...defaultProps(),
+        };
+        const defaultState = TestUtils.getDefaultTestState();
+        const initialState = getInitialState(defaultState);
+        TestUtils.renderComponent(<DataPackFeaturedItem {...props} />, {
+            appContextConfig: {
+                BASEMAP_URL: 'some url',
+            },
+            initialState
+        });
+        expect(screen.getByText(`Event: ${props.run.job.event}`));
+        expect(screen.getByText(`Added: ${moment(props.run.created_at).format('M/D/YY')}`));
+        expect(screen.getByText(`Expires: ${moment(props.run.expiration).format('M/D/YY')}`));
     });
 
     it('renders card text with the job description', () => {
-        expect(wrapper.find(CardContent).childAt(0).text()).toBe(instance.props.run.job.description);
+        const props = {
+            ...defaultProps(),
+        };
+        const defaultState = TestUtils.getDefaultTestState();
+        const initialState = getInitialState(defaultState);
+        TestUtils.renderComponent(<DataPackFeaturedItem {...props} />, {
+            appContextConfig: {
+                BASEMAP_URL: 'some url',
+            },
+            initialState
+        });
+        expect(screen.getByText(props.run.job.description));
     });
-
-    it('gets the correct map id', () => {
-        expect(instance.getMapId()).toBe(`${instance.props.gridName}_${instance.props.run.uid}_${instance.props.index}_map`);
-        wrapper.setProps({ gridName: undefined });
-        expect(instance.getMapId()).toBe(`${instance.props.run.uid}_${instance.props.index}_map`);
-        wrapper.setProps({ index: undefined });
-        expect(instance.getMapId()).toBe(`${instance.props.run.uid}_map`);
-        wrapper.setProps({ gridName: 'test' });
-        expect(instance.getMapId()).toBe(`${instance.props.gridName}_${instance.props.run.uid}_map`);
-    });
-
-
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackGrid.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackGrid.spec.tsx
@@ -1,8 +1,7 @@
 import * as sinon from 'sinon';
 import { shallow } from 'enzyme';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import { DataPackGrid } from '../../components/DataPackPage/DataPackGrid';
-import DataPackGridItem from '../../components/DataPackPage/DataPackGridItem';
 
 describe('DataPackGrid component', () => {
     const getProps = () => ({
@@ -30,12 +29,12 @@ describe('DataPackGrid component', () => {
 
     it('getColumns should return 2, 3, or 4 depending on screensize', () => {
         wrapper.setProps({ width: 'sm' });
-        expect(wrapper.find(GridList).props().cols).toEqual(2);
+        expect(wrapper.find(ImageList).props().cols).toEqual(2);
 
         wrapper.setProps({ width: 'lg' });
-        expect(wrapper.find(GridList).props().cols).toEqual(3);
+        expect(wrapper.find(ImageList).props().cols).toEqual(3);
 
         wrapper.setProps({ width: 'xl' });
-        expect(wrapper.find(GridList).props().cols).toEqual(4);
+        expect(wrapper.find(ImageList).props().cols).toEqual(4);
     });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackList.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackList.spec.tsx
@@ -4,7 +4,7 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import NavigationArrowDropDown from '@material-ui/icons/ArrowDropDown';
 import NavigationArrowDropUp from '@material-ui/icons/ArrowDropUp';
 import { DataPackList } from '../../components/DataPackPage/DataPackList';
@@ -41,14 +41,14 @@ describe('DataPackList component', () => {
 
     it('should render list items as part of the mobile view', () => {
         wrapper.setProps({ width: 'xs' });
-        expect(wrapper.find(GridList)).toHaveLength(1);
+        expect(wrapper.find(ImageList)).toHaveLength(1);
         expect(wrapper.find(DataPackListItem)).toHaveLength(3);
         expect(wrapper.find(Table)).toHaveLength(0);
     });
 
     it('should render table items as part of the desktop view', () => {
         wrapper.setProps({ width: 'lg' });
-        expect(wrapper.find(GridList)).toHaveLength(0);
+        expect(wrapper.find(ImageList)).toHaveLength(0);
         expect(wrapper.find(Table)).toHaveLength(2);
         expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
         expect(wrapper.find(Table).first().find(TableRow)).toHaveLength(1);

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.tsx
@@ -1,6 +1,6 @@
 import * as sinon from 'sinon';
 import { shallow } from 'enzyme';
-import GridList from '@material-ui/core/GridList';
+import ImageList from '@material-ui/core/ImageList';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -241,7 +241,7 @@ describe('MapView component', () => {
     it('should render all the basic components', () => {
         expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
         expect(wrapper.find(ScrollBarRefWrap)).toHaveLength(1);
-        expect(wrapper.find(GridList)).toHaveLength(1);
+        expect(wrapper.find(ImageList)).toHaveLength(1);
         expect(wrapper.find(LoadButtons)).toHaveLength(1);
         expect(wrapper.find(DataPackListItem)).toHaveLength(props.runs.length);
         expect(wrapper.find('#map')).toHaveLength(1);

--- a/eventkit_cloud/ui/static/ui/app/tests/test-utils/defaultTestState.ts
+++ b/eventkit_cloud/ui/static/ui/app/tests/test-utils/defaultTestState.ts
@@ -22,7 +22,7 @@ const initialTestState = {
     exportInfo: dataCartState.exportInfo,
     geocode: geocodeState,
     importGeom: fileState,
-    user: userState.status,
+    user: userState,
     router: connectRouter(history),
     drawer: uiState.drawer,
     providers: initialStateProviders,

--- a/eventkit_cloud/ui/static/ui/app/tests/test-utils/renderWithAppShell.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/test-utils/renderWithAppShell.tsx
@@ -7,6 +7,7 @@ import { Provider } from "react-redux";
 import createTestStore from "./createTestStore";
 import { getDefaultTestState } from "./defaultTestState";
 import { ToastContainer } from "react-toastify";
+import { MemoryRouter } from "react-router";
 
 const theme = createMuiTheme(ekTheme);
 
@@ -20,10 +21,12 @@ export const renderComponent = (component: any, {
         ...render(
             <Provider store={store}>
                 <AppConfigProvider value={appContextConfig}>
+                    <MemoryRouter>
                     <MuiThemeProvider theme={theme}>
                         {component}
                         {includeToastContainer && <ToastContainer />}
                     </MuiThemeProvider>
+                    </MemoryRouter>
                 </AppConfigProvider>
             </Provider>
         )

--- a/eventkit_cloud/ui/static/ui/app/tests/test-utils/renderWithAppShell.tsx
+++ b/eventkit_cloud/ui/static/ui/app/tests/test-utils/renderWithAppShell.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import ekTheme from '../../styles/eventkit_theme';
-import {createMuiTheme, MuiThemeProvider} from "@material-ui/core/styles";
+import {MuiThemeProvider, createTheme} from "@material-ui/core/styles";
 import { render } from "@testing-library/react";
 import { AppConfigProvider, ApplicationContext } from "../../components/ApplicationContext";
 import { Provider } from "react-redux";
@@ -9,7 +9,7 @@ import { getDefaultTestState } from "./defaultTestState";
 import { ToastContainer } from "react-toastify";
 import { MemoryRouter } from "react-router";
 
-const theme = createMuiTheme(ekTheme);
+const theme = createTheme(ekTheme);
 
 export const renderComponent = (component: any, {
     initialState = getDefaultTestState(),


### PR DESCRIPTION
# Description of Improvement

Refactors the dashboard to use functional components, and updates tests to use react testing library.

Some bugs were found and fixed with testing components that use `withWidth` on export and react testing library. `withWidth` was removed from some components on export because of silent failure from react testing library (elements simply not included in DOM render, no error messages even with verbose output). `width` property had to be added manually where those components are used.

## How to test

Does the dashboard still render correctly?
Verify rendering when no data is present
Verify rendering when data is present
Verify notifications refresh as new packs are created + completed
Verify all tests pass

## Quality Assurance

The following items have been updated:

- [x] Linters pass.
- [x] Unittests pass.
- [x] The docs have been updated for any changes to the settings module.
- [x] New tests have been added to reproduce the functionality of the above description.
- [x] Comments have been added to declare intent, or because of some wild comprehension statement.
- [x] UI enhancements have screenshots attached below.
- [x] Screenshots, code, or descriptions don't include proprietary information.

## Screenshots

<!-- If this includes a UI enhancement include a screenshot -->

:smile:
